### PR TITLE
fix(incus): scope --host to the targeted host's extra disk (#1)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -13,6 +13,17 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 - Rien pour l'instant.
 
+## [0.1.1] - 2026-07-15
+
+### Corrigé
+
+- **incus** : `provision --host X` ne crée plus le disque additionnel des
+  *autres* hôtes, et `destroy --host X` supprime désormais le disque additionnel
+  de cet hôte. Une variable Terraform `target_hosts` restreint le `for_each` du
+  volume extra, et `host_targets` cible le volume propre à l'hôte pour que
+  `-target` le nettoie.
+  ([#1](https://github.com/stephrobert/dsoxlab/issues/1))
+
 ## [0.1.0] - 2026-07-15
 
 Première version publique.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet.
 
+## [0.1.1] - 2026-07-15
+
+### Fixed
+
+- **incus**: `provision --host X` no longer creates the additional disk of
+  *other* hosts, and `destroy --host X` now removes that host's own additional
+  disk. A `target_hosts` Terraform variable scopes the extra-volume `for_each`,
+  and `host_targets` targets the host's own volume so `-target` cleans it up.
+  ([#1](https://github.com/stephrobert/dsoxlab/issues/1))
+
 ## [0.1.0] - 2026-07-15
 
 Initial public release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.0"
+version = "0.1.1"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -1188,7 +1188,10 @@ def provision(
         # Étape 2 : terraform apply avec progress bar par ressource
         result = _run_terraform_with_progress(
             "provision",
-            lambda cb: tf.apply(repo_meta, on_event=cb, targets=targets or None),
+            lambda cb: tf.apply(
+                repo_meta, on_event=cb,
+                targets=targets or None, target_hosts=list(host) if host else None,
+            ),
         )
     except ProviderNotImplemented as exc:
         error(str(exc))
@@ -1250,7 +1253,10 @@ def destroy(
         )
         _run_terraform_with_progress(
             "destroy",
-            lambda cb: tf.destroy(repo_meta, on_event=cb, targets=targets or None),
+            lambda cb: tf.destroy(
+                repo_meta, on_event=cb,
+                targets=targets or None, target_hosts=list(host) if host else None,
+            ),
         )
     except ProviderNotImplemented as exc:
         error(str(exc))

--- a/src/dsoxlab/infra/terraform.py
+++ b/src/dsoxlab/infra/terraform.py
@@ -278,6 +278,7 @@ def apply(
     auto_approve: bool = True,
     on_event: Callable[[dict[str, Any]], None] | None = None,
     targets: list[str] | None = None,
+    target_hosts: list[str] | None = None,
 ) -> ProvisionResult:
     """Lance ``terraform apply`` et retourne les outputs.
 
@@ -314,6 +315,12 @@ def apply(
         cmd.append("-auto-approve")
     for t in targets or []:
         cmd.append(f"-target={t}")
+    # Scope les ressources dédiées (disques additionnels) aux hôtes ciblés,
+    # complément indispensable de -target : sans lui, le for_each extra
+    # créerait le disque d'autres hôtes (issue #1). Templates ignorant la
+    # variable la déclarent quand même (default []), donc -var est sûr.
+    if target_hosts:
+        cmd += ["-var", f"target_hosts={json.dumps(target_hosts)}"]
     if on_event is not None:
         cmd.append("-json")
         _stream_terraform(cmd, env=_provider_env(repo_meta), on_event=on_event)
@@ -400,6 +407,7 @@ def destroy(
     auto_approve: bool = True,
     on_event: Callable[[dict[str, Any]], None] | None = None,
     targets: list[str] | None = None,
+    target_hosts: list[str] | None = None,
 ) -> None:
     """Lance ``terraform destroy``.
 
@@ -424,6 +432,11 @@ def destroy(
         cmd.append("-auto-approve")
     for t in targets or []:
         cmd.append(f"-target={t}")
+    # Même scoping qu'à l'apply : sur un destroy --host, ne détruire que le
+    # disque additionnel de l'hôte ciblé (le for_each extra est filtré par
+    # target_hosts). Vide = tous les hôtes.
+    if target_hosts:
+        cmd += ["-var", f"target_hosts={json.dumps(target_hosts)}"]
     if on_event is not None:
         cmd.append("-json")
         _stream_terraform(cmd, env=_provider_env(repo_meta), on_event=on_event)
@@ -466,10 +479,15 @@ def host_targets(provider: str, fqdn: str) -> list[str]:
             f'outscale_vm.host["{fqdn}"]',
         ]
     if provider == "incus":
-        # incus_instance contient déjà disque + NIC + cloud-init en
-        # config inline → une seule ressource à cibler par host.
+        # Instance + son volume extra dédié. À l'apply, -target de
+        # l'instance suffit à créer le volume (dépendance amont) ; mais au
+        # destroy, le volume amont N'EST PAS détruit par -target de la seule
+        # instance → on le cible explicitement pour que `destroy --host X`
+        # le nettoie. Le for_each extra étant filtré par target_hosts
+        # (issue #1), cibler extra["<host sans disque>"] est un no-op bénin.
         return [
             f'incus_instance.host["{fqdn}"]',
+            f'incus_storage_volume.extra["{fqdn}"]',
         ]
     raise NotImplementedError(
         f"--host non implémenté pour le provider '{provider}'"

--- a/src/dsoxlab/templates/terraform/incus/main.tf
+++ b/src/dsoxlab/templates/terraform/incus/main.tf
@@ -43,10 +43,25 @@ locals {
   hosts_with_idx = [
     for idx, h in var.hosts : merge(h, {
       idx = idx
-      mac = format("00:16:3e:cd:00:%02x", idx + 16)  # OUI Xen/LXC
+      mac = format("00:16:3e:cd:00:%02x", idx + 16) # OUI Xen/LXC
       ip  = cidrhost(var.network_cidr, idx + 11)
     })
   ]
+
+  # Hôtes dont on crée réellement le disque additionnel : ceux qui en
+  # déclarent un (extra_disk_gb > 0) ET, si un ciblage --host est actif
+  # (var.target_hosts non vide), qui sont dans la cible. Sinon TOUS les
+  # hôtes à disque. Ce filtrage évite que `provision --host X` ne crée le
+  # volume extra d'un AUTRE hôte : terraform -target de l'instance tire le
+  # for_each extra en entier, mais ce for_each ne contient alors que les
+  # volumes des hôtes ciblés (issue #1). La référence de ressource est
+  # conservée dans le device → l'ordre create/destroy reste correct.
+  in_scope_extra = {
+    for h in local.hosts_with_idx : h.name => h
+    if h.extra_disk_gb > 0 && (
+      length(var.target_hosts) == 0 || contains(var.target_hosts, h.name)
+    )
+  }
 }
 
 # ── Réseau Incus dédié (bridge NAT) ───────────────────────────────────────────
@@ -82,9 +97,7 @@ resource "incus_network" "lab" {
 # (pas formaté) que la VM voit comme /dev/sdb (virtio-scsi sur Incus).
 
 resource "incus_storage_volume" "extra" {
-  for_each = {
-    for h in local.hosts_with_idx : h.name => h if h.extra_disk_gb > 0
-  }
+  for_each = local.in_scope_extra
 
   name         = "${replace(each.value.name, ".", "-")}-extra"
   pool         = "default"
@@ -109,12 +122,12 @@ resource "incus_instance" "host" {
   running = true
 
   config = {
-    "limits.cpu"               = tostring(each.value.vcpu)
-    "limits.memory"            = "${each.value.ram_mb}MiB"
-    "boot.autostart"           = "true"
+    "limits.cpu"     = tostring(each.value.vcpu)
+    "limits.memory"  = "${each.value.ram_mb}MiB"
+    "boot.autostart" = "true"
     # Cloud-init NoCloud-style : Incus pose le seed via virtio-fs ou
     # config drive selon la version. user-data = full YAML cloud-config.
-    "cloud-init.user-data"     = templatefile(
+    "cloud-init.user-data" = templatefile(
       "${path.module}/../../cloud-init/${local.distro_to_template[each.value.distro]}.yaml.tmpl",
       {
         hostname   = each.value.name
@@ -123,7 +136,7 @@ resource "incus_instance" "host" {
     )
     # Réservation DHCP statique côté Incus : la NIC reçoit toujours la
     # même IP au sein du bridge.
-    "user.lab.ip"  = each.value.ip
+    "user.lab.ip"   = each.value.ip
     "user.lab.role" = each.value.role
   }
 
@@ -133,10 +146,10 @@ resource "incus_instance" "host" {
     name = "eth0"
     type = "nic"
     properties = {
-      "name"           = "eth0"
-      "network"        = incus_network.lab.name
-      "ipv4.address"   = each.value.ip
-      "hwaddr"         = each.value.mac
+      "name"         = "eth0"
+      "network"      = incus_network.lab.name
+      "ipv4.address" = each.value.ip
+      "hwaddr"       = each.value.mac
     }
   }
 
@@ -167,11 +180,13 @@ resource "incus_instance" "host" {
     }
   }
 
-  # Disque additionnel optionnel (extra_disk_gb > 0). Apparaît dans
-  # la VM comme /dev/sdb (virtio-scsi). On utilise dynamic pour ne
-  # créer le device QUE pour les hosts concernés.
+  # Disque additionnel optionnel. Apparaît dans la VM comme /dev/sdb
+  # (virtio-scsi). On n'attache le device QUE quand le volume extra de
+  # cet hôte est réellement créé (cf. local.in_scope_extra) : ainsi le
+  # ciblage --host reste cohérent (pas de référence à un volume filtré)
+  # et la référence de ressource garde l'ordre create/destroy.
   dynamic "device" {
-    for_each = each.value.extra_disk_gb > 0 ? [each.value] : []
+    for_each = contains(keys(local.in_scope_extra), each.value.name) ? [each.value] : []
     content {
       name = "extra"
       type = "disk"

--- a/src/dsoxlab/templates/terraform/incus/variables.tf
+++ b/src/dsoxlab/templates/terraform/incus/variables.tf
@@ -26,3 +26,9 @@ variable "provider_config" {
   type        = map(string)
   default     = {}
 }
+
+variable "target_hosts" {
+  description = "Restreint la création des ressources dédiées à ces hôtes (ciblage `dsoxlab provision/destroy --host`). Vide = tous les hôtes. Utilisé pour scoper le for_each des disques additionnels afin qu'un ciblage --host ne crée pas le disque d'un autre hôte (dsoxlab issue #1)."
+  type        = list(string)
+  default     = []
+}

--- a/src/dsoxlab/templates/terraform/kvm/variables.tf
+++ b/src/dsoxlab/templates/terraform/kvm/variables.tf
@@ -26,3 +26,9 @@ variable "provider_config" {
   type        = map(string)
   default     = {}
 }
+
+variable "target_hosts" {
+  description = "Restreint la création des ressources dédiées à ces hôtes (ciblage `dsoxlab provision/destroy --host`). Vide = tous les hôtes. Utilisé pour scoper le for_each des disques additionnels afin qu'un ciblage --host ne crée pas le disque d'un autre hôte (dsoxlab issue #1)."
+  type        = list(string)
+  default     = []
+}

--- a/src/dsoxlab/templates/terraform/outscale/variables.tf
+++ b/src/dsoxlab/templates/terraform/outscale/variables.tf
@@ -39,3 +39,9 @@ variable "provider_config" {
   type        = map(string)
   default     = {}
 }
+
+variable "target_hosts" {
+  description = "Restreint la création des ressources dédiées à ces hôtes (ciblage `dsoxlab provision/destroy --host`). Vide = tous les hôtes. Utilisé pour scoper le for_each des disques additionnels afin qu'un ciblage --host ne crée pas le disque d'un autre hôte (dsoxlab issue #1)."
+  type        = list(string)
+  default     = []
+}

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
`provision --host X` pulled the whole extra-volume for_each through terraform -target and created the additional disk of *other* hosts; `destroy --host X` left that host's own disk behind.

- Add a `target_hosts` Terraform variable that scopes the extra-volume for_each (and the instance's extra device) to the targeted hosts, so a targeted apply/destroy no longer touches other hosts' disks. The resource reference is kept, so create/destroy ordering stays correct.
- host_targets(incus) also targets the host's own extra volume so `destroy --host X` removes it (an upstream dependency, not a dependent, so -target of the instance alone would not).
- Thread target_hosts from `provision`/`destroy --host` through apply/destroy.

Declared `target_hosts` in every provider variables.tf so `-var` is safe; only incus consumes it for now (kvm/outscale unchanged).

Verified end-to-end on incus: provision --host (no orphan), provision + destroy of a host with an extra disk (created/attached/removed in order), full destroy (pool untouched).

Closes #1

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [ ] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
