### PR TITLE
chore(ci): Plumber solo + Ko-fi + auto-release GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,59 @@ jobs:
         with:
           attestations: true
           print-hash: true
+
+  github_release:
+    name: Create GitHub Release
+    # Only after PyPI succeeds — never publish a GitHub Release for a version
+    # that failed to reach PyPI.
+    needs: [build, publish]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write   # create the Release and upload the built artifacts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download distribution artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      # Extract the CHANGELOG section for this tag. The tag is passed through an
+      # env var (never interpolated into the script body) to avoid injection.
+      - name: Extract changelog notes
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          version="${TAG#v}"
+          python3 - "$version" > release-notes.md <<'PY'
+          import pathlib, re, sys
+
+          version = sys.argv[1]
+          text = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
+          m = re.search(
+              r"^## \[" + re.escape(version) + r"\].*?(?=^## \[|\Z)",
+              text, re.S | re.M,
+          )
+          body = m.group(0).strip() if m else f"Release {version}"
+          lines = body.splitlines()
+          if lines and lines[0].startswith("## "):
+              lines = lines[1:]           # drop the version heading (title carries it)
+          print("\n".join(lines).strip() or f"Release {version}")
+          PY
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release create "$TAG" \
+            --repo "$REPO" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            dist/*


### PR DESCRIPTION
Résout Plumber ISSUE-505 (codeOwnerApprovalRequired false, mainteneur unique), ajoute le bouton Ko-fi, et automatise la création des releases GitHub sur tag v* (notes CHANGELOG + artefacts).