### PR TITLE
feat(runtime): labs multi-hôtes via runtime.targets[].roles

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -13,6 +13,18 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 - Rien pour l'instant.
 
+## [0.1.3] - 2026-07-15
+
+### Ajouté
+
+- **labs multi-hôtes** : un mapping `runtime.targets[].roles` (ex.
+  `roles: {server: alma-rhcsa-2.lab}`) permet à un lab `vm` d'utiliser plusieurs
+  hôtes à la fois. Chaque rôle devient un groupe Ansible `lab_<role>` (en plus de
+  `lab_target`, l'hôte primaire où tournent les tests), pour que `setup.yaml` /
+  `solution.yaml` / `cleanup.yaml` configurent un serveur et un client sans coder
+  de FQDN en dur. Les hôtes de rôle sont validés contre l'inventory provisionné
+  au runtime. Rétro-compatible : sans `roles`, lab mono-hôte comme avant.
+
 ## [0.1.2] - 2026-07-15
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet.
 
+## [0.1.3] - 2026-07-15
+
+### Added
+
+- **multi-host labs**: a `runtime.targets[].roles` mapping (e.g.
+  `roles: {server: alma-rhcsa-2.lab}`) lets a `vm` lab use several hosts at once.
+  Each role becomes an Ansible group `lab_<role>` (alongside `lab_target`, the
+  primary host where tests run), so `setup.yaml` / `solution.yaml` /
+  `cleanup.yaml` can configure a server and a client without hard-coding a FQDN.
+  The role hosts are validated against the provisioned inventory at run time.
+  Backward compatible: no `roles` means a single-host lab as before.
+
 ## [0.1.2] - 2026-07-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.2"
+version = "0.1.3"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/infra/inventory.py
+++ b/src/dsoxlab/infra/inventory.py
@@ -40,6 +40,7 @@ def build_inventory(
     ssh_user: str = "student",
     terraform_outputs: dict[str, Any] | None = None,
     target_fqdn: str | None = None,
+    roles: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Construit un inventory Ansible (format dict) depuis meta + outputs.
 
@@ -139,6 +140,20 @@ def build_inventory(
             )
         children["lab_target"] = {
             "hosts": {target_fqdn: {}},
+        }
+
+    # Labs multi-hôtes : chaque rôle devient un groupe ``lab_<role>`` (ex.
+    # ``lab_server``) que le setup/solution/cleanup peut cibler, en plus de
+    # ``lab_target``. Les host_vars restent hérités du groupe ``labenv``.
+    for role_name, role_fqdn in (roles or {}).items():
+        if role_fqdn not in inventory_hosts:
+            raise ValueError(
+                f"role '{role_name}' → '{role_fqdn}' n'est pas dans la liste "
+                f"des hôtes connus : {sorted(inventory_hosts)} "
+                "(host non déclaré dans meta.yml ou non provisionné)."
+            )
+        children[f"lab_{role_name}"] = {
+            "hosts": {role_fqdn: {}},
         }
 
     return {"all": {"children": children}}

--- a/src/dsoxlab/models/lab.py
+++ b/src/dsoxlab/models/lab.py
@@ -81,11 +81,18 @@ class LabDefinition:
                     f"{lab_yaml}: runtime.targets[{idx}] doit contenir "
                     f"'name' et 'host'."
                 )
+            roles_raw = t.get("roles") or {}
+            if not isinstance(roles_raw, dict):
+                raise ValueError(
+                    f"{lab_yaml}: runtime.targets[{idx}].roles doit être un "
+                    f"mapping role→fqdn, reçu : {type(roles_raw).__name__}"
+                )
             targets.append(Target(
                 name=str(t["name"]),
                 host=str(t["host"]),
                 label_en=str(t.get("label_en", "")),
                 label_fr=str(t.get("label_fr", "")),
+                roles={str(k): str(v) for k, v in roles_raw.items()},
             ))
 
         runtime = RuntimeConfig(

--- a/src/dsoxlab/models/runtime.py
+++ b/src/dsoxlab/models/runtime.py
@@ -60,6 +60,14 @@ class Target:
     label_fr: str = ""
     """Description courte (français)."""
 
+    roles: dict[str, str] = field(default_factory=dict)
+    """Hôtes additionnels utilisés simultanément par le lab, par rôle —
+    ex. ``{"server": "alma-rhcsa-2.lab"}``. Chaque rôle devient un groupe
+    Ansible ``lab_<role>`` dans l'inventory du ``setup.yaml`` /
+    ``solution.yaml`` / ``cleanup.yaml``, en plus de ``lab_target`` (l'hôte
+    primaire, où tournent les tests). Vide = lab mono-hôte (défaut). Les FQDN
+    doivent être déclarés dans ``meta.yml: infra.hosts[]`` et provisionnés."""
+
     def label(self, lang: str = "en") -> str:
         """Retourne le label dans la langue demandée, fallback EN."""
         if lang == "fr" and self.label_fr:

--- a/src/dsoxlab/runtimes/vm.py
+++ b/src/dsoxlab/runtimes/vm.py
@@ -271,10 +271,17 @@ class VmRuntime(BaseRuntime):
     def _inventory(
         self, repo_meta: RepoMetadata, target: Target
     ) -> dict[str, Any]:
-        """Inventory filtré au seul host de la target choisie."""
+        """Inventory du lab : ``lab_target`` = host primaire, plus un groupe
+        ``lab_<role>`` par rôle déclaré (labs multi-hôtes serveur/client).
+
+        Le groupe ``labenv`` contient de toute façon tous les hôtes
+        provisionnés ; les groupes synthétiques ne font que nommer les rôles
+        pour que les playbooks n'aient pas à coder un FQDN en dur.
+        """
         tf_outputs = read_terraform_outputs(repo_meta)
         return build_inventory(
             repo_meta,
             terraform_outputs=tf_outputs,
             target_fqdn=target.host,
+            roles=target.roles or None,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
Une target peut déclarer des hôtes additionnels par rôle (ex. server: alma-rhcsa-2.lab). Chaque rôle devient un groupe Ansible lab_<role> (en plus de lab_target) ciblable par setup/solution/cleanup — labs serveur/client sans FQDN en dur. Validé au runtime contre l'inventory. Rétro-compatible. Bump 0.1.3.

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [ ] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [x] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
