### PR TITLE
fix(progress): nom de bloc clair (section meta.yml) au lieu de ?

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -13,6 +13,16 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 - Rien pour l'instant.
 
+## [0.1.4] - 2026-07-15
+
+### Corrigé
+
+- **progress** : `dsoxlab progress` affiche désormais un nom de bloc clair (le
+  titre de la section meta.yml, ex. « Fondamentaux (l1) ») au lieu de `?`, et la
+  colonne Bloc est alignée à gauche. Chaque lab est rattaché à sa section
+  meta.yml à la découverte (`bloc` + nouveau `bloc_name`), donc le récapitulatif
+  regroupe par vraie section plutôt que par un `bloc=0` non affecté.
+
 ## [0.1.3] - 2026-07-15
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet.
 
+## [0.1.4] - 2026-07-15
+
+### Fixed
+
+- **progress**: `dsoxlab progress` now shows a clear bloc name (the meta.yml
+  section title, e.g. "Fondamentaux (l1)") instead of `?`. Each lab is attached
+  to its meta.yml section during discovery (`bloc` + new `bloc_name`), so the
+  summary groups by real section instead of an unassigned `bloc=0`.
+
 ## [0.1.3] - 2026-07-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.3"
+version = "0.1.4"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/discovery/scanner.py
+++ b/src/dsoxlab/discovery/scanner.py
@@ -86,6 +86,17 @@ def _assign_section(
         # par défaut on prend la catégorie du dépôt.
         if not lab.section or lab.section == "linux":
             lab.section = repo_meta.category
+        # Rattache le lab à sa section pédagogique du meta.yml (l1, l2, …) pour
+        # que ``dsoxlab progress`` affiche un nom de bloc clair au lieu de « ? ».
+        try:
+            rel = yaml_path.parent.relative_to(root / "labs").as_posix()
+        except ValueError:
+            rel = ""
+        for idx, section in enumerate(repo_meta.sections, start=1):
+            if rel in section.labs:
+                lab.bloc = lab.bloc or idx
+                lab.bloc_name = section.title or section.id
+                break
         return
 
     # Mode legacy : inférence depuis le chemin (compat ancienne

--- a/src/dsoxlab/models/lab.py
+++ b/src/dsoxlab/models/lab.py
@@ -38,6 +38,7 @@ class LabDefinition:
     lab_type: str = "lab"       # "lab" | "challenge" | "capstone"
     bloc: int = 0               # bloc number 1-8; 0 = unassigned
     bloc_order: int = 0         # position within the bloc; 0 = unassigned
+    bloc_name: str = ""         # nom lisible du bloc (section meta.yml), ex. "Fondamentaux (l1)"
 
     # Translatable fields — overridden by lab.<lang>.yaml when available
     _TRANSLATABLE = ("title", "description")

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -267,7 +267,7 @@ def print_progress_table(
         blocs.setdefault(lab.bloc, []).append(lab)
 
     table = Table(title=_("progress_table_title"), show_lines=True)
-    table.add_column(_("col_bloc_num"), justify="center", style="bold")
+    table.add_column(_("col_bloc_num"), justify="left", style="bold")
     table.add_column(_("col_bloc_done"), justify="center")
     table.add_column(_("col_bloc_avg"), justify="center")
     table.add_column(_("col_challenge"), justify="center")
@@ -316,7 +316,11 @@ def print_progress_table(
         else:
             capstone_text = "—"
 
-        bloc_label = str(bloc_num) if bloc_num else "?"
+        # Nom de bloc lisible (titre de la section meta.yml) plutôt qu'un
+        # numéro nu ou « ? ». Fallback : numéro, puis « ? » si vraiment non
+        # rattaché (ex. lab hors de toute section).
+        bloc_name = next((lab.bloc_name for lab in bloc_labs if lab.bloc_name), "")
+        bloc_label = bloc_name or (str(bloc_num) if bloc_num else "?")
         table.add_row(bloc_label, done_text, avg_text, challenge_text, capstone_text)
 
     console.print(table)

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
dsoxlab progress affiche le titre de la section (ex. Fondamentaux (l1)) au lieu de ?, colonne alignée à gauche. Chaque lab est rattaché à sa section meta.yml à la découverte (bloc + bloc_name). Bump 0.1.4.

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [ ] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [x] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
