### PR TITLE
feat(i18n): challenge README.<lang>.md + hints base64 bilingues

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -13,6 +13,22 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 - Rien pour l'instant.
 
+## [0.1.5] - 2026-07-15
+
+### Ajouté
+
+- **hints i18n** : le format moderne d'indice (`text_en` / `text_fr`) accepte
+  désormais aussi des valeurs encodées en base64, pour que les indices soient à
+  la fois bilingues et obfusqués dans le fichier. Le loader tente le base64
+  d'abord, avec repli sur le texte brut.
+
+### Modifié
+
+- **challenge i18n** : le brief de challenge localisé est résolu en
+  `challenge/README.<lang>.md` (ex. `README.fr.md`), cohérent avec
+  `scenario.<lang>.md` et le `README.<lang>.md` racine — au lieu de l'ancien
+  nommage `README_FR.md`.
+
 ## [0.1.4] - 2026-07-15
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet.
 
+## [0.1.5] - 2026-07-15
+
+### Added
+
+- **hints i18n**: the modern hint format (`text_en` / `text_fr`) now also accepts
+  base64-encoded values, so hints can be both bilingual and obfuscated in the
+  file. The loader tries base64 first and falls back to plain text.
+
+### Changed
+
+- **challenge i18n**: the localized challenge brief is resolved as
+  `challenge/README.<lang>.md` (e.g. `README.fr.md`), consistent with
+  `scenario.<lang>.md` and the root `README.<lang>.md` — instead of the old
+  `README_FR.md` naming.
+
 ## [0.1.4] - 2026-07-15
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.4"
+version = "0.1.5"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/models/hint.py
+++ b/src/dsoxlab/models/hint.py
@@ -31,6 +31,22 @@ from pathlib import Path
 import yaml
 
 
+def _decode_hint(raw: object) -> str:
+    """Décode un texte d'indice : base64 si possible, sinon plain text.
+
+    Permet d'obfusquer les indices (les garder illisibles en clair dans le
+    fichier) tout en supportant du texte brut. S'applique aux champs
+    ``text_en``/``text_fr`` (i18n) comme au ``text`` legacy.
+    """
+    text = str(raw or "")
+    if not text:
+        return ""
+    try:
+        return base64.b64decode(text.encode(), validate=True).decode().rstrip("\n")
+    except (ValueError, binascii.Error, UnicodeDecodeError):
+        return text.rstrip("\n")
+
+
 @dataclass
 class Hint:
     text_en: str = ""
@@ -63,19 +79,15 @@ class HintFile:
             text_en = ""
             text_fr = ""
 
-            # Format moderne i18n
+            # Format moderne i18n. text_en/text_fr acceptent aussi le base64
+            # (même obfuscation que le legacy) : on tente le décodage, fallback
+            # plain text.
             if "text_en" in h or "text_fr" in h:
-                text_en = str(h.get("text_en", "")).rstrip("\n")
-                text_fr = str(h.get("text_fr", "")).rstrip("\n")
+                text_en = _decode_hint(h.get("text_en", ""))
+                text_fr = _decode_hint(h.get("text_fr", ""))
             # Format legacy : text unique (base64 ou plain)
             elif "text" in h:
-                raw = str(h["text"])
-                # Tente base64 d'abord ; sinon fallback en plain text
-                try:
-                    decoded = base64.b64decode(raw.encode(), validate=True).decode()
-                    text_en = decoded
-                except (ValueError, binascii.Error, UnicodeDecodeError):
-                    text_en = raw
+                text_en = _decode_hint(h["text"])
 
             hints.append(
                 Hint(

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -496,11 +496,11 @@ def print_lab_welcome(lab: LabDefinition) -> None:
 
 
 def print_lab_challenge(lab: LabDefinition, lang: str = "en") -> None:
-    """Display the challenge brief (challenge/README.md or README_FR.md) for a lab."""
+    """Display the challenge brief (challenge/README.md or README.<lang>.md)."""
     from rich.markdown import Markdown
     from rich.rule import Rule
 
-    localised = lab.path / "challenge" / f"README_{lang.upper()}.md"
+    localised = lab.path / "challenge" / f"README.{lang}.md"
     challenge_file = (
         localised
         if lang != "en" and localised.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
challenge brief localisé résolu en challenge/README.<lang>.md (cohérent avec scenario.<lang>.md), au lieu de README_FR.md. Les hints text_en/text_fr acceptent le base64 (bilingue + obfusqué). Bump 0.1.5.

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [x] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
