### PR TITLE
fix(infra): inventory KVM après provision ciblé + détection conflit i…

### DIFF
--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -1153,6 +1153,21 @@ def provision(
         raise typer.Exit(1)
 
     provider = _require_provider(repo_meta)
+
+    # Garde-fou cohabitation : incus et KVM partagent le nom de réseau et le
+    # subnet du lab → ils ne peuvent pas coexister. Si un AUTRE provider a
+    # encore de l'infra debout, on guide l'apprenant (destroy) plutôt que de
+    # le laisser buter sur « Network is already in use ».
+    conflicts = tf.other_active_providers(repo_meta)
+    if conflicts:
+        error(_(
+            "provision_provider_conflict",
+            current=provider,
+            others=", ".join(conflicts),
+            other=conflicts[0],
+        ))
+        raise typer.Exit(5)
+
     info(_("provision_starting", provider=provider))
 
     # Garde-fou : la clé SSH du repo doit exister avant tout provision.

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -84,6 +84,7 @@ STRINGS: dict[str, str] = {
     "provision_no_ssh_key": "Lab SSH key missing: {path}\nWithout it, cloud keypair would be empty and VMs unreachable.\nRun first: dsoxlab instructor bootstrap",
     "provision_done":      "Provisioning complete — {count} host(s) ready.",
     "provision_failed":    "Provisioning failed: {error}",
+    "provision_provider_conflict": "Cannot provision on '{current}': provider '{others}' still has active lab infrastructure.\nincus and KVM share the lab's network name and subnet, so they can't run at the same time.\nFinish or tear down the other one first:\n  DSOXLAB_PROVIDER={other} dsoxlab destroy",
     "provision_waiting_ssh": "Waiting for hosts to become reachable (SSH + cloud-init)…",
     "provision_waiting_ssh_host": "Waiting for {host} (SSH + cloud-init), attempt {attempt}…",
     "provision_ssh_timeout": "Host readiness timed out: {error}\nThe VM may still be booting — retry `dsoxlab run` in a moment.",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -84,6 +84,7 @@ STRINGS: dict[str, str] = {
     "provision_no_ssh_key": "Clé SSH du lab manquante : {path}\nSans elle, le keypair cloud serait vide et les VMs inaccessibles.\nLance d'abord : dsoxlab instructor bootstrap",
     "provision_done":      "Provisionnement terminé — {count} hôte(s) prêt(s).",
     "provision_failed":    "Provisionnement échoué : {error}",
+    "provision_provider_conflict": "Impossible de provisionner sur « {current} » : le provider « {others} » a encore une infra de lab active.\nincus et KVM partagent le nom de réseau et le subnet du lab, ils ne peuvent pas tourner en même temps.\nTermine ou détruis l'autre d'abord :\n  DSOXLAB_PROVIDER={other} dsoxlab destroy",
     "provision_waiting_ssh": "Attente que les hôtes soient joignables (SSH + cloud-init)…",
     "provision_waiting_ssh_host": "Attente de {host} (SSH + cloud-init), tentative {attempt}…",
     "provision_ssh_timeout": "Délai d'attente dépassé : {error}\nLa VM démarre peut-être encore — relance `dsoxlab run` dans un instant.",

--- a/src/dsoxlab/infra/terraform.py
+++ b/src/dsoxlab/infra/terraform.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from ..models.repo import RepoMetadata
+from ..models.repo import ProviderUnresolved, RepoMetadata
 from ..templates import terraform_template
 from ..utils.shell import CommandError, run_command
 from . import credentials as creds_mod
@@ -272,6 +272,46 @@ def init(
         run_command(cmd, timeout=600, env=_provider_env(repo_meta))
 
 
+def _state_has_resources(state_file: Path) -> bool:
+    """True si le tfstate existe et contient au moins une ressource.
+
+    Après un ``terraform destroy``, ``resources`` devient ``[]`` → False.
+    """
+    if not state_file.is_file():
+        return False
+    try:
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(data.get("resources"))
+
+
+def other_active_providers(repo_meta: RepoMetadata) -> list[str]:
+    """Autres providers candidats ayant de l'infra active (state non vide).
+
+    incus, KVM (et les autres providers locaux) dérivent le nom de réseau et
+    le subnet du lab de ``meta.yml`` : ils occupent le **même** bridge et le
+    **même** CIDR, donc ne peuvent pas coexister sur une même machine. Avant
+    un provision, on détecte un provider concurrent déjà debout pour guider
+    l'apprenant (il doit ``dsoxlab destroy`` l'autre d'abord) plutôt que de le
+    laisser buter sur l'erreur Terraform « Network is already in use ».
+
+    Retourne la liste des providers concurrents actifs (hors provider courant).
+    """
+    try:
+        current = repo_meta.infra.require_provider()
+    except ProviderUnresolved:
+        return []
+    candidates = repo_meta.infra.providers_available or [current]
+    base = _xdg_state_home() / "dsoxlab" / repo_meta.id / "terraform"
+    return [
+        prov
+        for prov in candidates
+        if prov != current
+        and _state_has_resources(base / prov / "terraform.tfstate")
+    ]
+
+
 def apply(
     repo_meta: RepoMetadata,
     *,
@@ -326,6 +366,27 @@ def apply(
         _stream_terraform(cmd, env=_provider_env(repo_meta), on_event=on_event)
     else:
         run_command(cmd, timeout=1800, env=_provider_env(repo_meta))
+
+    # Un apply ``-target`` n'évalue pas les outputs racine (comportement
+    # documenté de Terraform). Sans outputs, l'inventory (conftest de test,
+    # dsoxlab status/ssh) ne peut pas résoudre les IPs des hôtes dont
+    # l'adresse vient de l'output ``hosts`` (KVM/libvirt DHCP notamment) →
+    # « Aucun host dans l'inventory » pour tout lab de ce provider. On force
+    # un refresh-only pour recalculer le map ``hosts`` sans recréer ni
+    # détruire de ressource.
+    if targets:
+        run_command(
+            [
+                "terraform",
+                f"-chdir={tf_dir}",
+                "apply",
+                "-refresh-only",
+                "-input=false",
+                "-auto-approve",
+            ],
+            timeout=600,
+            env=_provider_env(repo_meta),
+        )
 
     return _read_outputs(tf_dir, env=_provider_env(repo_meta))
 


### PR DESCRIPTION
…ncus/KVM

Deux corrections du provisioning multi-provider :

1) `apply -target` n'évalue pas les outputs racine (comportement Terraform),
   donc les IP des hôtes KVM (DHCP libvirt, non déclarées dans meta.yml)
   manquaient → inventory vide → « Aucun host dans l'inventory » pour tout lab
   KVM (dsoxlab check, conftest de test). apply() force désormais un
   `terraform apply -refresh-only` après un apply ciblé pour recalculer le map
   d'outputs `hosts`, sans recréer ni détruire de ressource.

2) incus et KVM dérivent le nom de réseau et le subnet du lab de meta.yml : ils
   occupent le même bridge/CIDR et ne peuvent pas coexister.
   other_active_providers() détecte un provider concurrent ayant de l'infra
   active (tfstate non vide) et `dsoxlab provision` s'arrête avec un message
   d'aide (i18n EN+FR) pointant le `dsoxlab destroy` à lancer — au lieu de
   l'erreur Terraform « Network is already in use ».

ruff + mypy strict + pytest verts ; parité clés i18n EN/FR.

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [x] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
