### PR TITLE
chore(release): 0.1.6

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,9 +9,23 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-07-16
+
+### Corrigé
+
+- **Inventory KVM après un provision ciblé** : `terraform apply -target`
+  n'évalue pas les outputs racine, donc les IP des hôtes KVM (DHCP libvirt)
+  manquaient et `dsoxlab check` échouait « Aucun host dans l'inventory » pour
+  tout lab KVM. `apply()` lance désormais un `terraform apply -refresh-only`
+  après un apply ciblé pour recalculer le map d'outputs `hosts` sans recréer de
+  ressource.
+
 ### Ajouté
 
-- Rien pour l'instant.
+- **Détection de conflit de provider** : `dsoxlab provision` s'arrête avec un
+  message d'aide (EN + FR) si un autre provider (incus/KVM) a encore de l'infra
+  active — ils partagent le nom de réseau et le subnet du lab et ne peuvent pas
+  tourner en même temps.
 
 ## [0.1.5] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-07-16
+
+### Fixed
+
+- **KVM inventory after a targeted provision**: `terraform apply -target` does
+  not evaluate root outputs, so KVM host IPs (libvirt DHCP) were missing and
+  `dsoxlab check` failed with "Aucun host dans l'inventory" for every KVM lab.
+  `apply()` now runs `terraform apply -refresh-only` after a targeted apply to
+  recompute the `hosts` output map without recreating resources.
+
 ### Added
 
-- Nothing yet.
+- **Provider conflict detection**: `dsoxlab provision` stops with a helpful
+  message (EN + FR) when another provider (incus/KVM) still has active lab
+  infrastructure — they share the lab's network name and subnet and cannot run
+  at the same time.
 
 ## [0.1.5] - 2026-07-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.5"
+version = "0.1.6"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
Bump 0.1.5 → 0.1.6 + CHANGELOG (EN/FR) : fix inventory KVM (refresh-only après apply ciblé) + détection de conflit de provider incus/KVM.

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [x] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
