### PR TITLE
feat(check): --target + DSOXLAB_TARGET_HOST — le multi-distrib devien…

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -7,7 +7,30 @@ Toutes les modifications notables du projet sont documentées dans ce fichier.
 Le format s'appuie sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/),
 et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
-## [Unreleased]
+## [Non publié]
+
+## [0.1.7] - 2026-07-16
+
+### Ajouté
+
+- **Les labs multi-distrib deviennent réels** : `check`/`submit` acceptent
+  `--target/-t` et exportent le FQDN de la cible résolue aux tests via
+  `DSOXLAB_TARGET_HOST`. Jusqu'ici `runtime.targets[]` n'était que déclaratif —
+  un lab pouvait déclarer une cible Ubuntu pendant que ses tests codaient
+  l'hôte RHEL en dur : choisir Ubuntu ne changeait rien et le contrat mentait.
+  Les tests demandent désormais l'hôte choisi (helper `lab_target_host()` dans
+  le `conftest.py` du dépôt), donc un même lab peut être réellement validé sur
+  plusieurs distributions.
+
+### Corrigé
+
+- **Une faute de frappe dans `--target` n'enregistre plus un 0/100** : une
+  cible explicite inconnue est désormais une erreur (`unknown_target`, EN+FR)
+  levée avant le lancement des tests, au lieu d'un check échoué sauvegardé dans
+  l'historique de l'apprenant.
+- **Une cible de session ne casse plus les labs qui ne la déclarent pas** :
+  l'`active_target` persistée par `use --target` n'est appliquée qu'aux labs
+  qui la déclarent ; les labs shell et mono-cible l'ignorent silencieusement.
 
 ## [0.1.6] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-07-16
+
+### Added
+
+- **Multi-distro labs are now real**: `check`/`submit` accept `--target/-t` and
+  export the resolved target's FQDN to the tests via `DSOXLAB_TARGET_HOST`.
+  Until now `runtime.targets[]` was declarative only — a lab could declare an
+  Ubuntu target while its tests hard-coded the RHEL host, so selecting Ubuntu
+  changed nothing and the contract lied. Tests now ask for the chosen host
+  (`lab_target_host()` helper in the repo's `conftest.py`), so one lab can be
+  genuinely validated on several distributions.
+
+### Fixed
+
+- **A typo in `--target` no longer records a 0/100**: an unknown explicit
+  target is now an error (`unknown_target`, EN+FR) raised before the tests run,
+  instead of a failed check saved to the learner's history.
+- **A session target no longer breaks labs that don't declare it**: the
+  `active_target` persisted by `use --target` is applied only to labs that
+  actually declare it; shell and single-target labs silently ignore it.
+
 ## [0.1.6] - 2026-07-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.6"
+version = "0.1.7"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -648,9 +648,14 @@ def _resolve_lab(
         raise typer.Exit(1)
 
 
-def _run_check_with_progress(lab: LabDefinition) -> CheckResult:
+def _run_check_with_progress(
+    lab: LabDefinition, target: str | None = None
+) -> CheckResult:
     """Lance ``check_lab`` en streamant les verdicts pytest dans une
     progress bar Rich.
+
+    ``target`` sélectionne la target du lab sur laquelle valider (labs
+    multi-distrib). None = la target ``default`` du lab.
 
     Affiche un ✔/✘/⊘ par test et une barre M of N. En cas d'échec,
     le caller imprime le résumé/traceback contenu dans ``result.output``.
@@ -705,16 +710,38 @@ def _run_check_with_progress(lab: LabDefinition) -> CheckResult:
             # Les autres lignes (log/header/traceback) sont gardées dans
             # result.output et imprimées seulement si le check échoue.
 
-        result = check_lab(lab, on_event=on_event)
+        result = check_lab(lab, target=target, on_event=on_event)
         progress.update(task, description=f"Tests {lab.id} terminés")
 
     return result
 
 
-def _run_check(root: Path, lab: LabDefinition) -> tuple[CheckResult, int, int]:
-    """Lance les tests, enregistre le résultat, retourne (result, score, max_score)."""
+def _run_check(
+    root: Path, lab: LabDefinition, target: str | None = None
+) -> tuple[CheckResult, int, int]:
+    """Lance les tests, enregistre le résultat, retourne (result, score, max_score).
+
+    ``target`` (option ``--target``) l'emporte sur la target active de la
+    session ; à défaut, la target ``default`` du lab s'applique.
+    """
+    # Un --target explicite et inconnu est une ERREUR : on sort avant de
+    # lancer quoi que ce soit, sinon une faute de frappe enregistrerait un
+    # 0/100 dans l'historique de l'apprenant.
+    if target is not None and lab.runtime.target(target) is None:
+        declared = ", ".join(t.name for t in lab.runtime.targets) or "—"
+        error(_("unknown_target", target=target, declared=declared))
+        raise typer.Exit(1)
+
+    # À défaut, la target de session. Elle vaut pour TOUS les labs du dépôt :
+    # si celui-ci ne la déclare pas (lab shell, lab mono-target), on l'ignore
+    # simplement — ce n'est pas une erreur de l'apprenant.
+    if target is None:
+        session_target = read_context(root).active_target
+        if session_target and lab.runtime.target(session_target) is not None:
+            target = session_target
+
     info(_("validating", lab_id=lab.id))
-    result = _run_check_with_progress(lab)
+    result = _run_check_with_progress(lab, target)
     if not result.ok:
         # En cas d'échec, dump l'output brut (tracebacks, summary pytest)
         # pour que l'apprenant voie les erreurs détaillées.
@@ -747,11 +774,13 @@ def _run_check(root: Path, lab: LabDefinition) -> tuple[CheckResult, int, int]:
 @app.command("check", help=_("cmd_check_help"))
 def check(
     lab_id: Annotated[Optional[str], typer.Argument(help=_("cmd_check_arg"), shell_complete=_complete_lab_id)] = None,
+    target: Annotated[Optional[str], typer.Option("--target", "-t",
+        help=_("opt_check_target"))] = None,
     lab_home: LabHomeOption = None,
 ) -> None:
     root = _root(lab_home)
     lab = _resolve_lab(root, lab_id, _lang(root))
-    result, _score, _max_score = _run_check(root, lab)
+    result, _score, _max_score = _run_check(root, lab, target)
     if result.ok:
         success(_("all_tests_passed"))
         info(_("check_tip_submit"))
@@ -765,11 +794,13 @@ def check(
 @app.command("submit", help=_("cmd_submit_help"))
 def submit(
     lab_id: Annotated[Optional[str], typer.Argument(help=_("cmd_submit_arg"), shell_complete=_complete_lab_id)] = None,
+    target: Annotated[Optional[str], typer.Option("--target", "-t",
+        help=_("opt_check_target"))] = None,
     lab_home: LabHomeOption = None,
 ) -> None:
     root = _root(lab_home)
     lab = _resolve_lab(root, lab_id, _lang(root))
-    result, score, max_score = _run_check(root, lab)
+    result, score, max_score = _run_check(root, lab, target)
 
     if result.ok:
         success(_("submit_success", score=score, max_score=max_score))

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -23,6 +23,8 @@ STRINGS: dict[str, str] = {
     "opt_lang":          "Language for lab content (e.g.: en, fr). Overrides auto-detection.",
     "opt_target":        "Default execution target name (must match runtime.targets[].name in lab.yaml).",
     "opt_run_target":    "Execution target for this run (overrides --target from 'use'). Must match a runtime.targets[].name.",
+    "opt_check_target":  "Target to validate against (overrides the session target). Must match a runtime.targets[].name — the tests run on that host.",
+    "unknown_target":    "Unknown target '{target}' for this lab. Declared targets: {declared}.",
     "cmd_list_labs_help":"List all available labs (filtered by active context if set).",
     "cmd_progress_help": "Show progression by bloc (labs completed, average score, challenges and capstones).",
     "cmd_next_help":     "Recommend the next lab or challenge to complete in the active context.",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -22,6 +22,8 @@ STRINGS: dict[str, str] = {
     "opt_use_reset":      "Efface le contexte actif.",
     "opt_target":         "Nom de la cible d'exécution par défaut (doit matcher runtime.targets[].name dans lab.yaml).",
     "opt_run_target":     "Cible pour cette exécution (override le défaut de 'use'). Doit matcher un runtime.targets[].name.",
+    "opt_check_target":   "Cible sur laquelle valider (override la cible de session). Doit matcher un runtime.targets[].name — les tests tournent sur cet hôte.",
+    "unknown_target":     "Cible '{target}' inconnue pour ce lab. Cibles déclarées : {declared}.",
     "opt_lang":           "Langue pour le contenu des labs (ex: en, fr). Remplace l'auto-détection.",
     "cmd_list_labs_help": "Liste tous les labs disponibles (filtrés par contexte actif si défini).",
     "cmd_progress_help": "Affiche la progression par bloc (labs complétés, score moyen, challenges et capstones).",

--- a/src/dsoxlab/services/lab_service.py
+++ b/src/dsoxlab/services/lab_service.py
@@ -188,9 +188,17 @@ def _collect_test_count(
 def check_lab(
     lab: LabDefinition,
     *,
+    target: str | None = None,
     on_event: Callable[[dict[str, Any]], None] | None = None,
 ) -> CheckResult:
     """Lance les tests pytest du lab et retourne un CheckResult détaillé.
+
+    ``target`` sélectionne la target du lab (``runtime.targets[].name``) sur
+    laquelle les tests doivent porter. Son FQDN est exporté aux tests via
+    ``DSOXLAB_TARGET_HOST`` : c'est ce qui permet à un lab multi-distrib
+    d'être réellement validé sur la distrib choisie, au lieu que les tests
+    codent un hôte en dur. Si ``target`` est None, la target ``default`` du
+    lab est utilisée.
 
     Si ``on_event`` est fourni, les évènements suivants sont émis pour
     afficher une progress bar côté CLI :
@@ -227,6 +235,23 @@ def check_lab(
     # côté formateur, écrasant le travail manuel de l'apprenant).
     env = os.environ.copy()
     env.setdefault("LAB_NO_REPLAY", "1")
+
+    # Expose aux tests le FQDN de la target choisie. Sans ça, un lab
+    # multi-distrib ne peut que coder son hôte en dur : la target Ubuntu
+    # serait déclarée mais jamais testée — le contrat mentirait.
+    resolved = lab.runtime.target(target)
+    if target and resolved is None:
+        declared = ", ".join(t.name for t in lab.runtime.targets) or "aucune"
+        return CheckResult(
+            ok=False,
+            output=(
+                f"Target '{target}' inconnue pour le lab {lab.id}.\n"
+                f"Targets déclarées : {declared}."
+            ),
+            passed=0, total=0,
+        )
+    if resolved is not None and resolved.host:
+        env["DSOXLAB_TARGET_HOST"] = resolved.host
 
     if on_event is None:
         # Mode legacy : capture en bloc, pas de streaming.

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
…t réel

runtime.targets[] n'était que déclaratif. Un lab pouvait annoncer une cible Ubuntu pendant que ses tests codaient l'hôte RHEL en dur : choisir Ubuntu ne changeait rien, le contrat mentait, et aucun lab ne pouvait réellement être validé sur plusieurs distributions.

- check/submit acceptent --target/-t ; à défaut la cible de session (active_target), à défaut la cible « default » du lab.
- Le FQDN de la cible résolue est exporté aux tests via DSOXLAB_TARGET_HOST. Les tests le lisent par le helper lab_target_host() du conftest du dépôt de labs, au lieu de coder un hôte en dur.

Deux garde-fous, sans lesquels la fonctionnalité ferait plus de mal que de bien :

- Une cible explicite inconnue est une ERREUR levée AVANT les tests (clé unknown_target, EN+FR). Sans ça, une faute de frappe dans --target enregistrait un 0/100 dans l'historique de l'apprenant.
- Une cible de session n'est appliquée qu'aux labs qui la déclarent. Sans ça, un active_target posé pour un lab VM faisait échouer à tort tous les labs shell, avec un « cible inconnue » qui n'était pas la faute de l'apprenant.

Prouvé sur l3-service-diagnose : --target ubuntu -> 3/6 (hôte cassé), --target rhel -> 6/6 (hôte intact), sans --target -> 6/6 (cible default). ruff + mypy strict verts.

Bump 0.1.7 + CHANGELOG EN/FR + uv.lock.

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [x] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
