### PR TITLE
fix(cli): plus de traceback ni de 0/100 quand l'infra n'est pas provi…

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,24 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.8] - 2026-07-16
+
+### Corrigé
+
+- **Plus de traceback Python quand l'infrastructure n'est pas provisionnée** :
+  un apprenant qui lançait un lab VM avant `dsoxlab provision` (premier
+  lancement, ou après un `destroy`) recevait un `ValueError: target_fqdn '...'
+  n'est pas dans la liste des hôtes connus : []` brut. C'est une situation
+  normale, pas un bug — `build_inventory()` lève désormais
+  `InfraNotProvisioned`, que la CLI rend en une phrase actionnable (EN+FR)
+  indiquant de lancer `dsoxlab provision`. Un point d'entrée `main()` l'attrape
+  pour toutes les commandes : aucune ne peut plus afficher de traceback pour ça.
+- **`check` n'enregistre plus un 0/100 en l'absence d'infrastructure** : pytest
+  tourne en sous-processus, donc l'erreur d'hôte manquant ne pouvait pas
+  remonter jusqu'à la CLI — l'exécution était notée comme un échec de
+  l'apprenant et sauvegardée dans son historique. `check`/`submit` vérifient
+  maintenant l'inventory avant de noter, et sortent sans rien enregistrer.
+
 ## [0.1.7] - 2026-07-16
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-07-16
+
+### Fixed
+
+- **No more Python traceback when the infrastructure is not provisioned**: a
+  learner running a VM lab before `dsoxlab provision` (first run, or after a
+  `destroy`) got a raw `ValueError: target_fqdn '...' is not in the list of
+  known hosts: []`. This is a normal situation, not a bug — `build_inventory()`
+  now raises `InfraNotProvisioned`, rendered by the CLI as one actionable
+  sentence (EN+FR) telling the learner to run `dsoxlab provision`. A `main()`
+  entry point catches it for every command, so no command can surface a
+  traceback for it.
+- **`check` no longer records a 0/100 when there is no infrastructure**: pytest
+  runs in a subprocess, so the missing-host error could not reach the CLI — the
+  run was scored as a learner failure and saved to their history. `check`/
+  `submit` now verify the inventory before scoring, and exit without recording.
+
 ## [0.1.7] - 2026-07-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.7"
+version = "0.1.8"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -47,7 +47,7 @@ dependencies = [
 ]
 
 [project.scripts]
-dsoxlab = "dsoxlab.cli:app"
+dsoxlab = "dsoxlab.cli:main"
 
 [project.urls]
 Homepage = "https://blog.stephane-robert.info/"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -33,6 +33,7 @@ from .config import (
     set_active_provider, set_course_pos, write_context,
 )
 from .i18n import _, get_lang, set_lang
+from .infra.inventory import InfraNotProvisioned
 from .models.hint import HintFile
 from .sessions.store import (
     get_best_scores,
@@ -498,6 +499,11 @@ def run(
             )
         else:
             run_lab(lab, target_name=target)
+    except InfraNotProvisioned:
+        # Avant le except RuntimeError : InfraNotProvisioned en hérite, et
+        # mérite la phrase actionnable plutôt que son message technique.
+        error(_("infra_not_provisioned"))
+        raise typer.Exit(2) from None
     except RuntimeError as exc:
         error(str(exc))
         raise typer.Exit(2)
@@ -724,6 +730,26 @@ def _run_check(
     ``target`` (option ``--target``) l'emporte sur la target active de la
     session ; à défaut, la target ``default`` du lab s'applique.
     """
+    # Même logique que pour --target : on refuse de NOTER ce qui n'a pas pu
+    # tourner. Un lab VM sans infrastructure n'est pas un échec de l'apprenant
+    # et ne doit pas lui coûter un 0/100 dans son historique. pytest tourne en
+    # sous-processus, donc l'erreur du conftest ne remonterait pas jusqu'ici :
+    # il faut vérifier AVANT.
+    if lab.runtime.type.value in ("vm", "kvm", "incus"):
+        from .discovery.repo import read_repo_metadata
+        from .infra.inventory import build_inventory, read_terraform_outputs
+
+        repo_meta = read_repo_metadata(root)
+        if repo_meta is not None:
+            try:
+                build_inventory(
+                    repo_meta,
+                    terraform_outputs=read_terraform_outputs(repo_meta),
+                )
+            except InfraNotProvisioned:
+                error(_("infra_not_provisioned"))
+                raise typer.Exit(2) from None
+
     # Un --target explicite et inconnu est une ERREUR : on sort avant de
     # lancer quoi que ce soit, sinon une faute de frappe enregistrerait un
     # 0/100 dans l'historique de l'apprenant.
@@ -1817,3 +1843,23 @@ def instructor_bootstrap(
 @app.command("fullhelp", help=_("cmd_fullhelp_help"))
 def fullhelp() -> None:
     print_fullhelp()
+
+
+# ── point d'entrée console ────────────────────────────────────────────────────
+
+def main() -> None:
+    """Point d'entrée de la commande ``dsoxlab``.
+
+    Enveloppe l'app Typer pour rendre les erreurs ATTENDUES en une phrase
+    actionnable, jamais en traceback Python. Une infrastructure non
+    provisionnée est une situation normale (premier lancement, après un
+    ``destroy``) : l'apprenant doit lire quoi faire, pas une pile d'appels.
+
+    Les erreurs inattendues, elles, continuent de remonter avec leur
+    traceback — c'est ce qu'on veut pour un vrai bug.
+    """
+    try:
+        app()
+    except InfraNotProvisioned:
+        error(_("infra_not_provisioned"))
+        raise SystemExit(1) from None

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -25,6 +25,7 @@ STRINGS: dict[str, str] = {
     "opt_run_target":    "Execution target for this run (overrides --target from 'use'). Must match a runtime.targets[].name.",
     "opt_check_target":  "Target to validate against (overrides the session target). Must match a runtime.targets[].name — the tests run on that host.",
     "unknown_target":    "Unknown target '{target}' for this lab. Declared targets: {declared}.",
+    "infra_not_provisioned": "This lab needs a VM, and none is running: the lab infrastructure is not provisioned.\nBring it up first:\n  dsoxlab provision",
     "cmd_list_labs_help":"List all available labs (filtered by active context if set).",
     "cmd_progress_help": "Show progression by bloc (labs completed, average score, challenges and capstones).",
     "cmd_next_help":     "Recommend the next lab or challenge to complete in the active context.",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -24,6 +24,7 @@ STRINGS: dict[str, str] = {
     "opt_run_target":     "Cible pour cette exécution (override le défaut de 'use'). Doit matcher un runtime.targets[].name.",
     "opt_check_target":   "Cible sur laquelle valider (override la cible de session). Doit matcher un runtime.targets[].name — les tests tournent sur cet hôte.",
     "unknown_target":     "Cible '{target}' inconnue pour ce lab. Cibles déclarées : {declared}.",
+    "infra_not_provisioned": "Ce lab a besoin d'une VM, et aucune ne tourne : l'infrastructure du lab n'est pas provisionnée.\nMonte-la d'abord :\n  dsoxlab provision",
     "opt_lang":           "Langue pour le contenu des labs (ex: en, fr). Remplace l'auto-détection.",
     "cmd_list_labs_help": "Liste tous les labs disponibles (filtrés par contexte actif si défini).",
     "cmd_progress_help": "Affiche la progression par bloc (labs complétés, score moyen, challenges et capstones).",

--- a/src/dsoxlab/infra/__init__.py
+++ b/src/dsoxlab/infra/__init__.py
@@ -11,6 +11,7 @@ from . import terraform as terraform_mod
 from .ansible import AnsibleNotInstalled, PlaybookResult, run_playbook
 from .inventory import (
     bastion_info,
+    InfraNotProvisioned,
     build_inventory,
     inventory_path,
     read_terraform_outputs,
@@ -36,6 +37,7 @@ __all__ = [
     "TerraformNotInstalled",
     "ansible",
     "bastion_info",
+    "InfraNotProvisioned",
     "build_inventory",
     "inventory_path",
     "read_terraform_outputs",

--- a/src/dsoxlab/infra/inventory.py
+++ b/src/dsoxlab/infra/inventory.py
@@ -33,6 +33,16 @@ from ..models.repo import RepoMetadata
 logger = logging.getLogger(__name__)
 
 
+class InfraNotProvisioned(RuntimeError):
+    """L'infrastructure du lab n'est pas provisionnée (aucun hôte joignable).
+
+    Levée quand le ``meta.yml`` déclare des hôtes mais qu'aucun n'a d'adresse :
+    Terraform n'a pas tourné. C'est une situation NORMALE (premier lancement,
+    après un ``destroy``), pas un bug — la CLI la rend en une phrase, jamais en
+    traceback.
+    """
+
+
 def build_inventory(
     repo_meta: RepoMetadata,
     *,
@@ -122,6 +132,16 @@ def build_inventory(
             "distro": host_def.distro,
             "role": host_def.role,
         }
+
+    # Le dépôt déclare des hôtes mais AUCUN n'a d'IP : l'infrastructure n'est
+    # pas provisionnée. C'est le cas le plus fréquent chez un débutant, et il
+    # ne doit surtout pas se manifester par une traceback : on lève une erreur
+    # que la CLI sait rendre en une phrase actionnable.
+    if repo_meta.infra.hosts and not inventory_hosts:
+        raise InfraNotProvisioned(
+            "Aucun hôte n'a d'adresse : l'infrastructure du lab n'est pas "
+            "provisionnée."
+        )
 
     children: dict[str, Any] = {
         "labenv": {"hosts": inventory_hosts},

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
…sionnée

Découvert en jouant 10 labs au hasard comme le ferait un étudiant.

Un apprenant qui lance un lab VM avant `dsoxlab provision` — premier lancement, ou après un `destroy` — recevait une traceback Python brute :

    ValueError: target_fqdn 'alma-rhcsa-1.lab' n'est pas dans la liste des
    hôtes connus : []

C'est le tout premier mur qu'un débutant rencontre, et ce n'est pas un bug : c'est une situation normale. build_inventory() lève désormais InfraNotProvisioned quand le meta.yml déclare des hôtes mais qu'aucun n'a d'adresse, et la CLI la rend en une phrase actionnable (EN+FR) : « Ce lab a besoin d'une VM, et aucune ne tourne. Monte-la d'abord : dsoxlab provision ».

Un point d'entrée main() l'attrape pour TOUTES les commandes : aucune ne peut plus afficher de traceback pour ça. Les erreurs inattendues, elles, continuent de remonter avec leur pile — c'est ce qu'on veut pour un vrai bug.

Second défaut, plus vicieux : `check` enregistrait un 0/100 dans l'historique de l'apprenant. pytest tourne en sous-processus, donc l'erreur d'hôte manquant ne pouvait pas remonter jusqu'à la CLI : l'exécution était notée comme un échec imputé à l'apprenant. check/submit vérifient maintenant l'inventory AVANT de noter, et sortent sans rien enregistrer — même principe que pour un --target inconnu.

Bump 0.1.8 + CHANGELOG EN/FR + uv.lock. ruff + mypy strict verts.

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [x] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
