### PR TITLE
fix(kvm): nommer le volume de base par dépôt, pour que deux catalogue…

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,36 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.9] - 2026-07-16
+
+### Corrigé
+
+- **KVM : deux dépôts de labs ne se disputent plus le même volume de base.**
+  L'image de base libvirt s'appelait `dsoxlab-base-<distro>.qcow2`, sans
+  l'identifiant du dépôt. Or le pool libvirt est *partagé* entre tous les
+  dépôts, alors que chacun garde son **propre** state Terraform. Le second
+  dépôt à provisionner sur une distro déjà utilisée par un autre échouait donc
+  sur `storage volume 'dsoxlab-base-alma10.qcow2' exists already` : son state
+  ignorait simplement le volume créé par le premier. Concrètement,
+  `linux-dsoxlab-training` (alma10) bloquait `ansible-training` (alma10) sur la
+  même machine. Le volume devient `dsoxlab-base-<repo-id>-<distro>.qcow2` : les
+  catalogues cohabitent vraiment, comme le contrat le promet déjà avec leurs
+  réseaux libvirt séparés. L'image cloud est dupliquée par dépôt (sparse, ~600 Mo
+  à 2 Go) : c'est le prix de l'isolation.
+
+  Terraform reçoit une variable `repo_id`, déclarée par les trois providers
+  (`kvm`, `incus`, `outscale`) puisque les tfvars sont communs ; seul `kvm` crée
+  un volume local, lui seul était touché. Incus tire des alias d'images publiques
+  et Outscale utilise des AMI : aucune collision possible.
+
+  **Impact à la mise à jour.** Sur un dépôt provisionné en ≤ 0.1.8, le prochain
+  `dsoxlab provision` renomme le volume de base, ce que Terraform traite comme un
+  *remplacement* : les VMs sont recréées. Rien n'est perdu (les VMs de labs sont
+  jetables par conception, et le travail de l'apprenant vit dans le dépôt,
+  `challenge/`, jamais sur la VM), mais l'état des labs en cours sur les VMs
+  disparaît. Enchaîner `dsoxlab destroy` puis `dsoxlab provision` pour un cycle
+  propre.
+
 ## [0.1.8] - 2026-07-16
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-07-16
+
+### Fixed
+
+- **KVM: two lab repositories can no longer fight over the same base volume.**
+  The libvirt base image was named `dsoxlab-base-<distro>.qcow2`, without the
+  repository id — but the libvirt pool is *shared* across repositories while
+  each repository keeps its **own** Terraform state. So the second repository to
+  provision on a distro already used by another failed with
+  `storage volume 'dsoxlab-base-alma10.qcow2' exists already`: its state simply
+  did not know about the volume the first one had created. Concretely,
+  `linux-dsoxlab-training` (alma10) blocked `ansible-training` (alma10) on the
+  same host. The volume is now `dsoxlab-base-<repo-id>-<distro>.qcow2`, so lab
+  catalogs really do cohabit, as the contract promises with their separate
+  libvirt networks. The cloud image is duplicated per repository (sparse, ~600 MB
+  to 2 GB) — the price of isolation.
+
+  Terraform gets a new `repo_id` variable, declared by the three providers
+  (`kvm`, `incus`, `outscale`) since the tfvars are shared; only `kvm` creates a
+  local volume, so only it was affected. Incus pulls public image aliases and
+  Outscale uses AMIs: neither could collide.
+
+  **Upgrade impact.** On a repository provisioned with ≤ 0.1.8, the next
+  `dsoxlab provision` renames the base volume, which Terraform treats as a
+  *replacement*: the VMs get recreated. Nothing is lost — lab VMs are meant to
+  be disposable and the learner's work lives in the repository
+  (`challenge/`), never on the VM — but any in-progress lab state on the VMs
+  goes away. Run `dsoxlab destroy` then `dsoxlab provision` for a clean cycle.
+
 ## [0.1.8] - 2026-07-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.8"
+version = "0.1.9"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/infra/terraform.py
+++ b/src/dsoxlab/infra/terraform.py
@@ -202,6 +202,12 @@ def write_tfvars(repo_meta: RepoMetadata) -> Path:
     )
 
     payload = {
+        # Identifiant du dépôt de labs : sert à nommer les ressources qui vivent
+        # dans un espace partagé entre dépôts (le pool libvirt, par exemple).
+        # Sans lui, deux dépôts utilisant la même distro se disputent le volume
+        # de base, alors que chacun a son propre state Terraform et ignore
+        # l'autre.
+        "repo_id": repo_meta.id,
         "network_name": repo_meta.infra.network,
         "network_cidr": network_cidr,
         "hosts": [

--- a/src/dsoxlab/templates/terraform/incus/variables.tf
+++ b/src/dsoxlab/templates/terraform/incus/variables.tf
@@ -1,3 +1,8 @@
+variable "repo_id" {
+  description = "Identifiant du dépôt de labs (meta.yml: repo.id). Préfixe les ressources partagées entre dépôts au sein d'un même hyperviseur, pour que deux catalogues utilisant la même distro ne se disputent pas le volume de base."
+  type        = string
+}
+
 variable "network_name" {
   description = "Nom du réseau Incus à créer (ex. lab-linux). Sera prefixé par 'incusbr-' au niveau du bridge si non géré par Incus."
   type        = string

--- a/src/dsoxlab/templates/terraform/kvm/main.tf
+++ b/src/dsoxlab/templates/terraform/kvm/main.tf
@@ -116,7 +116,14 @@ resource "libvirt_network" "lab" {
 resource "libvirt_volume" "base_image" {
   for_each = local.unique_distros
 
-  name = "dsoxlab-base-${each.key}.qcow2"
+  # Le nom porte le repo_id : le pool libvirt est PARTAGÉ entre tous les dépôts
+  # de labs, alors que chacun a son propre state Terraform et ignore les autres.
+  # Sans ce préfixe, deux catalogues utilisant la même distro (linux et ansible
+  # sur alma10, par exemple) se disputent « dsoxlab-base-alma10.qcow2 » : le
+  # second à provisionner échoue sur « storage volume exists already », puisque
+  # son state ne contient pas le volume créé par le premier.
+  # Coût assumé : l'image cloud est dupliquée par dépôt (sparse, ~600 Mo à 2 Go).
+  name = "dsoxlab-base-${var.repo_id}-${each.key}.qcow2"
   pool = "default"
 
   # 10 GiB : capacity requise quand le serveur HTTP ne renvoie pas de

--- a/src/dsoxlab/templates/terraform/kvm/variables.tf
+++ b/src/dsoxlab/templates/terraform/kvm/variables.tf
@@ -1,3 +1,8 @@
+variable "repo_id" {
+  description = "Identifiant du dépôt de labs (meta.yml: repo.id). Préfixe les ressources partagées entre dépôts au sein d'un même hyperviseur, pour que deux catalogues utilisant la même distro ne se disputent pas le volume de base."
+  type        = string
+}
+
 variable "network_name" {
   description = "Nom du réseau libvirt à créer (ex. lab-linux)."
   type        = string

--- a/src/dsoxlab/templates/terraform/outscale/variables.tf
+++ b/src/dsoxlab/templates/terraform/outscale/variables.tf
@@ -1,3 +1,8 @@
+variable "repo_id" {
+  description = "Identifiant du dépôt de labs (meta.yml: repo.id). Préfixe les ressources partagées entre dépôts au sein d'un même hyperviseur, pour que deux catalogues utilisant la même distro ne se disputent pas le volume de base."
+  type        = string
+}
+
 variable "network_name" {
   description = "Nom du Net Outscale (équivalent VPC) — ex. lab-linux."
   type        = string

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
…s cohabitent

Le volume de base libvirt s'appelait `dsoxlab-base-<distro>.qcow2`, sans l'identifiant du dépôt. Or le pool libvirt est PARTAGÉ entre tous les dépôts de labs, alors que chacun garde son PROPRE state Terraform (~/.local/state/dsoxlab/<repo-id>/). Le second dépôt à provisionner sur une distro déjà utilisée échouait donc :

    Error: Volume Creation Failed
    storage volume 'dsoxlab-base-alma10.qcow2' exists already

Son state ignorait simplement le volume créé par le premier. Rencontré en vrai : linux-dsoxlab-training (alma10) bloquait ansible-training (alma10) sur la même machine — les deux dépôts que le projet cite en exemple de cohabitation.

C'est un écart entre le contrat et le code : le CLAUDE.md promet que chaque dépôt a « son infra dédiée (réseau libvirt séparé pour cohabitation) ». Le réseau l'était (lab-linux vs lab-ansible), pas le volume de base.

Le volume devient `dsoxlab-base-<repo-id>-<distro>.qcow2`. Terraform reçoit une variable `repo_id`, déclarée par les trois providers puisque les tfvars sont communs. Seul kvm crée un volume local, lui seul était touché : incus tire des alias d'images publiques (images:almalinux/10/cloud), outscale utilise des AMI.

Coût assumé : l'image cloud est dupliquée par dépôt (sparse, ~600 Mo à 2 Go). C'est le prix de l'isolation, et il est faible au regard d'un provisioning qui échoue.

IMPACT à la mise à jour, documenté dans le CHANGELOG : sur un dépôt provisionné en <= 0.1.8, le prochain `dsoxlab provision` renomme le volume, ce que Terraform traite comme un remplacement — les VMs sont recréées. Rien n'est perdu (les VMs de labs sont jetables par conception, le travail de l'apprenant vit dans le dépôt, jamais sur la VM), mais l'état des labs en cours disparaît.

Vérifié : terraform validate OK, ruff OK, les 3 tests passent. Les 45 erreurs mypy sont préexistantes sur main (identiques avant/après), terraform.py n'en fait pas partie.

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [x] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
