### PR TITLE
fix(check): le score était faux sur les labs manipulant le mot ERROR

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,20 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.10] - 2026-07-16
+
+### Corrigé
+
+- **Les scores étaient faux sur les labs dont les données contiennent
+  « ERROR », « PASSED » ou « FAILED »** : `_parse_counts()` comptait les
+  occurrences de ces mots dans la sortie brute de pytest, messages d'assertion
+  compris. Un lab qui filtre des lignes `ERROR` (`l1-get-help`,
+  `l1-grep-regex`, `l1-redirections-pipes`, `l3-service-diagnose`…) gonflait son
+  propre total — `dsoxlab check` annonçait `1/5` pour un lab de 4 tests, et le
+  score de l'apprenant s'en trouvait sous-évalué (20 pts au lieu de 25). La
+  ligne de résumé que pytest produit lui-même fait désormais foi, avec un repli
+  ancré sur les node-ids.
+
 ## [0.1.9] - 2026-07-16
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-07-16
+
+### Fixed
+
+- **Scores were wrong on labs whose data contains "ERROR", "PASSED" or
+  "FAILED"**: `_parse_counts()` counted occurrences of those words in pytest's
+  raw output, including inside assertion messages. A lab that filters `ERROR`
+  lines (`l1-get-help`, `l1-grep-regex`, `l1-redirections-pipes`,
+  `l3-service-diagnose`…) inflated its own total — `dsoxlab check` reported
+  `1/5` for a 4-test lab, so the learner's score was under-counted (20 pts
+  instead of 25). The summary line pytest produces itself is now the source of
+  truth, with a node-id-anchored fallback.
+
 ## [0.1.9] - 2026-07-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.9"
+version = "0.1.10"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/services/lab_service.py
+++ b/src/dsoxlab/services/lab_service.py
@@ -33,18 +33,41 @@ class CheckResult:
 
 
 def _parse_counts(output: str) -> tuple[int, int]:
-    """Extrait (passed, total) depuis la sortie verbose de pytest."""
-    passed = len(re.findall(r" PASSED", output))
-    failed = len(re.findall(r" FAILED", output))
-    errors = len(re.findall(r" ERROR", output))
-    total = passed + failed + errors
+    """Extrait (passed, total) depuis la sortie de pytest.
+
+    On lit la ligne de RÉSUMÉ que pytest produit lui-même ("3 failed, 1 passed
+    in 0.02s") : c'est la seule source fiable.
+
+    Compter les occurrences de " PASSED"/" FAILED"/" ERROR" dans la sortie
+    brute — ce que faisait cette fonction — est faux dès qu'un lab manipule ces
+    mots : les messages d'assertion les affichent. Un lab qui filtre des lignes
+    « ERROR » (l1-get-help, l1-grep-regex, l1-redirections-pipes…) gonflait son
+    total, et le score de l'apprenant s'en trouvait FAUSSÉ : 1/5 au lieu de
+    1/4. Bug vécu, trouvé en jouant les labs.
+    """
+    # La dernière ligne qui porte un compte est le résumé final : les lignes
+    # de verdict par test ("… PASSED [ 25%]") n'ont pas ce format.
+    resumes = [
+        ligne
+        for ligne in output.splitlines()
+        if re.search(r"\b\d+ (passed|failed|error|skipped)", ligne)
+    ]
+    resume = resumes[-1] if resumes else ""
+
+    def _compte(mot: str) -> int:
+        m = re.search(rf"(\d+) {mot}", resume)
+        return int(m.group(1)) if m else 0
+
+    passed = _compte("passed")
+    total = passed + _compte("failed") + _compte("error") + _compte("skipped")
+
     if total == 0:
-        # Fallback sur la ligne récapitulative : "3 passed, 2 failed in 0.03s"
-        m_p = re.search(r"(\d+) passed", output)
-        m_f = re.search(r"(\d+) failed", output)
-        passed = int(m_p.group(1)) if m_p else 0
-        failed = int(m_f.group(1)) if m_f else 0
-        total = passed + failed
+        # Aucun résumé exploitable (pytest a planté avant) : on retombe sur le
+        # comptage des verdicts, ancré sur le format "<nodeid> VERDICT" pour ne
+        # pas ramasser les mots présents dans les messages.
+        verdicts = re.findall(r"::\S+\s+(PASSED|FAILED|ERROR)\b", output)
+        passed = verdicts.count("PASSED")
+        total = len(verdicts)
     return passed, total
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
Trouvé en écrivant les solutions des labs shell : dsoxlab annonçait « 1/5 » sur l1-get-help, qui n'a que 4 tests.

_parse_counts() comptait les occurrences de " PASSED", " FAILED" et " ERROR" dans la sortie BRUTE de pytest — messages d'assertion compris. Or l1-get-help filtre justement des lignes contenant ERROR : quand un test échoue, son message affiche ces lignes, chacune matche, et le total gonfle.

Le score valant passed/total × points, l'apprenant était SOUS-NOTÉ : 1/5 = 20 points au lieu de 1/4 = 25. Le bug touche tout lab dont les données ou les messages portent ces mots — l1-get-help, l1-grep-regex, l1-redirections-pipes, l3-service-diagnose…

La ligne de résumé que pytest produit lui-même (« 3 failed, 1 passed in 0.02s ») fait désormais foi. Le repli, lui, est ancré sur le format des node-ids (« <nodeid> VERDICT ») pour ne plus ramasser les mots présents dans les messages.

Vérifié : l1-get-help 1/5 -> 1/4, l1-redirections-pipes 1/6 -> 1/5. Bump 0.1.10 + CHANGELOG EN/FR + uv.lock. ruff + mypy strict + pytest verts.

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [x] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
