### PR TITLE
docs(contributing): aligner le gabarit de PR et CONTRIBUTING sur le projet réel

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Summary
 
-<!-- What does this PR change and why? -->
+<!-- What does this PR change, and why? -->
 
 ## Type of change
 
@@ -9,17 +9,65 @@
 - [ ] Refactor
 - [ ] Documentation
 - [ ] Chore / tooling
+- [ ] Security / supply chain
 
 ## Checklist
 
-- [ ] `uv run ruff check src/dsoxlab` passes
+Only the **Always** block applies to every PR. The other blocks are conditional:
+if a block does not apply, say so (`N/A`) rather than leaving it blank — a blank
+box reads as "forgotten", an explicit `N/A` reads as "considered".
+
+### Always
+
+- [ ] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit)
 - [ ] `uv run mypy src/dsoxlab` passes (strict)
 - [ ] `uv run pytest` passes
-- [ ] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
-- [ ] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
-- [ ] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
-- [ ] `CHANGELOG.md` updated when behavior changes
-- [ ] Manually tested against at least one lab repository
+- [ ] The engine stays domain-agnostic — no domain-specific logic in
+      `src/dsoxlab/` (no `if category == "linux"`)
+- [ ] No hardcoded personal path or host; `pathlib.Path` throughout
+- [ ] Manually tested against **two** lab repositories, to prove the agnostic
+      design (e.g. `linux-dsoxlab-training` and `ansible-training`)
+
+### When behavior changes — otherwise N/A
+
+- [ ] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated (the project is
+      bilingual; an EN-only entry is an incomplete entry)
+- [ ] Version bumped in `pyproject.toml` and `uv.lock` refreshed (`uv lock`).
+      `__version__` is derived from the package metadata — there is nothing to
+      bump in `src/dsoxlab/__init__.py`.
+
+### When a command or option is added, removed or changed — otherwise N/A
+
+- [ ] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
+- [ ] `help=_("…")` in `cli.py` and the `fullhelp_commands` section updated in
+      EN **and** FR — `fullhelp` must never describe a command that no longer
+      exists
+- [ ] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`
+
+### When `.github/workflows/` is touched — otherwise N/A
+
+These are CI gates: they fail the build, so run them before pushing.
+
+- [ ] `actionlint` clean
+- [ ] `zizmor --offline .github/workflows/` reports no findings
+- [ ] `poutine analyze_local . --fail-on-violation` clean
+- [ ] Every action pinned to a **full 40-character commit SHA** with a
+      `# vX.Y.Z` comment — never `@v4`, never `@main`
+- [ ] `step-security/harden-runner` is the job's first step
+- [ ] No job renamed, or the required status checks updated accordingly — they
+      match job names **exactly**, and a renamed job silently stops being
+      required
+- [ ] A new third-party action is added to `trustedGithubActions` in
+      `.plumber.yaml` (and acknowledged per purl in `.poutine.yml` if its
+      creator is not Marketplace-verified)
+
+### When the declarative contract (`meta.yml` / `lab.yaml`) changes — otherwise N/A
+
+- [ ] The contract section of `README.md` reflects the change
+- [ ] `fuzz/corpus/` seeds and `fuzz/dict/yaml_contract.dict` cover any new field
+- [ ] A malformed value of the new field still raises inside the parser contract
+      — `(KeyError, ValueError, yaml.YAMLError)` — so a bad lab is skipped with a
+      warning instead of crashing the CLI
 
 ## Related issues
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
-# Contribution gate. zizmor statically analyzes the workflows first, as a fast
-# security gate; the heavier jobs (quality matrix, CodeQL) only run once it
-# passes, so an insecure workflow fails fast without burning runners.
+# Contribution gate. Three workflow scanners run first, in parallel, as a fast
+# security gate: zizmor (workflow vulnerabilities), actionlint (syntax, invalid
+# permission scopes, shellcheck) and poutine (CI/CD exploitation chains). The
+# heavier jobs (quality matrix, pre-commit parity, fuzzing, CodeQL) only run
+# once all three pass, so an insecure workflow fails fast without burning
+# runners.
 #
-# Deeper CI/CD policy scanning and the compliance score live in plumber.yml
-# (trusted context only); supply-chain posture in scorecard.yml.
+# The compliance score and the repository-settings checks live in plumber.yml
+# (trusted context only — it needs a privileged token); supply-chain posture in
+# scorecard.yml.
 #
 # Hardening baseline: every action is pinned to a full commit SHA, the default
 # token has no permissions, each job grants only what it needs, checkout never
@@ -32,6 +36,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      # First step of every job: monitor egress and block the runner from being
+      # tampered with. `audit` records outbound calls without failing the run —
+      # the recorded list is what a future `block` policy would be built from.
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -46,9 +58,90 @@ jobs:
           version: "1.26.1"
           advanced-security: false
 
+  # Workflow syntax gate. actionlint is what refuses an invalid runner label, a
+  # malformed ${{ }} expression or a permission scope that does not exist — the
+  # class of mistake that silently disables a control rather than failing loudly.
+  # It also runs shellcheck over every `run:` block.
+  actionlint:
+    name: Actionlint (workflow syntax)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Verified release binary rather than a third-party action: the scanner
+      # that guards the pipeline must not itself widen the trust boundary.
+      # Same pattern as the trufflehog install below (no piped remote script).
+      - name: Install actionlint (verified release binary)
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          base="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+          asset="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL -o "${workdir}/${asset}" "${base}/${asset}"
+          curl -fsSL -o "${workdir}/checksums.txt" "${base}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          (cd "${workdir}" && grep " ${asset}$" checksums.txt | sha256sum -c -)
+          tar -xzf "${workdir}/${asset}" -C "${workdir}" actionlint
+          sudo install -m 0755 "${workdir}/actionlint" /usr/local/bin/actionlint
+          actionlint --version
+
+      - name: Actionlint
+        run: actionlint -color
+
+  # CI/CD exploitation-chain gate. poutine models triggers, permissions and data
+  # flow to surface complete attack scenarios, and flags actions from unverified
+  # creators. Acknowledged false positives live in .poutine.yml, per purl.
+  poutine:
+    name: Poutine (CI/CD exploitation chains)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install poutine (verified release binary)
+        env:
+          POUTINE_VERSION: "1.1.6"
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          base="https://github.com/boostsecurityio/poutine/releases/download/v${POUTINE_VERSION}"
+          asset="poutine_Linux_x86_64.tar.gz"
+          curl -fsSL -o "${workdir}/${asset}" "${base}/${asset}"
+          curl -fsSL -o "${workdir}/checksums.txt" "${base}/poutine_${POUTINE_VERSION}_checksums.txt"
+          (cd "${workdir}" && grep " ${asset}$" checksums.txt | sha256sum -c -)
+          tar -xzf "${workdir}/${asset}" -C "${workdir}" poutine
+          sudo install -m 0755 "${workdir}/poutine" /usr/local/bin/poutine
+          poutine version
+
+      # --fail-on-violation makes this a gate (exit 10) instead of a report.
+      - name: Poutine
+        run: poutine analyze_local . --fail-on-violation --quiet
+
   quality:
     name: Lint, type-check and test (py${{ matrix.python-version }})
-    needs: zizmor
+    needs: [zizmor, actionlint, poutine]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -62,6 +155,11 @@ jobs:
       # so no context value is ever interpolated into shell code.
       PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -80,7 +178,7 @@ jobs:
         run: uv sync --frozen --python "$PYTHON_VERSION"
 
       - name: Lint and security (ruff)
-        run: uv run ruff check src/dsoxlab tests
+        run: uv run ruff check src/dsoxlab tests fuzz
 
       - name: Type-check (mypy strict)
         run: uv run mypy src/dsoxlab
@@ -96,12 +194,17 @@ jobs:
   # committed .pre-commit-config.yaml itself — no hand-maintained copy to drift.
   pre-commit:
     name: Pre-commit parity (all hooks)
-    needs: zizmor
+    needs: [zizmor, actionlint, poutine]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -141,15 +244,85 @@ jobs:
       - name: Run every hook (push stage)
         run: uv run pre-commit run --all-files --hook-stage pre-push --show-diff-on-failure --color always
 
+  # Short fuzzing regression over the untrusted-YAML contract. lab.yaml and
+  # meta.yml come from lab-provider repositories, so they are this engine's
+  # main untrusted input; discovery/scanner.py only rattrape (KeyError,
+  # ValueError, YAMLError), and anything else crashes the CLI on an unrelated
+  # command. These harnesses assert that contract.
+  #
+  # This is a regression gate, not a fuzzing campaign: a short seeded run keeps
+  # the harnesses alive and catches the obvious breakages. Deep runs are done
+  # locally with a persistent corpus.
+  fuzz:
+    name: Fuzz the untrusted-YAML contract (short run)
+    needs: [zizmor, actionlint, poutine]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.26"
+          enable-cache: true
+
+      - name: Sync dependencies (locked, with the fuzz group)
+        run: uv sync --frozen --group fuzz
+
+      # Scratch dir first, seed corpus second: libFuzzer writes what it finds
+      # into the first directory, and fuzz/corpus/ is a curated seed set.
+      - name: Fuzz the lab.yaml parser
+        run: |
+          mkdir -p "${RUNNER_TEMP}/fuzz-lab"
+          uv run --group fuzz python fuzz/fuzz_lab_yaml.py \
+            "${RUNNER_TEMP}/fuzz-lab" fuzz/corpus/lab_yaml/ \
+            -dict=fuzz/dict/yaml_contract.dict \
+            -atheris_runs=20000 -max_len=4096
+
+      - name: Fuzz the meta.yml parser
+        run: |
+          mkdir -p "${RUNNER_TEMP}/fuzz-meta"
+          uv run --group fuzz python fuzz/fuzz_meta_yaml.py \
+            "${RUNNER_TEMP}/fuzz-meta" fuzz/corpus/meta_yml/ \
+            -dict=fuzz/dict/yaml_contract.dict \
+            -atheris_runs=20000 -max_len=4096
+
+      # A crash writes a `crash-*` reproducer next to the harness. Keep it: it
+      # is the exact input needed to replay the failure locally.
+      - name: Upload crash reproducers
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-crashes
+          path: crash-*
+          if-no-files-found: ignore
+          retention-days: 7
+
   codeql:
     name: CodeQL analyze (python)
-    needs: zizmor
+    needs: [zizmor, actionlint, poutine]
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
       security-events: write   # upload the CodeQL results to Code Scanning
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -41,6 +41,11 @@ jobs:
       actions: read            # read the workflow run for Plumber status
       id-token: write          # OIDC to publish the score to score.getplumber.io
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ jobs:
       id-token: write       # mint the OIDC token used to sign the provenance
       attestations: write   # record the SLSA build provenance for the artifacts
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -57,15 +62,40 @@ jobs:
       # `gh attestation verify <artifact> --repo stephrobert/dsoxlab` or
       # slsa-verifier. Complements the PEP 740 attestations PyPI records.
       - name: Attest build provenance
+        id: attest
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: 'dist/*'
+
+      # The attestation above is recorded on GitHub's attestation API, which is
+      # what `gh attestation verify` reads. It is NOT what OpenSSF Scorecard's
+      # Signed-Releases control looks at: that check wants a `*.intoto.jsonl`
+      # file attached as a release asset — a distinct artifact. Copy the bundle
+      # out under the expected name so `github_release` can attach it.
+      #
+      # The bundle path goes through `env:` rather than being interpolated into
+      # the script body, so no step output is ever expanded into shell code.
+      - name: Stage the provenance bundle as a release asset
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          cp "$BUNDLE_PATH" provenance.intoto.jsonl
+          echo "Provenance bundle staged ($(wc -c < provenance.intoto.jsonl) bytes)"
 
       - name: Upload distribution artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload provenance artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: provenance
+          path: provenance.intoto.jsonl
           if-no-files-found: error
           retention-days: 1
 
@@ -80,6 +110,11 @@ jobs:
     permissions:
       id-token: write   # OIDC token for Trusted Publishing — the only scope needed
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Download distribution artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -102,6 +137,11 @@ jobs:
     permissions:
       contents: write   # create the Release and upload the built artifacts
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -112,6 +152,12 @@ jobs:
         with:
           name: dist
           path: dist/
+
+      - name: Download provenance artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: provenance
+          path: .
 
       # Extract the CHANGELOG section for this tag. The tag is passed through an
       # env var (never interpolated into the script body) to avoid injection.
@@ -146,4 +192,4 @@ jobs:
             --repo "$REPO" \
             --title "$TAG" \
             --notes-file release-notes.md \
-            dist/*
+            dist/* provenance.intoto.jsonl

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,6 +30,11 @@ jobs:
       security-events: write   # upload SARIF to Code Scanning
       id-token: write          # publish results to the OpenSSF Scorecard API
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,9 @@ todo/
 # Terraform validate artefacts dans les templates packagés (non committables)
 src/dsoxlab/templates/terraform/*/.terraform/
 src/dsoxlab/templates/terraform/*/.terraform.lock.hcl
+
+# Fuzzing — reproducteurs écrits par libFuzzer à la racine en cas de crash.
+# Les graines, elles, sont versionnées sous fuzz/corpus/.
+crash-*
+leak-*
+timeout-*

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -510,19 +510,6 @@ gitlab:
       # Supports wildcards (e.g., https://internal-artifacts.example.com/*).
       trustedUrls: []
       # - https://internal-artifacts.example.com/*
-    # ── Pipeline must not leak secrets in configuration ─────────────
-    #
-    # Runs gitleaks against the resolved pipeline YAML to detect hardcoded
-    # secrets (API tokens, private keys, passwords) committed directly in
-    # the CI configuration. Requires gitleaks to be installed and available
-    # on PATH (or configured via gitleaksPath).
-    pipelineMustNotLeakSecretsInConfig:
-      # Set to true to enable this control (requires gitleaks)
-      enabled: false
-      # Path to the gitleaks binary. Defaults to "gitleaks" (PATH lookup).
-      # gitleaksPath: /usr/local/bin/gitleaks
-      # Optional path to a custom gitleaks configuration file.
-      # gitleaksConfigPath: /path/to/gitleaks.toml
     # ── Pipeline must not use Docker-in-Docker ──────────────────────
     #
     # Detects CI/CD jobs that use Docker-in-Docker (dind) services.
@@ -548,22 +535,6 @@ gitlab:
 # ============================================================================
 github:
   controls:
-    # ── Pipeline must not leak secrets in configuration ─────────────
-    #
-    # Runs gitleaks against every workflow file under
-    # .github/workflows/ to detect hardcoded secrets (API tokens,
-    # private keys, passwords) committed directly into the YAML.
-    # Requires gitleaks to be installed and available on PATH (or
-    # configured via gitleaksPath). Disabled by default because
-    # gitleaks is an external dependency.
-    pipelineMustNotLeakSecretsInConfig:
-      # Set to true to enable this control (requires gitleaks)
-      enabled: false
-      # Path to the gitleaks binary. Defaults to "gitleaks" (PATH lookup).
-      # gitleaksPath: /usr/local/bin/gitleaks
-      # Optional path to a custom gitleaks configuration file.
-      # gitleaksConfigPath: /path/to/gitleaks.toml
-
     # ===========================================
     # Actions must be pinned by commit SHA
     # ===========================================
@@ -610,6 +581,7 @@ github:
       trustedGithubActions:
         - getplumber/plumber # Plumber's own GitHub Action
         - zizmorcore/zizmor-action # GitHub Actions static analysis (zizmor)
+        - step-security/harden-runner # runner egress monitoring, first step of every job
         - astral-sh/setup-uv # uv installer (Astral, maintainer of ruff/uv)
         - pypa/gh-action-pypi-publish # official PyPA publisher (Trusted Publishing)
         - ossf/scorecard-action

--- a/.poutine.yml
+++ b/.poutine.yml
@@ -1,0 +1,24 @@
+# Poutine configuration — CI/CD exploitation-chain scanner (boostsecurity.io).
+#
+# Poutine's `github_action_from_unverified_creator_used` rule flags every action
+# whose author is not a Marketplace "verified creator". That signal is useful and
+# stays ON for every other action: it is what catches a typo-squatted or freshly
+# re-registered action slipping into the pipeline.
+#
+# The three entries below are acknowledged one purl at a time — never by turning
+# the rule off globally. Each is an action this pipeline vets by hand, pins to a
+# full commit SHA, and already lists in `.plumber.yaml` under
+# `trustedGithubActions` (the two allowlists are kept in sync on purpose).
+skip:
+  - rule: github_action_from_unverified_creator_used
+    purl:
+      # Astral's own uv installer. Astral maintains uv and ruff, both of which
+      # this project already depends on: the action adds no new trust root.
+      - pkg:githubactions/astral-sh/setup-uv
+      # Official action of the plumber scanner (getplumber.io) used by
+      # .github/workflows/plumber.yml. It verifies the SLSA build provenance of
+      # the binary it downloads before running it (`verify-attestation: true`).
+      - pkg:githubactions/getplumber/plumber
+      # Official action of the zizmor workflow analyzer, published by the
+      # zizmor project itself (zizmorcore). Runs in ci.yml as the security gate.
+      - pkg:githubactions/zizmorcore/zizmor-action

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,54 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.11] - 2026-07-17
+
+### Corrigé
+
+- **Un `lab.yaml` ou un `meta.yml` malformé pouvait faire planter la CLI au lieu
+  d'être ignoré.** `discovery/scanner.py` rattrape `(KeyError, ValueError,
+  yaml.YAMLError)` et ignore le lab fautif avec un warning — mais les parsers
+  pouvaient lever hors de ce contrat, et l'exception remontait alors en
+  traceback brut sur une commande sans rapport (`list-labs`, `progress`…).
+  Comme un `lab.yaml` provient d'un *dépôt fournisseur de labs*, c'est l'entrée
+  non fiable du moteur. Cinq cas, tous trouvés par les nouveaux harnais de
+  fuzzing :
+  - un `lab.yaml` **vide** (ou réduit à des commentaires) → `AttributeError`,
+    `yaml.safe_load` rendant `None` ;
+  - un document dont la **racine est une liste ou un scalaire**, dans les deux
+    fichiers ;
+  - **`runtime: vm`** écrit à la place du bloc `runtime:`, et
+    `runtime.targets: true` → `AttributeError` / `TypeError` ;
+  - **`infra.hosts:` écrit en mapping** au lieu d'une liste → `TypeError` sur
+    `h["name"]`, l'itération portant sur les clés ;
+  - une **clé présente mais vide** comme `vcpu:` ou `bloc:` → `int(None)` lève
+    `TypeError`, `.get("vcpu", 1)` rendant `None` et non le défaut quand la clé
+    existe.
+
+  Chacun de ces cas lève désormais un `ValueError` portant le chemin du fichier
+  et le champ fautif : le lab est ignoré et le reste du catalogue se charge. Un
+  `ip:` vide ne donne plus non plus la chaîne littérale « None ».
+
+### Ajouté
+
+- **Des harnais de fuzzing sur le contrat YAML non fiable** (`fuzz/`), rejoués
+  en régression courte dans la CI. Ils vérifient le *contrat* — toute exception
+  hors de `(KeyError, ValueError, yaml.YAMLError)` fait échouer le run — plutôt
+  que de simplement exécuter les parsers. Livrés avec un corpus de graines et un
+  dictionnaire libFuzzer des mots-clés du contrat ; `uv sync --group fuzz`
+  installe atheris (tenu hors du groupe `dev`).
+- **`actionlint` et `poutine` en gates CI**, aux côtés du job zizmor existant,
+  tous deux installés depuis un binaire de release dont le SHA-256 est vérifié
+  contre les checksums publiés. `poutine --fail-on-violation` en fait une gate,
+  pas un rapport. Les jobs lourds attendent désormais les trois scanners.
+- **`step-security/harden-runner`** en premier step de chaque job
+  (`egress-policy: audit`), et un `.poutine.yml` qui acquitte trois actions
+  vérifiées à la main par leur purl, sans désactiver la règle.
+- **La provenance de build attachée à la Release GitHub** sous le nom
+  `provenance.intoto.jsonl`. L'attestation existante est enregistrée sur l'API
+  d'attestation de GitHub, qui est un artefact *distinct* de l'asset de release
+  qu'attend le contrôle Signed-Releases d'OpenSSF Scorecard.
+
 ## [0.1.10] - 2026-07-16
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11] - 2026-07-17
+
+### Fixed
+
+- **A malformed `lab.yaml` or `meta.yml` could crash the CLI instead of being
+  skipped.** `discovery/scanner.py` catches `(KeyError, ValueError,
+  yaml.YAMLError)` and ignores the offending lab with a warning — but the
+  parsers could raise outside that contract, and the exception then surfaced as
+  a raw traceback on an unrelated command (`list-labs`, `progress`…). Since a
+  `lab.yaml` comes from a *lab-provider repository*, this is the engine's
+  untrusted input. Five cases, all found by the new fuzz harnesses:
+  - an **empty** `lab.yaml` (or one holding only comments) → `AttributeError`,
+    because `yaml.safe_load` returns `None`;
+  - a document whose **root is a list or a scalar**, in either file;
+  - **`runtime: vm`** written instead of the `runtime:` block, and
+    `runtime.targets: true` → `AttributeError` / `TypeError`;
+  - **`infra.hosts:` written as a mapping** instead of a list → `TypeError` on
+    `h["name"]`, the iteration walking the keys;
+  - a **present-but-empty key** such as `vcpu:` or `bloc:` → `int(None)` raises
+    `TypeError`, because `.get("vcpu", 1)` returns `None` rather than the
+    default when the key exists.
+
+  Every one of these now raises `ValueError` with the file path and the
+  offending field, so the lab is skipped and the rest of the catalogue still
+  loads. An empty `ip:` no longer yields the literal string `"None"` either.
+
+### Added
+
+- **Fuzz harnesses over the untrusted-YAML contract** (`fuzz/`), run as a short
+  regression in CI. They assert the *contract* — any exception outside
+  `(KeyError, ValueError, yaml.YAMLError)` fails the run — rather than merely
+  executing the parsers. Ships a seed corpus and a libFuzzer dictionary of the
+  contract's keywords; `uv sync --group fuzz` installs atheris (kept out of the
+  `dev` group).
+- **`actionlint` and `poutine` as CI gates**, alongside the existing zizmor job,
+  both installed from a release binary whose SHA-256 is verified against the
+  published checksums. `poutine --fail-on-violation` makes it a gate, not a
+  report. The heavier jobs now wait on all three scanners.
+- **`step-security/harden-runner`** as the first step of every job
+  (`egress-policy: audit`), and `.poutine.yml` acknowledging three hand-vetted
+  actions per purl rather than disabling the rule.
+- **Build provenance attached to the GitHub Release** as
+  `provenance.intoto.jsonl`. The existing attestation is recorded on GitHub's
+  attestation API, which is a *different* artifact from the release asset that
+  OpenSSF Scorecard's Signed-Releases control looks for.
+
 ## [0.1.10] - 2026-07-16
 
 ### Fixed

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -15,6 +15,9 @@ commit sont rédigés en anglais pour que tout le monde puisse participer.
 - [Règles fondamentales](#règles-fondamentales)
 - [Mise en place](#mise-en-place)
 - [Contrôles qualité](#contrôles-qualité)
+  - [Scanners de workflow](#scanners-de-workflow)
+  - [Fuzzer le contrat non fiable](#fuzzer-le-contrat-non-fiable)
+- [Hooks pre-commit](#hooks-pre-commit)
 - [Internationalisation (i18n)](#internationalisation-i18n)
 - [Conventions de commit](#conventions-de-commit)
 - [Pull requests](#pull-requests)
@@ -53,7 +56,8 @@ Testez sur un vrai dépôt de labs pour valider la neutralité (au moins deux,
 par exemple `linux-training` et `ansible-training`) :
 
 ```bash
-cd ~/Projets/linux-training && dsoxlab list-labs
+cd ~/Projets/linux-dsoxlab-training && dsoxlab list-labs
+cd ~/Projets/ansible-training && dsoxlab list-labs
 ```
 
 ## Contrôles qualité
@@ -61,10 +65,71 @@ cd ~/Projets/linux-training && dsoxlab list-labs
 À lancer avant d'ouvrir une pull request. La CI exécute les mêmes contrôles.
 
 ```bash
-uv run ruff check src/dsoxlab tests   # lint + sécurité (règles flake8-bandit S)
-uv run mypy src/dsoxlab               # typage (strict)
-uv run pytest                         # tests
+uv run ruff check src/dsoxlab tests fuzz   # lint + sécurité (règles flake8-bandit S)
+uv run mypy src/dsoxlab                    # typage (strict)
+uv run pytest                              # tests
 ```
+
+### Scanners de workflow
+
+Si vous touchez à `.github/workflows/`, quatre scanners bloquent la CI et
+doivent rester à **zéro finding**. Ils analysent le YAML des workflows, donc ils
+tournent sans aucune dépendance du projet :
+
+```bash
+actionlint                                    # syntaxe, scopes de permission invalides, shellcheck
+zizmor --offline .github/workflows/           # failles de workflow
+poutine analyze_local . --fail-on-violation   # chaînes d'exploitation CI/CD
+plumber analyze                               # graphe de confiance + réglages du dépôt
+```
+
+Les règles qu'ils imposent, à connaître avant d'écrire une ligne de YAML :
+
+- **Chaque action est épinglée par un SHA de commit de 40 caractères**, suivi
+  d'un commentaire `# vX.Y.Z`. Jamais `@v4`, jamais `@main` : un tag est
+  mutable, donc c'est un trou de supply chain.
+- **`step-security/harden-runner` est le premier step de chaque job.**
+- `permissions: {}` au niveau workflow, permissions minimales par job.
+- `actions/checkout` avec `persist-credentials: false`, un runner figé
+  (`ubuntu-24.04`, pas `ubuntu-latest`), un `timeout-minutes` et un `name:`.
+- **Ne jamais interpoler `${{ … }}` dans un bloc `run:`.** Passez la valeur par
+  un bloc `env:`, sinon zizmor signale une injection de template.
+- Une nouvelle action tierce doit être ajoutée à `trustedGithubActions` dans
+  `.plumber.yaml`. Si son créateur n'est pas vérifié sur le Marketplace,
+  acquittez-la dans `.poutine.yml` **par son purl exact** — jamais en
+  désactivant la règle, ce qui la rendrait aveugle à toutes les autres actions.
+
+Un piège mérite sa propre ligne : **les status checks requis portent les noms de
+jobs exacts**. Renommer un job fait taire silencieusement l'ancien check, qui
+n'est alors plus jamais satisfait, et les pull requests restent bloquées. Ne
+renommez qu'en mettant à jour la protection de branche dans le même geste.
+
+### Fuzzer le contrat non fiable
+
+`lab.yaml` et `meta.yml` viennent des dépôts fournisseurs de labs : ce sont les
+entrées non fiables du moteur. `discovery/scanner.py` rattrape
+`(KeyError, ValueError, yaml.YAMLError)` et ignore le lab fautif avec un
+warning — **toute exception hors de ce tuple échappe au filet et fait planter la
+CLI** sur une commande sans rapport.
+
+Les harnais de `fuzz/` vérifient ce contrat, et un run court amorcé bloque la
+CI. Lancez une campagne plus longue en local dès que vous touchez à un parser :
+
+```bash
+uv sync --group fuzz
+mkdir -p /tmp/fuzz-lab
+uv run --group fuzz python fuzz/fuzz_lab_yaml.py \
+    /tmp/fuzz-lab fuzz/corpus/lab_yaml/ \
+    -dict=fuzz/dict/yaml_contract.dict -atheris_runs=100000
+```
+
+Passez le répertoire de travail **en premier** : libFuzzer écrit ses trouvailles
+dans le premier dossier de corpus, et `fuzz/corpus/` est un jeu de graines
+choisi à la main. Un crash écrit un reproducteur `crash-*` que vous rejouez en
+le passant comme unique argument. Si vous ajoutez un champ au contrat, ajoutez
+une graine : des octets aléatoires ne reconstruisent jamais un mot-clé par
+hasard, donc le corpus et `fuzz/dict/yaml_contract.dict` sont ce qui permet au
+fuzzer d'atteindre votre code.
 
 ## Hooks pre-commit
 
@@ -114,7 +179,7 @@ Nous utilisons les Conventional Commits avec un scope de module :
 <type>(<module>): <description courte>
 ```
 
-Types : `feat`, `fix`, `docs`, `refactor`, `chore`, `test`. Exemples :
+Types : `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`. Exemples :
 
 - `feat(discovery): support multi-repo via ~/.config/dsoxlab/config.yaml`
 - `fix(runtimes/kvm): make snapshot revert idempotent when snapshot is absent`
@@ -125,9 +190,18 @@ consultez `git log --oneline -5` pour coller au style.
 
 ## Pull requests
 
-- Partez de `main`, gardez un périmètre restreint, remplissez le gabarit de PR.
-- Assurez-vous que lint, typage et tests sont verts.
-- Mettez à jour la documentation et `CHANGELOG.md` quand le comportement change.
+- Partez d'un `main` à jour, gardez un périmètre restreint, remplissez le
+  gabarit de PR. Supprimez la branche une fois mergée.
+- Assurez-vous que lint, typage et tests sont verts — plus les scanners de
+  workflow si vous avez touché à `.github/workflows/`.
+- Quand le comportement change, mettez à jour **les deux** fichiers
+  `CHANGELOG.md` et `CHANGELOG.fr.md`. Le projet est bilingue : une entrée en
+  anglais seul est une entrée incomplète.
+- Quand le comportement change, bumpez aussi la version dans `pyproject.toml` et
+  régénérez `uv.lock` (`uv lock`). Il n'y a rien à bumper dans
+  `src/dsoxlab/__init__.py` : `__version__` est lu depuis les métadonnées du
+  paquet installé, précisément pour qu'il ne puisse pas diverger de
+  `pyproject.toml`.
 - Si vous ajoutez une commande ou une option, confirmez la checklist i18n
   ci-dessus.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,9 @@ in English so everyone can take part.
 - [Ground rules](#ground-rules)
 - [Development setup](#development-setup)
 - [Quality gates](#quality-gates)
+  - [Workflow scanners](#workflow-scanners)
+  - [Fuzzing the untrusted contract](#fuzzing-the-untrusted-contract)
+- [Pre-commit hooks](#pre-commit-hooks)
 - [Internationalization (i18n)](#internationalization-i18n)
 - [Commit conventions](#commit-conventions)
 - [Pull requests](#pull-requests)
@@ -48,11 +51,13 @@ uv sync                      # create the venv and install dev dependencies
 uv tool install --editable . # optional: expose `dsoxlab` on your PATH
 ```
 
-Test against a real lab repository to validate the agnostic design (at least
-two, e.g. `linux-training` and `ansible-training`):
+Test against a real lab repository to validate the agnostic design. Use **at
+least two**, from different domains — that is the only way to prove the engine
+carries no domain-specific logic:
 
 ```bash
-cd ~/Projets/linux-training && dsoxlab list-labs
+cd ~/Projets/linux-dsoxlab-training && dsoxlab list-labs
+cd ~/Projets/ansible-training && dsoxlab list-labs
 ```
 
 ## Quality gates
@@ -60,10 +65,71 @@ cd ~/Projets/linux-training && dsoxlab list-labs
 Run these before opening a pull request. CI runs the same checks.
 
 ```bash
-uv run ruff check src/dsoxlab   # lint + security (flake8-bandit S rules)
-uv run mypy src/dsoxlab         # type-check (strict)
-uv run pytest                   # tests
+uv run ruff check src/dsoxlab tests fuzz   # lint + security (flake8-bandit S rules)
+uv run mypy src/dsoxlab                    # type-check (strict)
+uv run pytest                              # tests
 ```
+
+### Workflow scanners
+
+If you touch anything under `.github/workflows/`, four scanners gate the build
+and must stay at **zero finding**. They analyse the workflow YAML, so they run
+without any project dependency:
+
+```bash
+actionlint                                    # syntax, invalid permission scopes, shellcheck
+zizmor --offline .github/workflows/           # workflow vulnerabilities
+poutine analyze_local . --fail-on-violation   # CI/CD exploitation chains
+plumber analyze                               # trust graph + repository settings
+```
+
+The rules they enforce, and which are worth knowing before you write a line of
+YAML:
+
+- **Every action is pinned to a full 40-character commit SHA**, followed by a
+  `# vX.Y.Z` comment. Never `@v4`, never `@main`: a tag is mutable, so it is a
+  supply-chain hole.
+- **`step-security/harden-runner` is the first step of every job.**
+- `permissions: {}` at workflow level, minimal permissions per job.
+- `actions/checkout` with `persist-credentials: false`, a pinned runner
+  (`ubuntu-24.04`, not `ubuntu-latest`), a `timeout-minutes` and a `name:`.
+- **Never interpolate `${{ … }}` into a `run:` block.** Pass the value through
+  an `env:` block instead, or zizmor flags a template injection.
+- A new third-party action must be added to `trustedGithubActions` in
+  `.plumber.yaml`. If its creator is not Marketplace-verified, acknowledge it in
+  `.poutine.yml` **by its exact purl** — never by disabling the rule, which
+  would blind it to every other action.
+
+One trap deserves its own line: **the required status checks match job names
+exactly**. Renaming a job silently stops the old check from ever being
+satisfied, and pull requests hang forever. Rename only if you update the branch
+protection in the same move.
+
+### Fuzzing the untrusted contract
+
+`lab.yaml` and `meta.yml` come from lab-provider repositories: they are the
+engine's untrusted input. `discovery/scanner.py` catches
+`(KeyError, ValueError, yaml.YAMLError)` and skips the offending lab with a
+warning — **anything raised outside that tuple escapes the handler and crashes
+the CLI** on an unrelated command.
+
+The harnesses in `fuzz/` assert that contract, and a short seeded run gates CI.
+Run a longer campaign locally when you touch a parser:
+
+```bash
+uv sync --group fuzz
+mkdir -p /tmp/fuzz-lab
+uv run --group fuzz python fuzz/fuzz_lab_yaml.py \
+    /tmp/fuzz-lab fuzz/corpus/lab_yaml/ \
+    -dict=fuzz/dict/yaml_contract.dict -atheris_runs=100000
+```
+
+Pass the scratch directory **first**: libFuzzer writes what it finds into the
+first corpus directory, and `fuzz/corpus/` is a curated seed set. A crash writes
+a `crash-*` reproducer you can replay by passing it as the only argument. If you
+add a field to the contract, add a seed for it — random bytes never rebuild a
+keyword by chance, so the corpus and `fuzz/dict/yaml_contract.dict` are what
+make the fuzzer reach your code.
 
 ## Pre-commit hooks
 
@@ -113,7 +179,7 @@ We use Conventional Commits with a module scope:
 <type>(<module>): <short description>
 ```
 
-Types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`. Examples:
+Types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`. Examples:
 
 - `feat(discovery): support multi-repo via ~/.config/dsoxlab/config.yaml`
 - `fix(runtimes/kvm): make snapshot revert idempotent when snapshot is absent`
@@ -124,9 +190,16 @@ Keep commits focused and the history readable. Before a grouped commit, check
 
 ## Pull requests
 
-- Branch from `main`, keep the scope tight, and fill in the PR template.
-- Ensure lint, type-check and tests are green.
-- Update the documentation and `CHANGELOG.md` when behavior changes.
+- Branch from an up-to-date `main`, keep the scope tight, and fill in the PR
+  template. Delete the branch once merged.
+- Ensure lint, type-check and tests are green — plus the workflow scanners if
+  you touched `.github/workflows/`.
+- When behavior changes, update **both** `CHANGELOG.md` and `CHANGELOG.fr.md`.
+  The project is bilingual: an English-only entry is an incomplete entry.
+- When behavior changes, also bump the version in `pyproject.toml` and refresh
+  `uv.lock` (`uv lock`). There is nothing to bump in `src/dsoxlab/__init__.py`:
+  `__version__` is read from the installed package metadata, precisely so it
+  cannot drift from `pyproject.toml`.
 - If you add a command or option, confirm the i18n checklist above is done.
 
 ## Reporting bugs and requesting features

--- a/fuzz/corpus/lab_yaml/shell-minimal.yaml
+++ b/fuzz/corpus/lab_yaml/shell-minimal.yaml
@@ -1,0 +1,10 @@
+id: l1-log-parsing
+title: Parse an access log
+level: beginner
+skills: [awk, cut]
+distros: [any]
+doc_url: https://blog.stephane-robert.info/docs/linux/logs/
+runtime:
+  type: shell
+  workdir: challenge/work
+  fixtures: [acces.log]

--- a/fuzz/corpus/lab_yaml/vm-multi-target.yaml
+++ b/fuzz/corpus/lab_yaml/vm-multi-target.yaml
@@ -1,0 +1,31 @@
+id: l2-swap-management
+title: Manage swap space
+level: intermediate
+lab_type: lab
+section: linux
+description: Create, activate and persist a swap file.
+skills: [swap, fstab, systemd]
+distros: [alma10, ubuntu24]
+doc_url: https://blog.stephane-robert.info/docs/linux/swap/
+track: [rhcsa]
+difficulty: intermediate
+estimated_time: "30m"
+certification_tags: [rhcsa, lfcs]
+runtime:
+  type: vm
+  targets:
+    - name: rhel
+      host: alma-rhcsa-1.lab
+      label_en: "AlmaLinux 10"
+      label_fr: "AlmaLinux 10"
+      roles:
+        server: alma-rhcsa-2.lab
+    - name: debian
+      host: ubuntu-lfcs-1.lab
+      label_en: "Ubuntu 24.04"
+  default: rhel
+  snapshot_required: false
+validation:
+  functional: true
+  security: false
+  persistence_after_reboot: true

--- a/fuzz/corpus/meta_yml/full-infra.yml
+++ b/fuzz/corpus/meta_yml/full-infra.yml
@@ -1,0 +1,36 @@
+repo:
+  id: linux-dsoxlab-training
+  category: linux
+  title: Linux hands-on labs
+  blog_url: https://blog.stephane-robert.info
+  description: |
+    Labs Linux pour la préparation RHCSA et LFCS.
+
+infra:
+  provider: kvm
+  network: lab-linux
+  cidr: 10.10.10.0/24
+  hosts:
+    - name: alma-rhcsa-1.lab
+      distro: alma10
+      role: target
+      ram_mb: 2048
+      vcpu: 2
+      disk_gb: 20
+      extra_disk_gb: 5
+    - name: ubuntu-lfcs-1.lab
+      distro: ubuntu24
+  providers:
+    outscale:
+      network: lab-linux-osc
+
+sections:
+  - id: l1
+    title: Fondamentaux (l1)
+    description: Prise en main du système
+    labs:
+      - linux/l1/l1-log-parsing
+  - id: l2
+    title: Stockage (l2)
+    labs:
+      - linux/l2/l2-swap-management

--- a/fuzz/dict/yaml_contract.dict
+++ b/fuzz/dict/yaml_contract.dict
@@ -1,0 +1,99 @@
+# libFuzzer dictionary for the dsoxlab YAML contract.
+#
+# Random mutations almost never rebuild a contract keyword by chance, so the
+# fuzzer stalls on the first validation gate (`repo.id`/`repo.category` are
+# required, `id`/`title`/`level` are required). Feeding it the real tokens lets
+# it assemble documents that reach the field logic instead of bouncing off
+# safe_load. Use with:
+#     -dict=fuzz/dict/yaml_contract.dict
+#
+# Keys mirror the contract documented in CLAUDE.md. Keep in sync when the
+# contract gains a field.
+
+# ── YAML syntax ──
+# libFuzzer dictionaries only understand \xNN escapes, not \n / \t.
+colon_space=": "
+newline="\x0a"
+indent="  "
+dash="- "
+key_newline=":\x0a"
+nested_key="\x0a  "
+list_item="\x0a    - "
+null="null"
+true="true"
+false="false"
+empty_map="{}"
+empty_list="[]"
+anchor="&a "
+alias="*a"
+
+# ── meta.yml : racine ──
+repo="repo:"
+id="id:"
+category="category:"
+title="title:"
+blog_url="blog_url:"
+description="description:"
+
+# ── meta.yml : infra ──
+infra="infra:"
+provider="provider:"
+network="network:"
+cidr="cidr:"
+hosts="hosts:"
+name="name:"
+distro="distro:"
+role="role:"
+ram_mb="ram_mb:"
+vcpu="vcpu:"
+disk_gb="disk_gb:"
+extra_disk_gb="extra_disk_gb:"
+providers="providers:"
+kvm="kvm"
+incus="incus"
+outscale="outscale"
+
+# ── meta.yml : sections ──
+sections="sections:"
+labs="labs:"
+
+# ── lab.yaml ──
+level="level:"
+skills="skills:"
+distros="distros:"
+doc_url="doc_url:"
+lab_type="lab_type:"
+section="section:"
+track="track:"
+difficulty="difficulty:"
+estimated_time="estimated_time:"
+certification_tags="certification_tags:"
+bloc="bloc:"
+bloc_order="bloc_order:"
+
+# ── lab.yaml : runtime ──
+runtime="runtime:"
+type="type:"
+targets="targets:"
+host="host:"
+label_en="label_en:"
+label_fr="label_fr:"
+roles="roles:"
+default="default:"
+snapshot_required="snapshot_required:"
+workdir="workdir:"
+fixtures="fixtures:"
+topology="topology:"
+vm="vm"
+shell="shell"
+
+# ── lab.yaml : validation ──
+validation="validation:"
+functional="functional:"
+security="security:"
+persistence="persistence_after_reboot:"
+
+# ── valeurs énumérées ──
+lab="lab"
+challenge="challenge"
+capstone="capstone"

--- a/fuzz/fuzz_lab_yaml.py
+++ b/fuzz/fuzz_lab_yaml.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fuzz harness for the lab.yaml parser.
+
+Why this file exists
+--------------------
+`dsoxlab` reads `lab.yaml` files that come from *lab-provider repositories*, not
+from this codebase. That YAML is the engine's main untrusted input: a third
+party writes it, and `dsoxlab list-labs` parses every one of them.
+
+`discovery/scanner.py` states the parser's contract explicitly:
+
+    except (KeyError, ValueError, yaml.YAMLError) as exc:
+        logger.warning("lab.yaml ignoré (%s) : %s", yaml_path, exc)
+
+A malformed lab is meant to be *skipped*, never to take the CLI down. So any
+exception outside that tuple is a real defect: it escapes the scanner's handler
+and surfaces to the user as a traceback on an unrelated command.
+
+That is exactly what this harness looks for — it asserts the contract, it does
+not merely execute the parser.
+
+Run it — scratch dir FIRST, seed corpus second:
+    mkdir -p /tmp/fuzz-lab
+    uv run --group fuzz python fuzz/fuzz_lab_yaml.py \
+        /tmp/fuzz-lab fuzz/corpus/lab_yaml/ -atheris_runs=50000
+
+libFuzzer writes every input it finds interesting into the *first* corpus
+directory given. Passing the scratch dir first keeps `fuzz/corpus/` a
+hand-curated set of seeds instead of filling it with thousands of mutations.
+
+Two details that decide whether this harness finds anything at all:
+
+* Instrumentation is scoped to `include=["dsoxlab"]`. Instrumenting everything
+  would also instrument PyYAML's compiled C loader (`_yaml`) and segfault the
+  harness; instrumenting nothing makes the fuzzer blind, and libFuzzer then
+  reports "no interesting inputs were found".
+* The seed corpus matters more than the run count here. Random bytes are almost
+  never valid YAML, so without seeds the fuzzer never reaches the field logic
+  past `safe_load`. The corpus holds real lab.yaml documents to mutate.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import atheris
+import yaml
+
+# Only dsoxlab's own pure-Python modules are instrumented; PyYAML is imported
+# normally so its C extension is left alone.
+with atheris.instrument_imports(include=["dsoxlab"]):
+    from dsoxlab.models.lab import LabDefinition
+
+# The parser's documented contract: these mean "invalid lab, skip it" and are
+# caught by discovery/scanner.py. Anything else is a bug worth reporting.
+CONTRACT_EXCEPTIONS = (KeyError, ValueError, yaml.YAMLError)
+
+_TMPDIR = Path(tempfile.mkdtemp(prefix="dsoxlab-fuzz-"))
+_LAB_YAML = _TMPDIR / "lab.yaml"
+
+
+def test_one_input(data: bytes) -> None:
+    """Feed one fuzzer-generated document to LabDefinition.from_yaml."""
+    # Decode straight from the raw bytes instead of going through
+    # atheris.FuzzedDataProvider. The provider *reinterprets* the input, so a
+    # seed file would reach the parser as unrelated unicode rather than as the
+    # YAML it contains — the corpus would be inert and coverage would flatline.
+    try:
+        document = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return  # not YAML's problem: the file layer would reject it first
+
+    try:
+        _LAB_YAML.write_text(document, encoding="utf-8")
+    except (UnicodeEncodeError, OSError):
+        return  # not about the parser — skip this input
+
+    try:
+        LabDefinition.from_yaml(_LAB_YAML)
+    except CONTRACT_EXCEPTIONS:
+        return  # contract honoured: malformed input rejected cleanly
+    except RecursionError:
+        # Deeply nested YAML. Left in scope on purpose: scanner.py does not
+        # catch it either, so it would crash `dsoxlab list-labs` for real.
+        raise
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_meta_yaml.py
+++ b/fuzz/fuzz_meta_yaml.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Fuzz harness for the meta.yml parser.
+
+`meta.yml` is the second untrusted document a lab-provider repository hands to
+`dsoxlab`: it drives the catalogue topology (sections, ordering) and — for
+`runtime: vm` labs — the infrastructure description (hosts, network, provider)
+that feeds Terraform.
+
+`RepoMetadata.from_yaml` documents `ValueError` as its rejection signal for a
+malformed contract (missing `repo.id` / `repo.category`), and the CLI composes a
+readable error from it. Provider ambiguity deliberately does NOT raise here: it
+is deferred to `infra.require_provider()`. Anything raised outside the contract
+below reaches the user as a traceback.
+
+Run it — scratch dir FIRST, seed corpus second (see fuzz_lab_yaml.py):
+    mkdir -p /tmp/fuzz-meta
+    uv run --group fuzz python fuzz/fuzz_meta_yaml.py \
+        /tmp/fuzz-meta fuzz/corpus/meta_yml/ -atheris_runs=50000
+
+See fuzz/fuzz_lab_yaml.py for why instrumentation is scoped to dsoxlab only and
+why the seed corpus is what makes this harness effective.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import atheris
+import yaml
+
+with atheris.instrument_imports(include=["dsoxlab"]):
+    from dsoxlab.models.repo import RepoMetadata
+
+CONTRACT_EXCEPTIONS = (KeyError, ValueError, yaml.YAMLError)
+
+_TMPDIR = Path(tempfile.mkdtemp(prefix="dsoxlab-fuzz-meta-"))
+_META_YML = _TMPDIR / "meta.yml"
+
+
+def test_one_input(data: bytes) -> None:
+    """Feed one fuzzer-generated document to RepoMetadata.from_yaml."""
+    # Raw decode, not FuzzedDataProvider — see fuzz_lab_yaml.py: the provider
+    # would reinterpret the seed files and make the corpus inert.
+    try:
+        document = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return
+
+    try:
+        _META_YML.write_text(document, encoding="utf-8")
+    except (UnicodeEncodeError, OSError):
+        return
+
+    try:
+        RepoMetadata.from_yaml(_META_YML)
+    except CONTRACT_EXCEPTIONS:
+        return
+    except RecursionError:
+        raise
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.10"
+version = "0.1.11"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -70,6 +70,12 @@ dev = [
     "ruff>=0.4",
     "types-PyYAML>=6",
     "pre-commit>=3.5",
+]
+# Kept out of `dev` on purpose: atheris builds a native libFuzzer extension and
+# is not needed to lint, type-check or test. Only the fuzzing job installs it.
+#   uv run --group fuzz python fuzz/fuzz_lab_yaml.py -atheris_runs=50000
+fuzz = [
+    "atheris>=2.3",
 ]
 
 [tool.ruff]

--- a/src/dsoxlab/models/_contract.py
+++ b/src/dsoxlab/models/_contract.py
@@ -1,0 +1,107 @@
+"""Garde-fous de typage du contrat déclaratif (lab.yaml, meta.yml).
+
+Ces fichiers viennent d'un **dépôt fournisseur de labs** : ce sont les entrées
+non fiables du moteur. ``discovery/scanner.py`` rattrape exactement
+``(KeyError, ValueError, yaml.YAMLError)`` et ignore le lab fautif avec un
+warning ; la CLI, elle, compose son message d'erreur depuis le ``ValueError``.
+
+Toute autre exception (``AttributeError`` sur un ``.get`` appliqué à autre
+chose qu'un mapping, ``TypeError`` sur ``int(None)`` ou ``list(42)``) échappe à
+ce filet et remonte en traceback brut sur une commande sans rapport.
+
+Ces helpers ramènent donc chaque champ mal typé dans le contrat. Ils sont
+partagés par ``models/lab.py`` et ``models/repo.py`` : mêmes pièges, mêmes
+garde-fous, une seule implémentation. Les cas couverts ont été trouvés par les
+harnais de ``fuzz/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def as_int(value: object, default: int, field_name: str, source: Path) -> int:
+    """Convertit un champ entier du contrat, défaut compris.
+
+    ``data.get("vcpu", 1)`` rend ``None`` — et non ``1`` — quand la clé est
+    présente mais vide (``vcpu:`` en blanc) : ``int(None)`` lèverait TypeError.
+    C'est le cas le plus courant du contrat.
+
+    ``bool`` est refusé explicitement : ``True`` est un ``int`` en Python, donc
+    ``vcpu: true`` donnerait silencieusement 1 plutôt qu'une erreur.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{source}: '{field_name}' doit être un entier (reçu un booléen : {value!r})."
+        )
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            raise ValueError(
+                f"{source}: '{field_name}' doit être un entier (reçu : {value!r})."
+            ) from None
+    raise ValueError(
+        f"{source}: '{field_name}' doit être un entier (reçu : {type(value).__name__})."
+    )
+
+
+def as_str_list(value: object, field_name: str, source: Path) -> list[str]:
+    """Valide qu'un champ est une liste, et la normalise en ``list[str]``.
+
+    ``list(42)`` lèverait TypeError. Une str est refusée aussi : ``list("abc")``
+    « réussirait » en donnant ``["a", "b", "c"]``, ce qui est pire qu'une erreur.
+    """
+    if value is None:
+        return []
+    if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
+        raise ValueError(
+            f"{source}: '{field_name}' doit être une liste "
+            f"(reçu : {type(value).__name__})."
+        )
+    return [str(item) for item in value]
+
+
+def as_mapping(value: object, field_name: str, source: Path, *, default_empty: bool = True) -> dict[str, Any]:
+    """Valide qu'un champ est un mapping.
+
+    Couvre ``runtime: vm`` écrit à la place du bloc ``runtime:``, la faute la
+    plus naturelle du contrat.
+    """
+    if value is None and default_empty:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"{source}: '{field_name}' doit être un mapping "
+            f"(reçu : {type(value).__name__})."
+        )
+    return value
+
+
+def as_mapping_list(value: object, field_name: str, source: Path) -> list[dict[str, Any]]:
+    """Valide qu'un champ est une liste de mappings.
+
+    ``hosts:`` écrit en mapping plutôt qu'en liste ferait porter l'itération sur
+    les clés (des str), et ``h["name"]`` lèverait TypeError.
+    """
+    if value is None:
+        return []
+    if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
+        raise ValueError(
+            f"{source}: '{field_name}' doit être une liste de mappings "
+            f"(reçu : {type(value).__name__})."
+        )
+    items: list[dict[str, Any]] = []
+    for idx, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"{source}: '{field_name}[{idx}]' doit être un mapping "
+                f"(reçu : {type(item).__name__})."
+            )
+        items.append(item)
+    return items

--- a/src/dsoxlab/models/lab.py
+++ b/src/dsoxlab/models/lab.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import yaml
 
+from ._contract import as_int, as_mapping, as_mapping_list, as_str_list
 from .runtime import RuntimeConfig, RuntimeType, Target
 
 
@@ -54,40 +55,47 @@ class LabDefinition:
         with lab_yaml.open(encoding="utf-8") as fh:
             data = yaml.safe_load(fh)
 
+        # Un fichier vide ou réduit à des commentaires donne None ; une racine
+        # en liste ou en scalaire donne un list/int. Sans ce garde-fou, l'accès
+        # suivant lèverait AttributeError, hors du contrat (KeyError,
+        # ValueError, YAMLError) que discovery/scanner.py rattrape : le lab
+        # ferait planter la CLI au lieu d'être ignoré avec un warning.
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"{lab_yaml}: le document doit être un mapping YAML "
+                f"(reçu : {type(data).__name__})."
+            )
+
         # Fusion des traductions
         if lang and lang != "en":
             lang_yaml = lab_yaml.parent / f"lab.{lang[:2].lower()}.yaml"
             if lang_yaml.exists():
                 try:
                     with lang_yaml.open(encoding="utf-8") as fh:
-                        overrides = yaml.safe_load(fh) or {}
+                        overrides = yaml.safe_load(fh)
+                    if not isinstance(overrides, dict):
+                        overrides = {}
                     for key in cls._TRANSLATABLE:
                         if key in overrides:
                             data[key] = overrides[key]
                 except yaml.YAMLError:
                     pass  # fichier de traduction invalide — on garde les valeurs de base
 
-        runtime_data = data.get("runtime", {}) or {}
+        # `runtime: vm` au lieu du bloc `runtime:\n  type: vm` est la faute la
+        # plus naturelle du contrat : elle donne une str, pas un mapping.
+        runtime_data = as_mapping(data.get("runtime"), "runtime", lab_yaml)
 
-        targets_raw = runtime_data.get("targets") or []
+        targets_raw = as_mapping_list(runtime_data.get("targets"), "runtime.targets", lab_yaml)
         targets: list[Target] = []
         for idx, t in enumerate(targets_raw):
-            if not isinstance(t, dict):
-                raise ValueError(
-                    f"{lab_yaml}: runtime.targets[{idx}] doit être un dict, "
-                    f"reçu : {type(t).__name__}"
-                )
             if "name" not in t or "host" not in t:
                 raise ValueError(
                     f"{lab_yaml}: runtime.targets[{idx}] doit contenir "
                     f"'name' et 'host'."
                 )
-            roles_raw = t.get("roles") or {}
-            if not isinstance(roles_raw, dict):
-                raise ValueError(
-                    f"{lab_yaml}: runtime.targets[{idx}].roles doit être un "
-                    f"mapping role→fqdn, reçu : {type(roles_raw).__name__}"
-                )
+            roles_raw = as_mapping(
+                t.get("roles"), f"runtime.targets[{idx}].roles", lab_yaml
+            )
             targets.append(Target(
                 name=str(t["name"]),
                 host=str(t["host"]),
@@ -102,11 +110,11 @@ class LabDefinition:
             default=str(runtime_data.get("default", "")),
             snapshot_required=bool(runtime_data.get("snapshot_required", False)),
             workdir=runtime_data.get("workdir", "challenge/work"),
-            fixtures=list(runtime_data.get("fixtures") or []),
+            fixtures=as_str_list(runtime_data.get("fixtures"), "runtime.fixtures", lab_yaml),
             topology=runtime_data.get("topology", "local"),
         )
 
-        validation_data = data.get("validation", {})
+        validation_data = as_mapping(data.get("validation"), "validation", lab_yaml)
         validation = ValidationConfig(
             functional=validation_data.get("functional", True),
             security=validation_data.get("security", False),
@@ -117,19 +125,21 @@ class LabDefinition:
             id=data["id"],
             title=data["title"],
             level=data["level"],
-            skills=data.get("skills", []),
+            skills=as_str_list(data.get("skills"), "skills", lab_yaml),
             runtime=runtime,
-            distros=data.get("distros", []),
+            distros=as_str_list(data.get("distros"), "distros", lab_yaml),
             doc_url=data.get("doc_url", ""),
             validation=validation,
             path=lab_yaml.parent,
             section=data.get("section", "linux"),
             description=data.get("description", ""),
-            track=data.get("track", []),
+            track=as_str_list(data.get("track"), "track", lab_yaml),
             difficulty=data.get("difficulty", "beginner"),
             estimated_time=data.get("estimated_time", "30m"),
-            certification_tags=data.get("certification_tags", []),
+            certification_tags=as_str_list(
+                data.get("certification_tags"), "certification_tags", lab_yaml
+            ),
             lab_type=data.get("lab_type", "lab"),
-            bloc=int(data.get("bloc", 0)),
-            bloc_order=int(data.get("bloc_order", 0)),
+            bloc=as_int(data.get("bloc"), 0, "bloc", lab_yaml),
+            bloc_order=as_int(data.get("bloc_order"), 0, "bloc_order", lab_yaml),
         )

--- a/src/dsoxlab/models/repo.py
+++ b/src/dsoxlab/models/repo.py
@@ -38,6 +38,31 @@ from typing import Any
 
 import yaml
 
+from ._contract import as_int, as_mapping, as_mapping_list, as_str_list
+
+
+def _provider_overrides(value: object, meta_path: Path) -> dict[str, dict[str, Any]]:
+    """Valide ``infra.providers`` : un mapping provider → mapping d'overrides."""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"{meta_path}: 'infra.providers' doit être un mapping "
+            f"(reçu : {type(value).__name__})."
+        )
+    overrides: dict[str, dict[str, Any]] = {}
+    for name, cfg in value.items():
+        if cfg is None:
+            overrides[str(name)] = {}
+        elif isinstance(cfg, dict):
+            overrides[str(name)] = dict(cfg)
+        else:
+            raise ValueError(
+                f"{meta_path}: 'infra.providers.{name}' doit être un mapping "
+                f"(reçu : {type(cfg).__name__})."
+            )
+    return overrides
+
 
 class ProviderUnresolved(ValueError):
     """Aucun provider d'infrastructure n'est résolu pour ce dépôt.
@@ -287,15 +312,29 @@ class RepoMetadata:
         with meta_path.open(encoding="utf-8") as fh:
             data = yaml.safe_load(fh) or {}
 
+        # `or {}` couvre le fichier vide, pas une racine en liste ou en scalaire
+        # (ni un bloc `repo:` qui ne serait pas un mapping) : l'accès `.get`
+        # lèverait alors AttributeError au lieu du ValueError attendu par la CLI.
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"{meta_path}: le document doit être un mapping YAML "
+                f"(reçu : {type(data).__name__})."
+            )
+
         repo = data.get("repo") or {}
+        if not isinstance(repo, dict):
+            raise ValueError(
+                f"{meta_path}: le bloc 'repo' doit être un mapping "
+                f"(reçu : {type(repo).__name__})."
+            )
         if not repo.get("id") or not repo.get("category"):
             raise ValueError(
                 f"{meta_path}: les champs 'repo.id' et 'repo.category' "
                 "sont requis (contrat dsoxlab)."
             )
 
-        infra_data = data.get("infra") or {}
-        hosts_data = infra_data.get("hosts") or []
+        infra_data = as_mapping(data.get("infra"), "infra", meta_path)
+        hosts_data = as_mapping_list(infra_data.get("hosts"), "infra.hosts", meta_path)
         # Provider courant : env > contexte session > meta.yml (string OU
         # liste à 1 élément) > non résolu ("") si liste à plusieurs sans
         # choix — voir InfraDefinition.require_provider().
@@ -312,32 +351,33 @@ class RepoMetadata:
             cidr=infra_data.get("cidr", ""),
             hosts=[
                 HostDefinition(
-                    name=h["name"],
+                    name=str(h["name"]),
+                    # `or ""` plutôt que le défaut de .get() : une clé présente
+                    # mais vide rend None, que str() transformerait en "None".
                     # ip est legacy/optionnel — calculé par Terraform en MVP
-                    ip=str(h.get("ip", "")),
-                    distro=h.get("distro", ""),
-                    role=h.get("role", ""),
-                    ram_mb=int(h.get("ram_mb", 1024)),
-                    vcpu=int(h.get("vcpu", 1)),
-                    disk_gb=int(h.get("disk_gb", 10)),
-                    extra_disk_gb=int(h.get("extra_disk_gb", 0)),
+                    ip=str(h.get("ip") or ""),
+                    distro=str(h.get("distro") or ""),
+                    role=str(h.get("role") or ""),
+                    ram_mb=as_int(h.get("ram_mb"), 1024, "infra.hosts[].ram_mb", meta_path),
+                    vcpu=as_int(h.get("vcpu"), 1, "infra.hosts[].vcpu", meta_path),
+                    disk_gb=as_int(h.get("disk_gb"), 10, "infra.hosts[].disk_gb", meta_path),
+                    extra_disk_gb=as_int(
+                        h.get("extra_disk_gb"), 0, "infra.hosts[].extra_disk_gb", meta_path
+                    ),
                 )
                 for h in hosts_data
             ],
-            providers={
-                str(name): dict(cfg or {})
-                for name, cfg in (infra_data.get("providers") or {}).items()
-            },
+            providers=_provider_overrides(infra_data.get("providers"), meta_path),
         )
 
         sections = [
             SectionDefinition(
-                id=s["id"],
+                id=str(s["id"]),
                 title=s.get("title", ""),
                 description=s.get("description", ""),
-                labs=list(s.get("labs") or []),
+                labs=as_str_list(s.get("labs"), "sections[].labs", meta_path),
             )
-            for s in (data.get("sections") or [])
+            for s in as_mapping_list(data.get("sections"), "sections", meta_path)
         ]
 
         return cls(

--- a/tests/test_yaml_contract.py
+++ b/tests/test_yaml_contract.py
@@ -1,0 +1,143 @@
+"""Regression tests for the untrusted-YAML contract.
+
+`lab.yaml` and `meta.yml` come from lab-provider repositories, so they are the
+engine's untrusted input. `discovery/scanner.py` rattrape exactement
+``(KeyError, ValueError, yaml.YAMLError)`` et ignore le lab fautif avec un
+warning. Toute autre exception échappe à ce filet et remonte en traceback à
+l'utilisateur, sur une commande sans rapport.
+
+Ces cas ont été trouvés par les harnais de fuzzing (``fuzz/``) : un document
+vide et un ``runtime:`` scalaire faisaient lever AttributeError, hors contrat.
+Chaque test vérifie donc le *type* d'exception, pas seulement qu'il y a échec.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dsoxlab.models.lab import LabDefinition
+from dsoxlab.models.repo import RepoMetadata
+
+# Le filet exact de discovery/scanner.py.
+CONTRACT_EXCEPTIONS = (KeyError, ValueError, yaml.YAMLError)
+
+VALID_LAB = """\
+id: l1-demo
+title: Demo lab
+level: beginner
+skills: [demo]
+distros: [any]
+doc_url: https://example.org/docs/demo/
+runtime:
+  type: shell
+  workdir: challenge/work
+"""
+
+# Socle minimal valide : `repo.id` et `repo.category` sont les seuls champs
+# requis par le contrat. Les cas ci-dessous lui ajoutent le bloc à éprouver.
+VALID_META = """\
+repo:
+  id: demo-training
+  category: demo
+"""
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_valid_lab_still_parses(tmp_path: Path) -> None:
+    lab = LabDefinition.from_yaml(_write(tmp_path, "lab.yaml", VALID_LAB))
+    assert lab.id == "l1-demo"
+    assert lab.runtime.workdir == "challenge/work"
+
+
+def test_empty_validation_block_falls_back_to_defaults(tmp_path: Path) -> None:
+    """`validation:` sans valeur n'est pas une erreur : le bloc est optionnel."""
+    lab = LabDefinition.from_yaml(_write(tmp_path, "lab.yaml", VALID_LAB + "validation:\n"))
+    assert lab.validation.functional is True
+    assert lab.validation.security is False
+
+
+@pytest.mark.parametrize(
+    ("label", "document"),
+    [
+        ("empty file", ""),
+        ("comments only", "# rien qu'un commentaire\n"),
+        ("root is a list", "- id: l1\n- id: l2\n"),
+        ("root is a scalar", "42\n"),
+        # `runtime: vm` au lieu du bloc `runtime:\n  type: vm` : la faute la
+        # plus naturelle du contrat.
+        ("runtime is a scalar", VALID_LAB.replace("runtime:\n  type: shell\n  workdir: challenge/work\n", "runtime: vm\n")),
+        ("validation is a scalar", VALID_LAB + "validation: true\n"),
+        ("fixtures is a scalar", VALID_LAB + "  fixtures: 42\n"),
+        ("targets is a bool", VALID_LAB + "  targets: true\n"),
+        ("targets is a scalar", VALID_LAB + "  targets: 3\n"),
+        ("targets holds a scalar", VALID_LAB + "  targets:\n    - 42\n"),
+        ("roles is a scalar", VALID_LAB + "  targets:\n    - name: a\n      host: h.lab\n      roles: nope\n"),
+        ("bloc is not a number", VALID_LAB + "bloc: abc\n"),
+        ("skills is a scalar", VALID_LAB.replace("skills: [demo]", "skills: 42")),
+    ],
+)
+def test_malformed_lab_stays_within_contract(tmp_path: Path, label: str, document: str) -> None:
+    """Un lab.yaml hostile est rejeté DANS le contrat, jamais en AttributeError."""
+    lab_yaml = _write(tmp_path, "lab.yaml", document)
+    with pytest.raises(CONTRACT_EXCEPTIONS):
+        LabDefinition.from_yaml(lab_yaml)
+
+
+@pytest.mark.parametrize(
+    ("label", "document"),
+    [
+        ("root is a list", "- repo\n- other\n"),
+        ("root is a scalar", "42\n"),
+        ("repo is a scalar", "repo: linux\n"),
+        ("repo is empty", "repo:\n"),
+        ("missing category", "repo:\n  id: demo\n"),
+        ("infra is a scalar", VALID_META + "infra: kvm\n"),
+        # `hosts:` en mapping au lieu d'une liste : l'itération porterait sur
+        # les clés (des str) et `h["name"]` lèverait TypeError.
+        ("hosts is a mapping", VALID_META + "infra:\n  hosts:\n    web: 10.0.0.1\n"),
+        ("hosts holds a scalar", VALID_META + "infra:\n  hosts:\n    - 42\n"),
+        ("providers is a scalar", VALID_META + "infra:\n  providers: nope\n"),
+        ("sections is a mapping", VALID_META + "sections:\n  l1: yes\n"),
+        ("labs is a scalar", VALID_META + "sections:\n  - id: l1\n    labs: 42\n"),
+        ("vcpu is not a number", VALID_META + "infra:\n  hosts:\n    - name: a.lab\n      vcpu: abc\n"),
+    ],
+)
+def test_malformed_meta_stays_within_contract(tmp_path: Path, label: str, document: str) -> None:
+    meta_yml = _write(tmp_path, "meta.yml", document)
+    with pytest.raises(CONTRACT_EXCEPTIONS):
+        RepoMetadata.from_yaml(meta_yml)
+
+
+def test_empty_host_fields_fall_back_to_defaults(tmp_path: Path) -> None:
+    """Une clé présente mais vide (`vcpu:`) doit retomber sur le défaut.
+
+    `.get("vcpu", 1)` rend None dans ce cas, pas 1 : c'est ce qui faisait
+    lever `int(None)`.
+    """
+    meta_yml = _write(
+        tmp_path,
+        "meta.yml",
+        VALID_META + "infra:\n  hosts:\n    - name: a.lab\n      vcpu:\n      ram_mb:\n      ip:\n",
+    )
+    meta = RepoMetadata.from_yaml(meta_yml)
+    host = meta.infra.hosts[0]
+    assert host.vcpu == 1
+    assert host.ram_mb == 1024
+    assert host.ip == ""  # et surtout pas la chaîne "None"
+
+
+def test_invalid_translation_file_is_ignored(tmp_path: Path) -> None:
+    """Un lab.<lang>.yaml non-mapping ne doit pas casser le lab de base."""
+    _write(tmp_path, "lab.yaml", VALID_LAB)
+    _write(tmp_path, "lab.fr.yaml", "- pas un mapping\n")
+
+    lab = LabDefinition.from_yaml(tmp_path / "lab.yaml", lang="fr")
+    assert lab.title == "Demo lab"  # on retombe sur la valeur de base

--- a/uv.lock
+++ b/uv.lock
@@ -72,6 +72,16 @@ wheels = [
 ]
 
 [[package]]
+name = "atheris"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/88/fd6ad595dafa9c7ce56dbfcaff0c7244988dac3af86c771166c6516ccf6b/atheris-3.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ec5e11f21a4c197fe91f7aea2b2de88e623c73a21fc07b105ac6329a1588457b", size = 36875908, upload-time = "2026-06-17T00:04:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/18/e19718c384fd7d801d0da7485407daef9af6194b6d8c8818175bec5efec6/atheris-3.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8a9f51ce8369026e8eb7b7174835e8c4c85a1a6db5d9add36c15100779d2a39", size = 36800563, upload-time = "2026-06-17T00:04:04.559Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ff/ae7a5bfe99033e510bea4ed09934e636d93777317a48147369bc0dc2b71f/atheris-3.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:315a0b5c819852b1ffe1ca72efc389c7724881f2c33e4aacb8c6bcec49bd5011", size = 36772569, upload-time = "2026-06-17T00:04:07.702Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -112,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },
@@ -131,6 +141,9 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "types-pyyaml" },
+]
+fuzz = [
+    { name = "atheris" },
 ]
 
 [package.metadata]
@@ -152,6 +165,7 @@ dev = [
     { name = "ruff", specifier = ">=0.4" },
     { name = "types-pyyaml", specifier = ">=6" },
 ]
+fuzz = [{ name = "atheris", specifier = ">=2.3" }]
 
 [[package]]
 name = "filelock"


### PR DESCRIPTION
- **fix(models): un lab.yaml ou meta.yml malformé ne fait plus planter la CLI**
- **feat(ci): durcir le pipeline et fuzzer le contrat YAML non fiable**
- **docs(contributing): aligner le gabarit de PR et CONTRIBUTING sur le projet réel**

# Summary

<!-- What does this PR change and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling

## Checklist

- [x] `uv run ruff check src/dsoxlab` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes
- [x] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
- [x] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
- [x] `CHANGELOG.md` updated when behavior changes
- [x] Manually tested against at least one lab repository

## Related issues

<!-- e.g. Closes #123 -->
