### PR TITLE
fix(release): n'attester que les artefacts publiés, et aligner les docs de contribution

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Summary
 
-<!-- What does this PR change and why? -->
+<!-- What does this PR change, and why? -->
 
 ## Type of change
 
@@ -9,17 +9,65 @@
 - [ ] Refactor
 - [ ] Documentation
 - [ ] Chore / tooling
+- [ ] Security / supply chain
 
 ## Checklist
 
-- [ ] `uv run ruff check src/dsoxlab` passes
+Only the **Always** block applies to every PR. The other blocks are conditional:
+if a block does not apply, say so (`N/A`) rather than leaving it blank — a blank
+box reads as "forgotten", an explicit `N/A` reads as "considered".
+
+### Always
+
+- [ ] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit)
 - [ ] `uv run mypy src/dsoxlab` passes (strict)
 - [ ] `uv run pytest` passes
-- [ ] The engine stays domain-agnostic (no domain-specific logic in `src/dsoxlab/`)
-- [ ] New/changed user-facing strings are added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
-- [ ] New/changed command or option is reflected in its `help=_()`, the i18n keys, and `fullhelp` (EN + FR)
-- [ ] `CHANGELOG.md` updated when behavior changes
-- [ ] Manually tested against at least one lab repository
+- [ ] The engine stays domain-agnostic — no domain-specific logic in
+      `src/dsoxlab/` (no `if category == "linux"`)
+- [ ] No hardcoded personal path or host; `pathlib.Path` throughout
+- [ ] Manually tested against **two** lab repositories, to prove the agnostic
+      design (e.g. `linux-dsoxlab-training` and `ansible-training`)
+
+### When behavior changes — otherwise N/A
+
+- [ ] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated (the project is
+      bilingual; an EN-only entry is an incomplete entry)
+- [ ] Version bumped in `pyproject.toml` and `uv.lock` refreshed (`uv lock`).
+      `__version__` is derived from the package metadata — there is nothing to
+      bump in `src/dsoxlab/__init__.py`.
+
+### When a command or option is added, removed or changed — otherwise N/A
+
+- [ ] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
+- [ ] `help=_("…")` in `cli.py` and the `fullhelp_commands` section updated in
+      EN **and** FR — `fullhelp` must never describe a command that no longer
+      exists
+- [ ] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`
+
+### When `.github/workflows/` is touched — otherwise N/A
+
+These are CI gates: they fail the build, so run them before pushing.
+
+- [ ] `actionlint` clean
+- [ ] `zizmor --offline .github/workflows/` reports no findings
+- [ ] `poutine analyze_local . --fail-on-violation` clean
+- [ ] Every action pinned to a **full 40-character commit SHA** with a
+      `# vX.Y.Z` comment — never `@v4`, never `@main`
+- [ ] `step-security/harden-runner` is the job's first step
+- [ ] No job renamed, or the required status checks updated accordingly — they
+      match job names **exactly**, and a renamed job silently stops being
+      required
+- [ ] A new third-party action is added to `trustedGithubActions` in
+      `.plumber.yaml` (and acknowledged per purl in `.poutine.yml` if its
+      creator is not Marketplace-verified)
+
+### When the declarative contract (`meta.yml` / `lab.yaml`) changes — otherwise N/A
+
+- [ ] The contract section of `README.md` reflects the change
+- [ ] `fuzz/corpus/` seeds and `fuzz/dict/yaml_contract.dict` cover any new field
+- [ ] A malformed value of the new field still raises inside the parser contract
+      — `(KeyError, ValueError, yaml.YAMLError)` — so a bad lab is skipped with a
+      warning instead of crashing the CLI
 
 ## Related issues
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,20 @@ jobs:
       # SLSA build provenance for the wheel and sdist, verifiable with
       # `gh attestation verify <artifact> --repo stephrobert/dsoxlab` or
       # slsa-verifier. Complements the PEP 740 attestations PyPI records.
+      #
+      # The two artifacts are listed explicitly rather than globbed with
+      # `dist/*`: `uv build` also drops a one-byte `dist/.gitignore`, and this
+      # action's glob matches dotfiles (unlike the shell glob that feeds
+      # `gh release create` below). v0.1.11 therefore attested `.gitignore`
+      # alongside the distributions — harmless, but an attestation should name
+      # exactly what is published, nothing more.
       - name: Attest build provenance
         id: attest
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: 'dist/*'
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
 
       # The attestation above is recorded on GitHub's attestation API, which is
       # what `gh attestation verify` reads. It is NOT what OpenSSF Scorecard's

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,16 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Corrigé
+
+- **La provenance de build n'atteste plus un fichier qui n'est pas publié.**
+  `uv build` dépose un `dist/.gitignore` d'un octet, et
+  `attest-build-provenance` inclut les fichiers cachés dans son glob (au
+  contraire du glob shell qui alimente `gh release create`) : l'attestation de
+  la v0.1.11 listait donc `.gitignore` à côté de la wheel et du sdist. Les
+  artefacts sont désormais nommés explicitement. Anodin en soi, mais une
+  attestation doit nommer exactement ce qui est publié, rien de plus.
+
 ## [0.1.11] - 2026-07-17
 
 ### Corrigé
@@ -249,5 +259,16 @@ Première version publique.
 - Diagnostics de l'environnement (`dsoxlab doctor [--fix]`).
 - Interface utilisateur bilingue (anglais/français) pilotée par `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.11...HEAD
+[0.1.11]: https://github.com/stephrobert/dsoxlab/compare/v0.1.10...v0.1.11
+[0.1.10]: https://github.com/stephrobert/dsoxlab/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.com/stephrobert/dsoxlab/compare/v0.1.8...v0.1.9
+[0.1.8]: https://github.com/stephrobert/dsoxlab/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/stephrobert/dsoxlab/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/stephrobert/dsoxlab/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/stephrobert/dsoxlab/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/stephrobert/dsoxlab/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/stephrobert/dsoxlab/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/stephrobert/dsoxlab/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/stephrobert/dsoxlab/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/stephrobert/dsoxlab/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The build provenance no longer attests a file that is not published.**
+  `uv build` drops a one-byte `dist/.gitignore`, and `attest-build-provenance`
+  globs dotfiles (unlike the shell glob feeding `gh release create`), so the
+  v0.1.11 attestation listed `.gitignore` next to the wheel and the sdist. The
+  artifacts are now named explicitly. Harmless in itself, but an attestation
+  should name exactly what is published, nothing more.
+
 ## [0.1.11] - 2026-07-17
 
 ### Fixed
@@ -237,5 +246,16 @@ Initial public release.
 - Environment diagnostics (`dsoxlab doctor [--fix]`).
 - Bilingual (English/French) user interface driven by `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.11...HEAD
+[0.1.11]: https://github.com/stephrobert/dsoxlab/compare/v0.1.10...v0.1.11
+[0.1.10]: https://github.com/stephrobert/dsoxlab/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.com/stephrobert/dsoxlab/compare/v0.1.8...v0.1.9
+[0.1.8]: https://github.com/stephrobert/dsoxlab/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/stephrobert/dsoxlab/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/stephrobert/dsoxlab/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/stephrobert/dsoxlab/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/stephrobert/dsoxlab/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/stephrobert/dsoxlab/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/stephrobert/dsoxlab/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/stephrobert/dsoxlab/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/stephrobert/dsoxlab/releases/tag/v0.1.0

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -15,6 +15,9 @@ commit sont rédigés en anglais pour que tout le monde puisse participer.
 - [Règles fondamentales](#règles-fondamentales)
 - [Mise en place](#mise-en-place)
 - [Contrôles qualité](#contrôles-qualité)
+  - [Scanners de workflow](#scanners-de-workflow)
+  - [Fuzzer le contrat non fiable](#fuzzer-le-contrat-non-fiable)
+- [Hooks pre-commit](#hooks-pre-commit)
 - [Internationalisation (i18n)](#internationalisation-i18n)
 - [Conventions de commit](#conventions-de-commit)
 - [Pull requests](#pull-requests)
@@ -53,7 +56,8 @@ Testez sur un vrai dépôt de labs pour valider la neutralité (au moins deux,
 par exemple `linux-training` et `ansible-training`) :
 
 ```bash
-cd ~/Projets/linux-training && dsoxlab list-labs
+cd ~/Projets/linux-dsoxlab-training && dsoxlab list-labs
+cd ~/Projets/ansible-training && dsoxlab list-labs
 ```
 
 ## Contrôles qualité
@@ -61,10 +65,71 @@ cd ~/Projets/linux-training && dsoxlab list-labs
 À lancer avant d'ouvrir une pull request. La CI exécute les mêmes contrôles.
 
 ```bash
-uv run ruff check src/dsoxlab tests   # lint + sécurité (règles flake8-bandit S)
-uv run mypy src/dsoxlab               # typage (strict)
-uv run pytest                         # tests
+uv run ruff check src/dsoxlab tests fuzz   # lint + sécurité (règles flake8-bandit S)
+uv run mypy src/dsoxlab                    # typage (strict)
+uv run pytest                              # tests
 ```
+
+### Scanners de workflow
+
+Si vous touchez à `.github/workflows/`, quatre scanners bloquent la CI et
+doivent rester à **zéro finding**. Ils analysent le YAML des workflows, donc ils
+tournent sans aucune dépendance du projet :
+
+```bash
+actionlint                                    # syntaxe, scopes de permission invalides, shellcheck
+zizmor --offline .github/workflows/           # failles de workflow
+poutine analyze_local . --fail-on-violation   # chaînes d'exploitation CI/CD
+plumber analyze                               # graphe de confiance + réglages du dépôt
+```
+
+Les règles qu'ils imposent, à connaître avant d'écrire une ligne de YAML :
+
+- **Chaque action est épinglée par un SHA de commit de 40 caractères**, suivi
+  d'un commentaire `# vX.Y.Z`. Jamais `@v4`, jamais `@main` : un tag est
+  mutable, donc c'est un trou de supply chain.
+- **`step-security/harden-runner` est le premier step de chaque job.**
+- `permissions: {}` au niveau workflow, permissions minimales par job.
+- `actions/checkout` avec `persist-credentials: false`, un runner figé
+  (`ubuntu-24.04`, pas `ubuntu-latest`), un `timeout-minutes` et un `name:`.
+- **Ne jamais interpoler `${{ … }}` dans un bloc `run:`.** Passez la valeur par
+  un bloc `env:`, sinon zizmor signale une injection de template.
+- Une nouvelle action tierce doit être ajoutée à `trustedGithubActions` dans
+  `.plumber.yaml`. Si son créateur n'est pas vérifié sur le Marketplace,
+  acquittez-la dans `.poutine.yml` **par son purl exact** — jamais en
+  désactivant la règle, ce qui la rendrait aveugle à toutes les autres actions.
+
+Un piège mérite sa propre ligne : **les status checks requis portent les noms de
+jobs exacts**. Renommer un job fait taire silencieusement l'ancien check, qui
+n'est alors plus jamais satisfait, et les pull requests restent bloquées. Ne
+renommez qu'en mettant à jour la protection de branche dans le même geste.
+
+### Fuzzer le contrat non fiable
+
+`lab.yaml` et `meta.yml` viennent des dépôts fournisseurs de labs : ce sont les
+entrées non fiables du moteur. `discovery/scanner.py` rattrape
+`(KeyError, ValueError, yaml.YAMLError)` et ignore le lab fautif avec un
+warning — **toute exception hors de ce tuple échappe au filet et fait planter la
+CLI** sur une commande sans rapport.
+
+Les harnais de `fuzz/` vérifient ce contrat, et un run court amorcé bloque la
+CI. Lancez une campagne plus longue en local dès que vous touchez à un parser :
+
+```bash
+uv sync --group fuzz
+mkdir -p /tmp/fuzz-lab
+uv run --group fuzz python fuzz/fuzz_lab_yaml.py \
+    /tmp/fuzz-lab fuzz/corpus/lab_yaml/ \
+    -dict=fuzz/dict/yaml_contract.dict -atheris_runs=100000
+```
+
+Passez le répertoire de travail **en premier** : libFuzzer écrit ses trouvailles
+dans le premier dossier de corpus, et `fuzz/corpus/` est un jeu de graines
+choisi à la main. Un crash écrit un reproducteur `crash-*` que vous rejouez en
+le passant comme unique argument. Si vous ajoutez un champ au contrat, ajoutez
+une graine : des octets aléatoires ne reconstruisent jamais un mot-clé par
+hasard, donc le corpus et `fuzz/dict/yaml_contract.dict` sont ce qui permet au
+fuzzer d'atteindre votre code.
 
 ## Hooks pre-commit
 
@@ -114,7 +179,7 @@ Nous utilisons les Conventional Commits avec un scope de module :
 <type>(<module>): <description courte>
 ```
 
-Types : `feat`, `fix`, `docs`, `refactor`, `chore`, `test`. Exemples :
+Types : `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`. Exemples :
 
 - `feat(discovery): support multi-repo via ~/.config/dsoxlab/config.yaml`
 - `fix(runtimes/kvm): make snapshot revert idempotent when snapshot is absent`
@@ -125,9 +190,18 @@ consultez `git log --oneline -5` pour coller au style.
 
 ## Pull requests
 
-- Partez de `main`, gardez un périmètre restreint, remplissez le gabarit de PR.
-- Assurez-vous que lint, typage et tests sont verts.
-- Mettez à jour la documentation et `CHANGELOG.md` quand le comportement change.
+- Partez d'un `main` à jour, gardez un périmètre restreint, remplissez le
+  gabarit de PR. Supprimez la branche une fois mergée.
+- Assurez-vous que lint, typage et tests sont verts — plus les scanners de
+  workflow si vous avez touché à `.github/workflows/`.
+- Quand le comportement change, mettez à jour **les deux** fichiers
+  `CHANGELOG.md` et `CHANGELOG.fr.md`. Le projet est bilingue : une entrée en
+  anglais seul est une entrée incomplète.
+- Quand le comportement change, bumpez aussi la version dans `pyproject.toml` et
+  régénérez `uv.lock` (`uv lock`). Il n'y a rien à bumper dans
+  `src/dsoxlab/__init__.py` : `__version__` est lu depuis les métadonnées du
+  paquet installé, précisément pour qu'il ne puisse pas diverger de
+  `pyproject.toml`.
 - Si vous ajoutez une commande ou une option, confirmez la checklist i18n
   ci-dessus.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,9 @@ in English so everyone can take part.
 - [Ground rules](#ground-rules)
 - [Development setup](#development-setup)
 - [Quality gates](#quality-gates)
+  - [Workflow scanners](#workflow-scanners)
+  - [Fuzzing the untrusted contract](#fuzzing-the-untrusted-contract)
+- [Pre-commit hooks](#pre-commit-hooks)
 - [Internationalization (i18n)](#internationalization-i18n)
 - [Commit conventions](#commit-conventions)
 - [Pull requests](#pull-requests)
@@ -48,11 +51,13 @@ uv sync                      # create the venv and install dev dependencies
 uv tool install --editable . # optional: expose `dsoxlab` on your PATH
 ```
 
-Test against a real lab repository to validate the agnostic design (at least
-two, e.g. `linux-training` and `ansible-training`):
+Test against a real lab repository to validate the agnostic design. Use **at
+least two**, from different domains — that is the only way to prove the engine
+carries no domain-specific logic:
 
 ```bash
-cd ~/Projets/linux-training && dsoxlab list-labs
+cd ~/Projets/linux-dsoxlab-training && dsoxlab list-labs
+cd ~/Projets/ansible-training && dsoxlab list-labs
 ```
 
 ## Quality gates
@@ -60,10 +65,71 @@ cd ~/Projets/linux-training && dsoxlab list-labs
 Run these before opening a pull request. CI runs the same checks.
 
 ```bash
-uv run ruff check src/dsoxlab   # lint + security (flake8-bandit S rules)
-uv run mypy src/dsoxlab         # type-check (strict)
-uv run pytest                   # tests
+uv run ruff check src/dsoxlab tests fuzz   # lint + security (flake8-bandit S rules)
+uv run mypy src/dsoxlab                    # type-check (strict)
+uv run pytest                              # tests
 ```
+
+### Workflow scanners
+
+If you touch anything under `.github/workflows/`, four scanners gate the build
+and must stay at **zero finding**. They analyse the workflow YAML, so they run
+without any project dependency:
+
+```bash
+actionlint                                    # syntax, invalid permission scopes, shellcheck
+zizmor --offline .github/workflows/           # workflow vulnerabilities
+poutine analyze_local . --fail-on-violation   # CI/CD exploitation chains
+plumber analyze                               # trust graph + repository settings
+```
+
+The rules they enforce, and which are worth knowing before you write a line of
+YAML:
+
+- **Every action is pinned to a full 40-character commit SHA**, followed by a
+  `# vX.Y.Z` comment. Never `@v4`, never `@main`: a tag is mutable, so it is a
+  supply-chain hole.
+- **`step-security/harden-runner` is the first step of every job.**
+- `permissions: {}` at workflow level, minimal permissions per job.
+- `actions/checkout` with `persist-credentials: false`, a pinned runner
+  (`ubuntu-24.04`, not `ubuntu-latest`), a `timeout-minutes` and a `name:`.
+- **Never interpolate `${{ … }}` into a `run:` block.** Pass the value through
+  an `env:` block instead, or zizmor flags a template injection.
+- A new third-party action must be added to `trustedGithubActions` in
+  `.plumber.yaml`. If its creator is not Marketplace-verified, acknowledge it in
+  `.poutine.yml` **by its exact purl** — never by disabling the rule, which
+  would blind it to every other action.
+
+One trap deserves its own line: **the required status checks match job names
+exactly**. Renaming a job silently stops the old check from ever being
+satisfied, and pull requests hang forever. Rename only if you update the branch
+protection in the same move.
+
+### Fuzzing the untrusted contract
+
+`lab.yaml` and `meta.yml` come from lab-provider repositories: they are the
+engine's untrusted input. `discovery/scanner.py` catches
+`(KeyError, ValueError, yaml.YAMLError)` and skips the offending lab with a
+warning — **anything raised outside that tuple escapes the handler and crashes
+the CLI** on an unrelated command.
+
+The harnesses in `fuzz/` assert that contract, and a short seeded run gates CI.
+Run a longer campaign locally when you touch a parser:
+
+```bash
+uv sync --group fuzz
+mkdir -p /tmp/fuzz-lab
+uv run --group fuzz python fuzz/fuzz_lab_yaml.py \
+    /tmp/fuzz-lab fuzz/corpus/lab_yaml/ \
+    -dict=fuzz/dict/yaml_contract.dict -atheris_runs=100000
+```
+
+Pass the scratch directory **first**: libFuzzer writes what it finds into the
+first corpus directory, and `fuzz/corpus/` is a curated seed set. A crash writes
+a `crash-*` reproducer you can replay by passing it as the only argument. If you
+add a field to the contract, add a seed for it — random bytes never rebuild a
+keyword by chance, so the corpus and `fuzz/dict/yaml_contract.dict` are what
+make the fuzzer reach your code.
 
 ## Pre-commit hooks
 
@@ -113,7 +179,7 @@ We use Conventional Commits with a module scope:
 <type>(<module>): <short description>
 ```
 
-Types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`. Examples:
+Types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`. Examples:
 
 - `feat(discovery): support multi-repo via ~/.config/dsoxlab/config.yaml`
 - `fix(runtimes/kvm): make snapshot revert idempotent when snapshot is absent`
@@ -124,9 +190,16 @@ Keep commits focused and the history readable. Before a grouped commit, check
 
 ## Pull requests
 
-- Branch from `main`, keep the scope tight, and fill in the PR template.
-- Ensure lint, type-check and tests are green.
-- Update the documentation and `CHANGELOG.md` when behavior changes.
+- Branch from an up-to-date `main`, keep the scope tight, and fill in the PR
+  template. Delete the branch once merged.
+- Ensure lint, type-check and tests are green — plus the workflow scanners if
+  you touched `.github/workflows/`.
+- When behavior changes, update **both** `CHANGELOG.md` and `CHANGELOG.fr.md`.
+  The project is bilingual: an English-only entry is an incomplete entry.
+- When behavior changes, also bump the version in `pyproject.toml` and refresh
+  `uv.lock` (`uv lock`). There is nothing to bump in `src/dsoxlab/__init__.py`:
+  `__version__` is read from the installed package metadata, precisely so it
+  cannot drift from `pyproject.toml`.
 - If you add a command or option, confirm the i18n checklist above is done.
 
 ## Reporting bugs and requesting features

--- a/RELEASING.fr.md
+++ b/RELEASING.fr.md
@@ -23,11 +23,20 @@ OIDC) : aucun token d'API n'est jamais stocké dans le dépôt.
 
 ## Publier une version
 
-1. Incrémentez la version dans `pyproject.toml` et `src/dsoxlab/__init__.py`.
-2. Déplacez les entrées `Unreleased` de [CHANGELOG.md](./CHANGELOG.md) sous un
-   nouveau titre `## [X.Y.Z]` et mettez à jour les liens de comparaison.
+1. Incrémentez la version dans `pyproject.toml`, puis régénérez le lockfile avec
+   `uv lock`. Il n'y a **rien à incrémenter** dans `src/dsoxlab/__init__.py` :
+   `__version__` est lu depuis les métadonnées du paquet installé, précisément
+   pour qu'il ne puisse pas diverger de `pyproject.toml`.
+2. Déplacez les entrées `Unreleased` sous un nouveau titre `## [X.Y.Z]` dans
+   **les deux** fichiers [CHANGELOG.md](./CHANGELOG.md) et
+   [CHANGELOG.fr.md](./CHANGELOG.fr.md), et mettez à jour les liens de
+   comparaison en bas de chacun. Le projet est bilingue : une entrée en anglais
+   seul est une entrée incomplète.
 3. Committez via une pull request et mergez sur `main`.
-4. Taguez la version et poussez le tag :
+4. **Attendez que la CI soit verte sur `main`.** Le tag construit depuis ce
+   commit, et PyPI est définitif : un numéro de version ne peut jamais être
+   republié.
+5. Taguez la version et poussez le tag :
 
    ```bash
    git tag -a vX.Y.Z -m "vX.Y.Z"
@@ -37,7 +46,32 @@ OIDC) : aucun token d'API n'est jamais stocké dans le dépôt.
 Pousser le tag déclenche `release.yml`, qui :
 
 - construit le sdist et la wheel avec `uv build` et les vérifie avec `twine`,
-- publie sur PyPI via OIDC, en attachant les attestations de provenance PEP 740.
+- enregistre la **provenance de build SLSA** des deux artefacts
+  (`actions/attest-build-provenance`),
+- publie sur PyPI via OIDC, en attachant les attestations de provenance PEP 740,
+- crée la **Release GitHub** avec la section du CHANGELOG correspondant au tag,
+  les distributions, et `provenance.intoto.jsonl`.
+
+Deux détails de ce pipeline sont délibérés. Le job `publish` n'exécute aucun code
+du projet et ne porte que `id-token: write` ; et `github_release` ne tourne
+qu'après le succès de PyPI, donc aucune Release n'annonce une version qui aurait
+échoué à l'upload.
+
+`provenance.intoto.jsonl` est attaché comme asset de release à dessein : c'est un
+artefact *distinct* de l'attestation enregistrée sur l'API GitHub, et c'est celui
+que cherche le contrôle Signed-Releases d'OpenSSF Scorecard. Ce contrôle note les
+**cinq dernières** releases : il n'atteint donc son maximum qu'une fois cinq
+releases consécutives porteuses de l'asset.
+
+## Vérifier une release
+
+N'importe qui peut vérifier qu'un artefact publié provient réellement du workflow
+de ce dépôt, et depuis quel commit :
+
+```bash
+gh release download vX.Y.Z --repo stephrobert/dsoxlab --pattern '*.whl'
+gh attestation verify dsoxlab-X.Y.Z-py3-none-any.whl --repo stephrobert/dsoxlab
+```
 
 ## Versionnage
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,11 +22,18 @@ ever stored in the repository.
 
 ## Cutting a release
 
-1. Bump the version in `pyproject.toml` and `src/dsoxlab/__init__.py`.
-2. Move the `Unreleased` entries in [CHANGELOG.md](./CHANGELOG.md) under a new
-   `## [X.Y.Z]` heading and update the comparison links.
+1. Bump the version in `pyproject.toml`, then refresh the lockfile with
+   `uv lock`. There is **nothing to bump** in `src/dsoxlab/__init__.py`:
+   `__version__` is read from the installed package metadata precisely so it
+   cannot drift from `pyproject.toml`.
+2. Move the `Unreleased` entries under a new `## [X.Y.Z]` heading in **both**
+   [CHANGELOG.md](./CHANGELOG.md) and [CHANGELOG.fr.md](./CHANGELOG.fr.md), and
+   update the comparison links at the bottom of each file. The project is
+   bilingual: an English-only entry is an incomplete entry.
 3. Commit through a pull request and merge to `main`.
-4. Tag the release and push the tag:
+4. **Wait for CI to be green on `main`.** The tag builds from that commit, and
+   PyPI is final: a version number can never be republished.
+5. Tag the release and push the tag:
 
    ```bash
    git tag -a vX.Y.Z -m "vX.Y.Z"
@@ -36,7 +43,31 @@ ever stored in the repository.
 Pushing the tag triggers `release.yml`, which:
 
 - builds the sdist and wheel with `uv build` and checks them with `twine`,
-- publishes to PyPI via OIDC, attaching PEP 740 build attestations.
+- records **SLSA build provenance** for both artifacts
+  (`actions/attest-build-provenance`),
+- publishes to PyPI via OIDC, attaching PEP 740 build attestations,
+- creates the **GitHub Release** with the CHANGELOG section for the tag, the
+  distributions, and `provenance.intoto.jsonl`.
+
+Two details of that pipeline are deliberate. The `publish` job runs no project
+code and holds `id-token: write` only; and `github_release` runs after PyPI
+succeeds, so no Release ever advertises a version that failed to upload.
+
+`provenance.intoto.jsonl` is attached as a release asset on purpose: it is a
+*distinct* artifact from the attestation recorded on GitHub's API, and it is the
+one OpenSSF Scorecard's Signed-Releases control looks for. That control scores
+the **five most recent** releases, so it only reaches its maximum once five
+consecutive releases carry the asset.
+
+## Verifying a release
+
+Anyone can verify that a published artifact really came from this repository's
+workflow, and from which commit:
+
+```bash
+gh release download vX.Y.Z --repo stephrobert/dsoxlab --pattern '*.whl'
+gh attestation verify dsoxlab-X.Y.Z-py3-none-any.whl --repo stephrobert/dsoxlab
+```
 
 ## Versioning
 


### PR DESCRIPTION
# Summary

Deux défauts relevés en publiant la v0.1.11, plus l'alignement des documents de
contribution sur le projet réel.

## La provenance attestait un fichier non publié

L'attestation de la v0.1.11 liste `dist/.gitignore` à côté de la wheel et du
sdist. `uv build` dépose un fichier d'un octet dans `dist/`, et le glob de
`attest-build-provenance` inclut les fichiers cachés — contrairement au glob
shell qui alimente `gh release create`, d'où l'asymétrie entre ce qui est attesté
et ce qui est réellement publié. Les deux artefacts sont désormais nommés
explicitement.

Anodin sur le fond (aucune faille), mais une attestation doit nommer exactement
ce qui est publié, rien de plus.

## RELEASING décrivait une procédure qui ne marche pas

- « Incrémentez la version dans `pyproject.toml` **et** `src/dsoxlab/__init__.py` » :
  il n'y a rien à incrémenter dans `__init__.py`, `__version__` étant lu depuis
  les métadonnées du paquet — précisément pour qu'il ne diverge pas, suite à un
  bug vécu où la CLI restait figée en `0.1.0`.
- Seul `CHANGELOG.md` était mentionné, alors que le projet est bilingue.
- Ni `uv.lock`, ni l'attente d'une CI verte avant de taguer. PyPI est définitif :
  un numéro de version ne se republie jamais.
- La description du workflow s'arrêtait à PyPI, sans la provenance SLSA, la
  Release GitHub, ni `provenance.intoto.jsonl`.

L'étape « mettez à jour les liens de comparaison » n'était appliquée par personne
depuis la 0.1.0 : les onze versions suivantes n'avaient aucun lien. Ils sont
régénérés dans les deux CHANGELOG, et chaque version a été vérifiée comme ayant
un tag publié.

Ajout d'une section « vérifier une release », et de la raison pour laquelle
Signed-Releases note les **cinq dernières** releases : l'asset ne porte le
contrôle à son maximum qu'une fois cinq releases consécutives à le fournir. Le
score ira donc à ~7,4, pas à 8,0, tant que les quatre releases précédentes
restent nues.

## Le gabarit de PR et CONTRIBUTING

Écarts relevés en remplissant le gabarit pour de vrai :

- `cd ~/Projets/linux-training` : ce dépôt n'existe pas, il s'appelle
  `linux-dsoxlab-training`. La commande échouait telle quelle.
- « at least one lab repository » : un seul dépôt ne prouve rien de
  l'agnosticisme, la règle fondatrice du moteur. Il en faut deux.
- « `CHANGELOG.md` updated » : le bilingue, le bump et `uv.lock` manquaient.
- Les quatre scanners de workflow et leurs règles (épinglage par SHA,
  harden-runner, pas d'interpolation dans un `run:`, trust policy) étaient
  absents, alors que la CI les impose désormais : un contributeur ne pouvait pas
  les deviner avant de voir la CI rougir.
- Le piège des status checks, qui portent les noms de jobs **exacts** : renommer
  un job fait taire le check et bloque les PR indéfiniment.
- Le fuzzing, le groupe `fuzz`, et la raison de passer le répertoire de travail
  avant le corpus.
- Le type de commit `ci`, utilisé par le projet mais absent de la liste.

Le gabarit distingue maintenant ce qui vaut pour toute PR de ce qui est
conditionnel, et demande un `N/A` explicite plutôt qu'une case vide : une case
vide se lit « oubliée », un `N/A` se lit « considérée ».

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [x] Security / supply chain

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes (32 tests)
- [x] The engine stays domain-agnostic
- [x] No hardcoded personal path or host — c'est précisément ce que corrige le
      `~/Projets/linux-training` mort de CONTRIBUTING
- [x] Manually tested against two lab repositories
      <br>*Aucun changement de code produit ici ; `list-labs` reste vert sur
      `linux-dsoxlab-training` et `ansible-training`.*

### When behavior changes

- [x] Both `CHANGELOG.md` and `CHANGELOG.fr.md` updated (entrée `Unreleased`)
- [ ] Version bumped + `uv.lock` refreshed
      <br>**N/A** : rien ne change pour l'utilisateur du paquet. Le correctif
      porte sur le workflow de release, qui n'est pas distribué. Le bump viendra
      avec la prochaine version, et c'est elle qui portera l'attestation
      corrigée.

### When a command or option changes

**N/A** : aucune commande ni option touchée.

### When `.github/workflows/` is touched

- [x] `actionlint` clean
- [x] `zizmor --offline .github/workflows/` — no findings
- [x] `poutine analyze_local . --fail-on-violation` clean
- [x] Actions pinned by full commit SHA (aucune action ajoutée)
- [x] `harden-runner` first step (inchangé)
- [x] No job renamed
- [x] No new third-party action

### When the declarative contract changes

**N/A** : le contrat n'est pas touché.

## Vérification

Le glob corrigé a été éprouvé sur un `dist/` réel produit par `uv build` :
`dist/*.whl` + `dist/*.tar.gz` retiennent les deux distributions et excluent
`.gitignore`, là où `dist/*` le ramassait.
