### PR TITLE
chore(release): 0.1.12

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,8 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.12] - 2026-07-17
+
 ### Corrigé
 
 - **La provenance de build n'atteste plus un fichier qui n'est pas publié.**
@@ -259,7 +261,8 @@ Première version publique.
 - Diagnostics de l'environnement (`dsoxlab doctor [--fix]`).
 - Interface utilisateur bilingue (anglais/français) pilotée par `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.11...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.12...HEAD
+[0.1.12]: https://github.com/stephrobert/dsoxlab/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/stephrobert/dsoxlab/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/stephrobert/dsoxlab/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/stephrobert/dsoxlab/compare/v0.1.8...v0.1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12] - 2026-07-17
+
 ### Fixed
 
 - **The build provenance no longer attests a file that is not published.**
@@ -246,7 +248,8 @@ Initial public release.
 - Environment diagnostics (`dsoxlab doctor [--fix]`).
 - Bilingual (English/French) user interface driven by `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.11...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.12...HEAD
+[0.1.12]: https://github.com/stephrobert/dsoxlab/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/stephrobert/dsoxlab/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/stephrobert/dsoxlab/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/stephrobert/dsoxlab/compare/v0.1.8...v0.1.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.11"
+version = "0.1.12"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
# Summary

Release 0.1.12. Première version portant la **provenance corrigée** : l'attestation
ne nomme plus que la wheel et le sdist, là où la v0.1.11 y ajoutait le
`dist/.gitignore` d'un octet déposé par `uv build`.

Rien ne change pour l'utilisateur du paquet : le correctif porte sur le workflow
de release lui-même, qui n'est pas distribué. Cette version existe pour que le
correctif s'applique en conditions réelles — un workflow de publication ne se
teste qu'en publiant.

Effet attendu sur OpenSSF Scorecard : Signed-Releases passe de 2/10 à 4/10 (deux
des cinq dernières releases porteront `provenance.intoto.jsonl`), soit un score
global autour de 7,5. Le contrôle n'atteindra 10 qu'après cinq releases
consécutives à fournir l'asset.

Procédure suivie à la lettre depuis [RELEASING.md](./RELEASING.md), tel que corrigé
en #20 : bump de `pyproject.toml` seul (rien à toucher dans `__init__.py`,
`__version__` étant lu depuis les métadonnées du paquet), `uv lock`, entrées
`Unreleased` datées dans **les deux** CHANGELOG, et liens de comparaison
régénérés.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes (32 tests)
- [x] The engine stays domain-agnostic
- [x] No hardcoded personal path or host
- [x] Manually tested against two lab repositories
      <br>*Aucun changement de code produit ; `linux-dsoxlab-training` et
      `ansible-training` restent verts.*

### When behavior changes

- [x] Both `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` and `uv.lock` refreshed (`uv lock`)

### When a command or option changes

**N/A** : aucune commande ni option touchée.

### When `.github/workflows/` is touched

**N/A** : aucun workflow modifié dans cette PR (le correctif de provenance a été
mergé en #20).

### When the declarative contract changes

**N/A** : le contrat n'est pas touché.

## Après le merge

Attendre la CI verte sur `main`, puis :

```bash
git tag -a v0.1.12 -m "v0.1.12"
git push origin v0.1.12
```
