### PR TITLE
feat(ci): rendre Branch-Protection évaluable par Scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,6 +25,10 @@ jobs:
     if: ${{ !github.event.repository.private }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    # The privileged token lives in this protected environment, restricted to
+    # the main branch. This workflow never runs on `pull_request`, so the token
+    # is unreachable from a fork. Same model as plumber.yml.
+    environment: security
     permissions:
       contents: read
       security-events: write   # upload SARIF to Code Scanning
@@ -46,6 +50,21 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          # Without this, Branch-Protection cannot be evaluated at all: the
+          # default GITHUB_TOKEN may not read *classic* branch protection, and
+          # the check returned `-1` — an internal error, silently excluded from
+          # the average rather than scored.
+          #
+          # A fine-grained PAT with `Administration: Read` (plus the Metadata
+          # that comes with it) is what Scorecard documents for this case. The
+          # token is reused from plumber.yml, which needs the exact same right
+          # for `branchMustBeProtected` — one privileged credential to rotate,
+          # not two.
+          #
+          # Note: had this repository used a *ruleset* instead of classic branch
+          # protection, no token would be needed — rulesets are readable by the
+          # default GITHUB_TOKEN.
+          repo_token: ${{ secrets.PLUMBER_ADMIN_TOKEN }}
 
       - name: Upload SARIF to Code Scanning
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0


### PR DESCRIPTION
# Summary

Le contrôle OpenSSF **Branch-Protection** renvoyait `-1` :

> internal error: error during branchesHandler.setup: internal error: some
> github tokens can't read classic branch protection

Ce n'est pas une mauvaise note, c'est une **erreur interne** : le contrôle était
exclu de la moyenne. L'état réel de la protection n'était donc ni mesuré ni
visible, alors que la branche `main` est protégée depuis le début. Un contrôle
qui échoue en silence est pire qu'un contrôle bas : il ne dit rien.

## Le token

Scorecard documente ce cas précis : la **classic** branch protection n'est
lisible que par un PAT fine-grained portant `Administration: Read` (plus le
`Metadata` qui l'accompagne). Le workflow reçoit donc `repo_token`.

Le token est **repris de `plumber.yml`**, qui exige exactement le même droit pour
son contrôle `branchMustBeProtected` : un seul identifiant privilégié à faire
tourner plutôt que deux. Il vit dans l'environnement protégé `security`,
restreint à `main`, et `scorecard.yml` ne tourne jamais sur `pull_request` — le
secret reste hors de portée d'un fork. C'est le même modèle que `plumber.yml`.

À noter pour plus tard : un **ruleset** serait lisible par le `GITHUB_TOKEN` par
défaut et rendrait ce token inutile. La classic protection est le seul motif de
le porter ici.

## Le réglage de la protection (hors dépôt, côté GitHub)

Donner le token ne suffisait pas : avec la configuration précédente, le contrôle
serait sorti à ~4/10 et aurait **fait baisser** le score global.

La raison est dans `checks/evaluation/branch_protection.go` : la cascade est
stricte (`if basicScore < maxBasicScore { return }`), et le `reviewerWeight = 2`
du Tier 2 n'est accordé qu'au-dessus de **zéro** relecteur requis. Avec
`required_approving_review_count = 0`, la notation s'arrêtait au Tier 1, et les
status checks du Tier 3 n'étaient **jamais comptés**.

| | avant | après |
|---|---|---|
| Approbations requises | 0 | **1** |
| `require_last_push_approval` | non | **oui** |
| Status checks requis | 6 | **9** |
| force-push / deletion | bloqués | bloqués |
| linear history | oui | oui |
| `enforce_admins` | false | false |

`enforce_admins` reste à `false` **volontairement** : sur un dépôt à un seul
mainteneur, le bypass admin est ce qui permet de merger sans se bloquer soi-même.
Une approbation est requise, et le mainteneur la contourne explicitement — un
clic conscient, pas un blocage. Cette PR est la première à l'expérimenter.

Les status checks passent de 6 à 9 : `actionlint`, `poutine` et le job de
fuzzing tournaient **sans bloquer le merge**, ce qui vidait de son sens le fait
de les avoir ajoutés en gates.

## Effet attendu

Branch-Protection devrait sortir autour de **8/10** (Tier 1 + 2 + 3 validés ;
le Tier 4 exige 2 approbations, hors d'atteinte à un seul mainteneur), portant le
score global de ~7,5 à **~7,6**.

Le gain chiffré est modeste et n'est pas le but : le bénéfice réel est que la
protection est enfin **mesurée** plutôt que masquée derrière une erreur. Cette
estimation est déduite du code de Scorecard, pas observée — le scan qui suivra ce
merge tranchera.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [x] Security / supply chain

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes (32 tests)
- [x] The engine stays domain-agnostic
- [x] No hardcoded personal path or host
- [x] Manually tested against two lab repositories
      <br>*Aucun code produit touché : cette PR ne modifie qu'un workflow.*

### When behavior changes — otherwise N/A

**N/A** : rien ne change pour l'utilisateur du paquet. La modification porte sur
la façon dont le dépôt est audité, pas sur `dsoxlab` lui-même — donc pas d'entrée
CHANGELOG, pas de bump.

### When a command or option is added, removed or changed — otherwise N/A

**N/A** : aucune commande ni option touchée.

### When `.github/workflows/` is touched — otherwise N/A

- [x] `actionlint` clean
- [x] `zizmor --offline .github/workflows/` reports no findings
- [x] `poutine analyze_local . --fail-on-violation` clean
- [x] Every action pinned to a full 40-character commit SHA — aucune action
      ajoutée ni modifiée
- [x] `step-security/harden-runner` is the job's first step — inchangé
- [x] No job renamed, or the required status checks updated accordingly
      <br>*Aucun job renommé. Les checks requis sont au contraire **complétés**
      des 3 jobs manquants, en reprenant leurs noms exacts.*
- [x] A new third-party action is added to `trustedGithubActions` — aucune
      action ajoutée

### When the declarative contract changes — otherwise N/A

**N/A** : le contrat n'est pas touché.

## Retour arrière

La configuration exacte d'avant a été sauvegardée. Si la contrainte d'approbation
gêne le quotidien, un seul appel suffit à revenir :

```bash
gh api --method PUT repos/stephrobert/dsoxlab/branches/main/protection \
  --input protection-backup.json
```
