### PR TITLE
feat(infra)!: compte de service ansible et prérequis Ansible dans l'image de base

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,57 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.14] - 2026-07-20
+
+### Ajouté
+
+- **Un compte de service `ansible` dédié sur chaque nœud provisionné.** Les
+  gabarits cloud-init (AlmaLinux et Ubuntu) créent désormais un compte `ansible`
+  à côté du compte humain `student`, avec le même durcissement : clé SSH
+  uniquement, aucun mot de passe de connexion, appartenance à `wheel`/`sudo` et
+  `sudo NOPASSWD:ALL`.
+
+  Séparer le compte de *service* utilisé par l'automatisation du compte *humain*
+  est la bonne pratique : la traçabilité garde du sens et chaque compte peut être
+  révoqué sans verrouiller l'autre. `student` reste le compte humain sur le
+  control node ; `ansible` est le compte par lequel dsoxlab et les playbooks des
+  labs se connectent. Le `NOPASSWD:ALL` global est assumé, car ce compte pilote
+  une automatisation généraliste (dnf, systemd, LVM, SELinux, firewalld) : la
+  sécurité vient de la dédicace du compte, pas d'un bridage de ses règles sudo.
+
+- **Les paquets absents de l'image cloud minimale AlmaLinux.** `firewalld` n'est
+  pas fourni dans l'image cloud AlmaLinux 10 : `systemctl enable --now firewalld`
+  visait donc une unité inexistante et tous les labs de pare-feu échouaient.
+  Ajoutés avec lui :
+
+  - `python3-firewall`, requis par le module `ansible.posix.firewalld`, qui sinon
+    échoue sur *Failed to import the required Python library (firewall)*.
+  - `policycoreutils-python-utils`, qui fournit `semanage`, l'outil RHCSA de
+    référence pour la gestion des ports et des contextes SELinux.
+
+  Ce sont des *prérequis d'exécution* Ansible : leur place est dans l'image de
+  base, pour que chaque nœud managé soit prêt pour Ansible sans amorçage par lab.
+
+### Modifié
+
+- **CASSANT : le compte SSH par défaut devient `ansible`, et non plus
+  `student`.** `build_inventory()` et `write_ssh_config()` utilisent désormais
+  `ansible` comme valeur par défaut de `ssh_user` : l'inventaire et le
+  `ssh_config` générés se connectent avec le compte de service.
+
+### Migration
+
+Les nœuds provisionnés avant la 0.1.14 n'ont pas de compte `ansible` et
+deviennent injoignables avec ce nouveau défaut. Il faut les reprovisionner :
+
+```console
+dsoxlab destroy && dsoxlab provision
+```
+
+Dans les dépôts de labs, tout ce qui restreint la connexion (`AllowUsers`,
+`remote_user`, `ansible_user`) doit désormais viser `ansible`, jamais `student`.
+Le pointer sur `student` verrouille l'automatisation hors du nœud.
+
 ## [0.1.13] - 2026-07-17
 
 ### Modifié
@@ -283,7 +334,8 @@ Première version publique.
 - Diagnostics de l'environnement (`dsoxlab doctor [--fix]`).
 - Interface utilisateur bilingue (anglais/français) pilotée par `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.13...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.14...HEAD
+[0.1.14]: https://github.com/stephrobert/dsoxlab/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/stephrobert/dsoxlab/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/stephrobert/dsoxlab/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/stephrobert/dsoxlab/compare/v0.1.10...v0.1.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14] - 2026-07-20
+
+### Added
+
+- **A dedicated `ansible` service account on every provisioned node.** The
+  cloud-init templates (AlmaLinux and Ubuntu) now create an `ansible` account
+  next to the human `student` account, with the same hardening: SSH key only, no
+  login password, membership of `wheel`/`sudo`, and `sudo NOPASSWD:ALL`.
+
+  Separating the *service* account automation uses from the *human* account is
+  the standard practice: it keeps audit trails meaningful and lets either account
+  be revoked without locking the other one out. `student` remains the human
+  account on the control node; `ansible` is what dsoxlab and the lab playbooks
+  connect as. The blanket `NOPASSWD:ALL` is deliberate, since the account drives
+  general-purpose automation (dnf, systemd, LVM, SELinux, firewalld): the safety
+  comes from the account being dedicated, not from narrowing its sudo rules.
+
+- **Packages missing from the AlmaLinux minimal cloud image.** `firewalld` is not
+  shipped in the AlmaLinux 10 cloud image, so `systemctl enable --now firewalld`
+  targeted a unit that did not exist and every firewall lab failed. Added with it:
+
+  - `python3-firewall`, required by the `ansible.posix.firewalld` module, which
+    otherwise fails with *Failed to import the required Python library (firewall)*.
+  - `policycoreutils-python-utils`, which provides `semanage`, the reference RHCSA
+    tool for SELinux port and context management.
+
+  These are Ansible *execution prerequisites*: they belong in the base image, so
+  that every managed node is Ansible-ready without a per-lab bootstrap step.
+
+### Changed
+
+- **BREAKING: the default SSH account is now `ansible`, not `student`.**
+  `build_inventory()` and `write_ssh_config()` default `ssh_user` to `ansible`,
+  so the generated inventory and `ssh_config` connect as the service account.
+
+### Migration
+
+Nodes provisioned before 0.1.14 have no `ansible` account and become unreachable
+under the new default. Re-provision them:
+
+```console
+dsoxlab destroy && dsoxlab provision
+```
+
+In lab repositories, anything that restricts the connection (`AllowUsers`,
+`remote_user`, `ansible_user`) must now target `ansible`, never `student`.
+Pointing it at `student` locks automation out of the node.
+
 ## [0.1.13] - 2026-07-17
 
 ### Changed
@@ -268,7 +316,8 @@ Initial public release.
 - Environment diagnostics (`dsoxlab doctor [--fix]`).
 - Bilingual (English/French) user interface driven by `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.13...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.14...HEAD
+[0.1.14]: https://github.com/stephrobert/dsoxlab/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/stephrobert/dsoxlab/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/stephrobert/dsoxlab/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/stephrobert/dsoxlab/compare/v0.1.10...v0.1.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.13"
+version = "0.1.14"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/infra/inventory.py
+++ b/src/dsoxlab/infra/inventory.py
@@ -47,7 +47,7 @@ def build_inventory(
     repo_meta: RepoMetadata,
     *,
     ssh_private_key: Path | None = None,
-    ssh_user: str = "student",
+    ssh_user: str = "ansible",
     terraform_outputs: dict[str, Any] | None = None,
     target_fqdn: str | None = None,
     roles: dict[str, str] | None = None,
@@ -58,7 +58,7 @@ def build_inventory(
         repo_meta: ``RepoMetadata`` du dépôt fournisseur.
         ssh_private_key: Chemin vers la clé privée du lab. Si None,
             cherche ``<repo>/ssh/id_ed25519``.
-        ssh_user: Utilisateur SSH (par défaut ``student``).
+        ssh_user: Utilisateur SSH (par défaut ``ansible``, le compte de service).
         terraform_outputs: Outputs JSON de Terraform. Si fourni, l'IP de
             chaque host est lue depuis ``outputs["hosts"][fqdn]``.
             Sinon, fallback sur ``meta.yml: hosts[].ip``.
@@ -255,7 +255,7 @@ def write_ssh_config(
     ]
     for name, vars_ in hosts.items():
         ip = vars_.get("ansible_host", "")
-        user = vars_.get("ansible_user", "student")
+        user = vars_.get("ansible_user", "ansible")
         identity = vars_.get("ansible_ssh_private_key_file", "")
         extra = vars_.get("ansible_ssh_common_args", "") or ""
 
@@ -297,12 +297,12 @@ def wait_for_hosts_ready(
     """Attend que chaque host soit réellement utilisable après ``terraform apply``.
 
     Juste après le provisioning, la VM boote encore : ``sshd`` démarre, puis
-    cloud-init crée l'utilisateur ``student`` et configure sudo. Tant que ce
-    n'est pas terminé, la première commande ``dsoxlab run`` échoue en
+    cloud-init crée le compte de service ``ansible`` et configure sudo. Tant que
+    ce n'est pas terminé, la première commande ``dsoxlab run`` échoue en
     *unreachable* (« dark ») côté Ansible. On sonde donc une connexion SSH
-    réelle sous le compte ``student`` — ce qui prouve à la fois que ``sshd``
-    répond et que le compte existe — puis on laisse ``cloud-init status --wait``
-    bloquer jusqu'à la fin de la configuration.
+    réelle sous le compte ``ansible`` (le compte de connexion de l'automatisation),
+    ce qui prouve à la fois que ``sshd`` répond et que le compte existe, puis on
+    laisse ``cloud-init status --wait`` bloquer jusqu'à la fin de la configuration.
 
     Args:
         repo_meta: métadonnées du dépôt (pour construire le ssh_config).
@@ -323,7 +323,7 @@ def wait_for_hosts_ready(
     )
     ssh_cfg = write_ssh_config(inventory, repo_meta)
 
-    # SSH réussit dès que sshd répond ET que student existe ; on enchaîne sur
+    # SSH réussit dès que sshd répond ET que le compte ansible existe ; on enchaîne sur
     # `cloud-init status --wait` (best-effort) pour ne rendre la main qu'une fois
     # la VM entièrement configurée. Le `|| true` évite d'échouer sur un état
     # cloud-init « degraded » : ce qui compte, c'est qu'il ait terminé.

--- a/src/dsoxlab/templates/cloud-init/almalinux.yaml.tmpl
+++ b/src/dsoxlab/templates/cloud-init/almalinux.yaml.tmpl
@@ -24,12 +24,30 @@ users:
     ssh_authorized_keys:
       - ${ssh_pubkey}
 
+  # ansible : compte de SERVICE d'automatisation, distinct du compte humain
+  # ``student``. C'est lui que dsoxlab et les playbooks des labs utilisent pour
+  # se connecter (ansible_user: ansible). Séparer le compte de service du compte
+  # humain est la bonne pratique : traçabilité et révocation indépendantes. Même
+  # durcissement que student : clé SSH uniquement, sans mot de passe. Le
+  # NOPASSWD:ALL est volontaire (automatisation généraliste : dnf, systemd, LVM,
+  # SELinux, firewalld) ; la sécurité tient à la dédicace du compte, pas au bridage.
+  - name: ansible
+    groups: [wheel]
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    shell: /bin/bash
+    lock_passwd: false
+    passwd: "*"
+    ssh_authorized_keys:
+      - ${ssh_pubkey}
+
 disable_root: true
 ssh_pwauth: false
 
 # Outils minimum pour les labs RHCSA — diagnostic et observabilité.
-# Les paquets spécifiques (lvm2, parted, xfsprogs, firewalld) sont
-# déjà dans l'image AlmaLinux Cloud par défaut.
+# lvm2, parted, xfsprogs sont dans l'image AlmaLinux Cloud par défaut, mais
+# PAS firewalld (image minimale) : on l'installe explicitement, sinon tout lab
+# qui manipule le pare-feu échoue et `systemctl enable firewalld` plus bas cible
+# un service inexistant.
 packages:
   # openssh-server : NON préinstallé sur les images Incus cloud (Incus
   # assume incus exec via l'agent virtio). On l'installe pour avoir un
@@ -44,6 +62,19 @@ packages:
   - tcpdump
   - bind-utils
   - net-tools
+  # firewalld : le service de pare-feu. Absent de l'image AlmaLinux 10 minimale,
+  # alors que de nombreux labs (et l'EX294) le manipulent. Activé dans runcmd.
+  - firewalld
+  # python3-firewall : binding Python requis par le module
+  # ``ansible.posix.firewalld``. Sans lui, tout play qui touche firewalld échoue
+  # « Failed to import the required Python library (firewall) ». Prérequis
+  # d'exécution Ansible : sa place est dans la base, pour que chaque nœud managé
+  # soit « prêt pour Ansible ».
+  - python3-firewall
+  # policycoreutils-python-utils : fournit la commande `semanage` (gestion des
+  # ports/contextes SELinux). Absente de l'image minimale, alors que c'est
+  # l'outil RHCSA de référence pour SELinux (et ce que les tests inspectent).
+  - policycoreutils-python-utils
   # qemu-guest-agent : laisse libvirt récupérer l'IP via virtio channel
   # (``virsh domifaddr --source agent``). Indispensable côté provider kvm
   # quand on ne veut pas dépendre du DHCP lease (qui peut être lent ou
@@ -57,6 +88,7 @@ runcmd:
   # compte, on force le hash à '*' (pas de password possible mais
   # compte débloqué côté shadow). Idempotent.
   - [ usermod, -p, "*", student ]
+  - [ usermod, -p, "*", ansible ]
   - [ systemctl, enable, --now, sshd ]
   - [ systemctl, enable, --now, firewalld ]
   - [ systemctl, enable, --now, qemu-guest-agent ]

--- a/src/dsoxlab/templates/cloud-init/ubuntu.yaml.tmpl
+++ b/src/dsoxlab/templates/cloud-init/ubuntu.yaml.tmpl
@@ -22,6 +22,19 @@ users:
     ssh_authorized_keys:
       - ${ssh_pubkey}
 
+  # ansible : compte de SERVICE d'automatisation, distinct du compte humain
+  # ``student``. C'est lui que dsoxlab et les playbooks des labs utilisent pour
+  # se connecter (ansible_user: ansible). Même durcissement : clé SSH uniquement,
+  # sans mot de passe. NOPASSWD:ALL volontaire (automatisation généraliste).
+  - name: ansible
+    groups: [sudo]
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    shell: /bin/bash
+    lock_passwd: false
+    passwd: "*"
+    ssh_authorized_keys:
+      - ${ssh_pubkey}
+
 disable_root: true
 ssh_pwauth: false
 
@@ -54,6 +67,7 @@ runcmd:
   # Garde-fou anti-locking : force le hash à '*' (cf. commentaire dans
   # la section users). Idempotent.
   - [ usermod, -p, "*", student ]
+  - [ usermod, -p, "*", ansible ]
   - [ systemctl, enable, --now, ssh ]
   - [ systemctl, enable, --now, qemu-guest-agent ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
# Summary

Sépare le **compte de service** de l'automatisation du **compte humain**, ce qui est la bonne pratique de sécurité : traçabilité réelle et révocation indépendante. `student` reste le compte humain sur le control node ; `ansible` devient le compte par lequel dsoxlab **et** les playbooks des labs se connectent.

Au passage, l'image de base AlmaLinux gagne les prérequis d'exécution Ansible qui lui manquaient : `firewalld` n'est pas fourni dans l'image cloud minimale, si bien que `systemctl enable --now firewalld` visait une unité inexistante et que tout lab de pare-feu échouait. Ces paquets sont des prérequis d'exécution : leur place est dans l'image de base, pas dans un amorçage par lab.

> [!WARNING]
> **Changement cassant.** `ssh_user` passe de `student` à `ansible`. Les nœuds provisionnés avant la 0.1.14 n'ont pas ce compte et deviennent injoignables : il faut les reprovisionner (`dsoxlab destroy && dsoxlab provision`). Dans les dépôts de labs, tout ce qui restreint la connexion (`AllowUsers`, `remote_user`, `ansible_user`) doit désormais viser `ansible`.

## Type of change

- [x] New feature
- [x] Security / supply chain

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit)
- [x] `uv run mypy src/dsoxlab` passes (strict), 41 fichiers
- [x] `uv run pytest` passes, 32 passed
- [x] The engine stays domain-agnostic : le compte de service est une notion d'infra, pas de domaine
- [x] No hardcoded personal path or host; `pathlib.Path` throughout
- [x] Manually tested against **two** lab repositories :
  - `ansible-training` : **791 passed, 2 skipped** (suite complète, sous isolation)
  - `linux-dsoxlab-training` : 716 labs découverts, `validate-structure` rend *All labs are valid*

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.13 vers 0.1.14) and `uv lock` refreshed

### When a command or option is added, removed or changed

`N/A` : aucune commande ni option ajoutée, supprimée ou modifiée. Seul un **défaut interne** (`ssh_user`) change, sans surface CLI, donc rien à répercuter en i18n ni dans `fullhelp`.

### When `.github/workflows/` is touched

`N/A` : aucun workflow touché.

### When the declarative contract (`meta.yml` / `lab.yaml`) changes

`N/A` : le contrat déclaratif est inchangé, aucun champ ajouté ni dans `meta.yml` ni dans `lab.yaml`.

## Related issues

Aucune.
