### PR TITLE
feat(cli): ajouter la commande guide pour ouvrir le cours en ligne

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,32 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.16] - 2026-07-20
+
+### Ajouté
+
+- **`dsoxlab guide [<id>]` ouvre le cours en ligne d'un lab dans le navigateur.**
+  Le cours n'est pas embarqué dans le dépôt de labs : chaque lab déclare un
+  `doc_url` qui pointe vers le site du formateur. Ouvrir la vraie page, plutôt que
+  d'en rapatrier le contenu, la laisse s'afficher telle qu'elle est publiée (images,
+  blocs de code, navigation) et évite d'avoir à suivre la structure HTML d'un site
+  tiers. `--print` écrit l'URL au lieu d'ouvrir un navigateur : c'est ce qu'on veut
+  en SSH, où `webbrowser` n'a rien à ouvrir.
+
+- **`guide_url()` dans le nouveau `services/guide_service.py`**, une fonction pure
+  qui compose l'URL et n'ouvre rien. Elle ajoute des paramètres de campagne
+  (`utm_source=dsoxlab`, `utm_medium=lab`, `utm_campaign=<lab_id>`) pour qu'un
+  formateur puisse voir quels labs amènent réellement des lecteurs vers quels
+  guides.
+
+  Ce marquage est nécessaire, pas décoratif : un lien suivi depuis une interface
+  locale transmet au mieux `http://localhost:<port>` comme referrer, au pire rien du
+  tout, si bien que ces lectures seraient sinon indistinguables du trafic direct.
+  Les paramètres de requête déjà présents et les ancres `#section` sont conservés,
+  donc un lab peut viser une section précise d'un guide. `source` et `medium` sont
+  surchargeables, ce qui permettra à une future interface web de se distinguer de la
+  CLI.
+
 ## [0.1.15] - 2026-07-20
 
 ### Ajouté
@@ -386,7 +412,8 @@ Première version publique.
 - Diagnostics de l'environnement (`dsoxlab doctor [--fix]`).
 - Interface utilisateur bilingue (anglais/français) pilotée par `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...HEAD
+[0.1.16]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/stephrobert/dsoxlab/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/stephrobert/dsoxlab/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/stephrobert/dsoxlab/compare/v0.1.12...v0.1.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16] - 2026-07-20
+
+### Added
+
+- **`dsoxlab guide [<id>]` opens a lab's online course in your web browser.** The
+  course is not bundled in the lab repository: each lab declares a `doc_url`
+  pointing at the trainer's site. Opening the real page, rather than fetching its
+  content, keeps it rendered exactly as published (images, code blocks, navigation)
+  and avoids tracking a third-party site's HTML structure. `--print` writes the URL
+  instead of opening a browser, which is what you want over SSH, where
+  `webbrowser` has nothing to open.
+
+- **`guide_url()` in the new `services/guide_service.py`**, a pure function that
+  composes the URL and opens nothing. It appends campaign parameters
+  (`utm_source=dsoxlab`, `utm_medium=lab`, `utm_campaign=<lab_id>`) so a trainer can
+  tell which labs actually drive readers to which guides.
+
+  This marking is necessary, not decorative: a link followed from a local interface
+  carries `http://localhost:<port>` as referrer at best, nothing at all at worst, so
+  those reads would otherwise be indistinguishable from direct traffic. Existing
+  query parameters and `#anchors` are preserved, so a lab can point at a precise
+  section of a guide. `source` and `medium` are overridable, letting a future web
+  front-end distinguish itself from the CLI.
+
 ## [0.1.15] - 2026-07-20
 
 ### Added
@@ -363,7 +387,8 @@ Initial public release.
 - Environment diagnostics (`dsoxlab doctor [--fix]`).
 - Bilingual (English/French) user interface driven by `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...HEAD
+[0.1.16]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/stephrobert/dsoxlab/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/stephrobert/dsoxlab/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/stephrobert/dsoxlab/compare/v0.1.12...v0.1.13

--- a/README.fr.md
+++ b/README.fr.md
@@ -80,9 +80,29 @@ cd linux-dsoxlab-training
 # 2. Le contexte actif est détecté automatiquement via le meta.yml du dépôt
 dsoxlab list-labs
 dsoxlab show linux.depanner.service-crash-loop
+dsoxlab guide linux.depanner.service-crash-loop   # lire le cours dans le navigateur
 dsoxlab run linux.depanner.service-crash-loop
 dsoxlab check linux.depanner.service-crash-loop
 ```
+
+### Lire le cours
+
+Le cours n'est pas embarqué dans le dépôt de labs : chaque lab déclare un
+`doc_url` qui pointe vers le site du formateur. `dsoxlab guide` ouvre cette page
+dans un vrai onglet de navigateur, donc elle s'affiche telle qu'elle est publiée,
+avec ses images, ses blocs de code et sa navigation.
+
+```bash
+dsoxlab guide                 # le lab actif
+dsoxlab guide <id>            # un lab précis
+dsoxlab guide <id> --print    # affiche l'URL au lieu de l'ouvrir (utile en SSH)
+```
+
+L'URL porte des paramètres de campagne (`utm_source=dsoxlab`, `utm_medium=lab`,
+`utm_campaign=<lab_id>`), ce qui permet à un formateur de voir quels labs amènent
+réellement des lecteurs vers quels guides. Un lien ouvert depuis une interface
+locale ne transmet aucun referrer exploitable : sans ce marquage, ces lectures
+seraient indistinguables du trafic direct.
 
 Changer de langue à la volée :
 
@@ -167,6 +187,7 @@ test référencés sont présents.
 | `dsoxlab list-labs` | Liste les labs du dépôt courant (filtre `--section`/`--level`/`--type`/`--bloc`) |
 | `dsoxlab show <id>` | Détail d'un lab |
 | `dsoxlab course [section]` | Affiche une section de cours ou la table des matières |
+| `dsoxlab guide [id]` | Ouvre le guide en ligne du lab dans le navigateur (`--print` affiche l'URL) |
 | `dsoxlab run <id>` | Prépare et démarre l'environnement du lab |
 | `dsoxlab challenge <id>` | Affiche la mission de challenge d'un lab |
 | `dsoxlab hint <id>` | Révèle un indice (déduit du score) |

--- a/README.md
+++ b/README.md
@@ -80,9 +80,28 @@ cd linux-dsoxlab-training
 # 2. The active context is detected automatically from the repo's meta.yml
 dsoxlab list-labs
 dsoxlab show linux.depanner.service-crash-loop
+dsoxlab guide linux.depanner.service-crash-loop   # read the course in your browser
 dsoxlab run linux.depanner.service-crash-loop
 dsoxlab check linux.depanner.service-crash-loop
 ```
+
+### Reading the course
+
+The course itself is not bundled in the lab repository: each lab declares a
+`doc_url` pointing to the trainer's site. `dsoxlab guide` opens that page in a
+real browser tab, so it renders exactly as published, with its images, code
+blocks and navigation.
+
+```bash
+dsoxlab guide                 # the active lab
+dsoxlab guide <id>            # a specific lab
+dsoxlab guide <id> --print    # print the URL instead (useful over SSH)
+```
+
+The URL carries campaign parameters (`utm_source=dsoxlab`, `utm_medium=lab`,
+`utm_campaign=<lab_id>`), so a trainer can see which labs actually drive readers
+to which guides. A link opened from a local interface carries no usable referrer,
+so without this marking those reads would be indistinguishable from direct traffic.
 
 Switch language on the fly:
 
@@ -165,6 +184,7 @@ scripts and test files are present.
 | `dsoxlab list-labs` | List labs of the current repo (filter by `--section`/`--level`/`--type`/`--bloc`) |
 | `dsoxlab show <id>` | Show a lab's details |
 | `dsoxlab course [section]` | Display a course section, or the table of contents |
+| `dsoxlab guide [id]` | Open the lab's online guide in a browser (`--print` shows the URL) |
 | `dsoxlab run <id>` | Prepare and start the lab environment |
 | `dsoxlab challenge <id>` | Show the challenge mission for a lab |
 | `dsoxlab hint <id>` | Reveal a hint (deducted from the score) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.15"
+version = "0.1.16"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -16,6 +16,7 @@ Usage:
 from __future__ import annotations
 
 import os
+import webbrowser
 import shutil
 import subprocess
 import sys
@@ -79,6 +80,7 @@ from .services import (
     evaluate_lab,
     get_all_labs,
     get_lab,
+    guide_url,
     lab_status,
     next_pending_lab,
     open_lab_session,
@@ -597,6 +599,44 @@ def challenge_cmd(
 
 
 # ── hint ──────────────────────────────────────────────────────────────────────
+
+@app.command("guide", help=_("cmd_guide_help"))
+def guide(
+    lab_id: Annotated[Optional[str], typer.Argument(help=_("cmd_guide_arg"), shell_complete=_complete_lab_id)] = None,
+    print_only: Annotated[bool, typer.Option("--print", help=_("cmd_guide_opt_print"))] = False,
+    lab_home: LabHomeOption = None,
+) -> None:
+    """Ouvre le guide en ligne du lab dans le navigateur.
+
+    Le cours est publié sur le site du formateur, pas embarqué dans le dépôt :
+    on ouvre donc la vraie page plutôt que d'en rapatrier le contenu. Elle
+    s'affiche telle qu'elle est publiée, et la lecture compte comme une visite
+    réelle du site.
+    """
+    root = _root(lab_home)
+    lang = _lang(root)
+    lab = _resolve_lab(root, lab_id, lang)
+
+    url = guide_url(lab)
+    if url is None:
+        error(_("guide_no_url", lab_id=lab.id))
+        raise typer.Exit(1)
+
+    # soft_wrap : une URL coupée sur deux lignes n'est plus copiable ni
+    # exploitable dans un pipe. Elle doit sortir d'un seul tenant, même
+    # au-delà de la largeur du terminal.
+    if print_only:
+        console.print(url, soft_wrap=True)
+        return
+
+    info(_("guide_opening", lab_id=lab.id))
+    console.print(url, soft_wrap=True)
+    # L'URL reste affichée : sur une machine sans navigateur (session SSH,
+    # serveur), webbrowser rend False sans rien ouvrir, et l'apprenant doit
+    # pouvoir la copier.
+    if not webbrowser.open(url):
+        error(_("guide_no_browser"))
+
 
 @app.command("hint", help=_("cmd_hint_help"))
 def hint(

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -31,6 +31,12 @@ STRINGS: dict[str, str] = {
     "cmd_next_help":     "Recommend the next lab or challenge to complete in the active context.",
     "cmd_show_help":     "Show details and status of a lab.",
     "cmd_show_arg":      "Lab identifier (e.g.: l1-01-navigation-fichiers)",
+    "cmd_guide_help":    "Open the lab's online guide in your web browser.",
+    "cmd_guide_arg":     "Lab identifier (optional if a lab is active)",
+    "cmd_guide_opt_print": "Print the URL instead of opening a browser.",
+    "guide_opening":     "Opening the guide for {lab_id} in your browser…",
+    "guide_no_url":      "Lab {lab_id} declares no doc_url: no guide to open.",
+    "guide_no_browser":  "No browser could be opened. Copy the URL above.",
     "cmd_run_help":      "Prepare and start the lab environment.",
     "cmd_run_arg":       "Lab identifier",
     "cmd_course_help":    "Display a course section, or the table of contents if no section is given.",
@@ -170,6 +176,13 @@ Each lab exposes:
   [cyan]run <id>[/cyan]             Start the lab environment (shell, incus or KVM).
 
   [cyan]course[/cyan] [dim][<id>][/dim]        Re-display the guided exercises (scenario.md).
+                       [dim]<id>[/dim] is optional if a lab is active in the session.
+
+  [cyan]guide[/cyan] [dim][<id>][/dim]         Open the lab's online guide in your web browser.
+                       The course lives on the trainer's site: the page opens in a
+                       real tab, so it renders exactly as published.
+    [dim]--print[/dim]              Print the URL instead of opening a browser
+                       (useful over SSH, where no browser is available).
                        [dim]<id>[/dim] is optional if a lab is active in the session.
 
   [cyan]challenge[/cyan] [dim][<id>][/dim]     Display the challenge mission (challenge/README.md).

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -31,6 +31,12 @@ STRINGS: dict[str, str] = {
     "cmd_next_help":     "Recommande le prochain lab ou challenge à compléter dans le contexte actif.",
     "cmd_show_help":      "Affiche le détail et le statut d'un lab.",
     "cmd_show_arg":       "Identifiant du lab (ex: l1-01-navigation-fichiers)",
+    "cmd_guide_help":     "Ouvre le guide en ligne du lab dans le navigateur.",
+    "cmd_guide_arg":      "Identifiant du lab (optionnel si un lab est actif)",
+    "cmd_guide_opt_print": "Affiche l'URL au lieu d'ouvrir un navigateur.",
+    "guide_opening":      "Ouverture du guide de {lab_id} dans le navigateur…",
+    "guide_no_url":       "Le lab {lab_id} ne déclare pas de doc_url : aucun guide à ouvrir.",
+    "guide_no_browser":   "Aucun navigateur n'a pu être ouvert. Copiez l'URL ci-dessus.",
     "cmd_run_help":       "Prépare et démarre l'environnement du lab.",
     "cmd_run_arg":        "Identifiant du lab",
     "cmd_course_help":    "Affiche une section du cours, ou le sommaire si aucune section n'est précisée.",
@@ -170,6 +176,13 @@ Chaque lab expose :
   [cyan]run <id>[/cyan]             Démarre l'environnement du lab (shell, incus ou KVM).
 
   [cyan]course[/cyan] [dim][<id>][/dim]        Réaffiche les exercices guidés (scenario.md).
+                       [dim]<id>[/dim] est optionnel si un lab est actif en session.
+
+  [cyan]guide[/cyan] [dim][<id>][/dim]         Ouvre le guide en ligne du lab dans le navigateur.
+                       Le cours vit sur le site du formateur : la page s'ouvre dans
+                       un vrai onglet, donc elle s'affiche telle qu'elle est publiée.
+    [dim]--print[/dim]              Affiche l'URL au lieu d'ouvrir un navigateur
+                       (utile en SSH, où aucun navigateur n'est disponible).
                        [dim]<id>[/dim] est optionnel si un lab est actif en session.
 
   [cyan]challenge[/cyan] [dim][<id>][/dim]     Affiche la mission du challenge (challenge/README.md).

--- a/src/dsoxlab/services/__init__.py
+++ b/src/dsoxlab/services/__init__.py
@@ -18,6 +18,7 @@ from .lab_service import (
     validate_all_metadata,
     validate_all_structure,
 )
+from .guide_service import guide_url
 from .progress_service import (
     BlocProgress,
     build_progress,
@@ -36,6 +37,7 @@ __all__ = [
     "evaluate_lab",
     "get_all_labs",
     "get_lab",
+    "guide_url",
     "lab_session_spec",
     "lab_status",
     "next_pending_lab",

--- a/src/dsoxlab/services/guide_service.py
+++ b/src/dsoxlab/services/guide_service.py
@@ -1,0 +1,57 @@
+"""Lien vers le guide en ligne d'un lab, marqué pour l'attribution analytics.
+
+Le contenu pédagogique vit sur le site du formateur, pas dans le dépôt de labs :
+un lab porte son ``doc_url``. Ouvrir cette page dans le navigateur plutôt que
+d'en rapatrier le contenu est délibéré. C'est la seule façon dont la lecture
+compte comme une vraie visite (le script analytics s'exécute sur le domaine du
+site), et cela évite d'avoir à suivre la structure HTML d'un site tiers.
+
+Ce module ne fait que composer l'URL. Il n'ouvre rien : la CLI et une éventuelle
+interface web décident quoi en faire.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from ..models.lab import LabDefinition
+
+DEFAULT_SOURCE = "dsoxlab"
+DEFAULT_MEDIUM = "lab"
+
+
+def guide_url(
+    lab: LabDefinition,
+    *,
+    source: str = DEFAULT_SOURCE,
+    medium: str = DEFAULT_MEDIUM,
+    campaign: str | None = None,
+) -> str | None:
+    """URL du guide du lab, portant les paramètres de campagne, ou None.
+
+    Retourne None quand le lab ne déclare pas de ``doc_url`` : l'appelant décide
+    quoi dire à l'apprenant, ce module ne lève pas pour un champ absent.
+
+    Les paramètres UTM sont indispensables ici, et pas seulement confortables :
+    quand le lien est cliqué depuis une interface locale, le referrer transmis
+    vaut au mieux ``http://localhost:<port>``, au pire rien du tout selon la
+    politique du navigateur. Sans marquage, ces lectures se noieraient dans le
+    trafic « direct » et l'on ne saurait jamais quel lab amène à quel guide.
+
+    Les paramètres déjà présents dans le ``doc_url`` sont conservés, et une
+    ancre (``#section``) reste intacte : le lab peut pointer une section précise
+    d'un guide.
+    """
+    if not lab.doc_url:
+        return None
+
+    parts = urlparse(lab.doc_url)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query.update(
+        {
+            "utm_source": source,
+            "utm_medium": medium,
+            "utm_campaign": campaign or lab.id,
+        }
+    )
+    return urlunparse(parts._replace(query=urlencode(query)))

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -30,3 +30,21 @@ def test_help_lists_core_commands() -> None:
 
 def test_i18n_catalogs_share_the_same_keys() -> None:
     assert set(en.STRINGS) == set(fr.STRINGS)
+
+
+def test_guide_is_listed_in_help() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "guide" in result.stdout
+
+
+def test_guide_help_mentions_the_print_option() -> None:
+    result = runner.invoke(app, ["guide", "--help"])
+    assert result.exit_code == 0
+    assert "--print" in result.stdout
+
+
+def test_fullhelp_documents_guide_in_both_languages() -> None:
+    """fullhelp must never omit a command that exists."""
+    for catalog in (en, fr):
+        assert "guide" in catalog.STRINGS["fullhelp_commands"]

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -6,6 +6,10 @@ the version flag and the i18n catalogs in isolation.
 
 from __future__ import annotations
 
+import re
+from typing import Any
+
+import typer.main
 from typer.testing import CliRunner
 
 from dsoxlab import __version__
@@ -14,34 +18,68 @@ from dsoxlab.i18n.strings import en, fr
 
 runner = CliRunner()
 
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(output: str) -> str:
+    """Terminal output with Rich's escape sequences stripped.
+
+    Rich styles fragments of a token, so a literal substring can be absent from
+    coloured output while being perfectly visible on screen: `0.1.16` is emitted
+    as `ESC[1;36m0.1ESC[0m.ESC[1;36m16ESC[0m`. Whether colour is enabled depends
+    on the environment, so asserting on raw output passes locally and fails in
+    CI. Strip the styling and assert on what the user actually reads.
+    """
+    return _ANSI.sub("", output)
+
 
 def test_version_flag_prints_version() -> None:
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
-    assert __version__ in result.stdout
+    assert __version__ in _plain(result.stdout)
 
 
 def test_help_lists_core_commands() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     for command in ("list-labs", "run", "check", "doctor"):
-        assert command in result.stdout
+        assert command in _plain(result.stdout)
 
 
 def test_i18n_catalogs_share_the_same_keys() -> None:
     assert set(en.STRINGS) == set(fr.STRINGS)
 
 
-def test_guide_is_listed_in_help() -> None:
-    result = runner.invoke(app, ["--help"])
-    assert result.exit_code == 0
-    assert "guide" in result.stdout
+def _params(command: str) -> dict[str | None, Any]:
+    """Parameters the parser really registered for a command, keyed by name.
+
+    This asserts the *contract* rather than the `--help` output. Rich styles the
+    help text, and under colour it splits a flag across escape sequences
+    (`--print` comes out as `ESC[1;36m-ESC[0mESC[1;36m-printESC[0m`), so a literal
+    substring search passes locally and fails in CI; terminal width truncates it
+    too. Nor can we lean on click's class hierarchy: `TyperGroup` does not
+    subclass `click.Group` in every version. The parser's own data is the only
+    stable thing here.
+    """
+    group = typer.main.get_command(app)
+    return {param.name: param for param in group.commands[command].params}
 
 
-def test_guide_help_mentions_the_print_option() -> None:
-    result = runner.invoke(app, ["guide", "--help"])
-    assert result.exit_code == 0
-    assert "--print" in result.stdout
+def test_guide_command_is_registered() -> None:
+    group = typer.main.get_command(app)
+
+    assert "guide" in group.commands
+
+
+def test_guide_declares_a_print_option() -> None:
+    flags = {flag for param in _params("guide").values() for flag in param.opts}
+
+    assert "--print" in flags
+
+
+def test_guide_takes_an_optional_lab_id() -> None:
+    """`dsoxlab guide` with no argument must fall back to the active lab."""
+    assert _params("guide")["lab_id"].required is False
 
 
 def test_fullhelp_documents_guide_in_both_languages() -> None:

--- a/tests/test_guide_service.py
+++ b/tests/test_guide_service.py
@@ -1,0 +1,88 @@
+"""Tests for the guide URL builder.
+
+The learner reads the course on the trainer's site, in a real browser tab, so
+the visit is counted by the site's own analytics. This module only composes the
+URL, and the campaign parameters are what make those visits attributable: a link
+clicked from a local interface carries `http://localhost:<port>` as referrer at
+best, nothing at all at worst.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+from dsoxlab.models.lab import LabDefinition, ValidationConfig
+from dsoxlab.models.runtime import RuntimeConfig, RuntimeType
+from dsoxlab.services import guide_url
+
+
+def _lab(lab_id: str = "lineinfile", doc_url: str = "https://example.test/guide/") -> LabDefinition:
+    return LabDefinition(
+        id=lab_id,
+        title=lab_id,
+        level="l1",
+        skills=["s"],
+        runtime=RuntimeConfig(type=RuntimeType.SHELL),
+        distros=["alma10"],
+        doc_url=doc_url,
+        validation=ValidationConfig(),
+    )
+
+
+def _params(url: str) -> dict[str, list[str]]:
+    return parse_qs(urlparse(url).query)
+
+
+def test_campaign_defaults_to_the_lab_id() -> None:
+    """This is what tells which lab sends readers to which guide."""
+    url = guide_url(_lab())
+    assert url is not None
+
+    assert _params(url) == {
+        "utm_source": ["dsoxlab"],
+        "utm_medium": ["lab"],
+        "utm_campaign": ["lineinfile"],
+    }
+
+
+def test_a_lab_without_doc_url_yields_none() -> None:
+    """An absent field is the caller's business to report, not ours to raise on."""
+    assert guide_url(_lab(doc_url="")) is None
+
+
+def test_existing_query_parameters_are_kept() -> None:
+    url = guide_url(_lab(doc_url="https://example.test/guide/?lang=fr"))
+    assert url is not None
+
+    assert _params(url)["lang"] == ["fr"]
+    assert _params(url)["utm_source"] == ["dsoxlab"]
+
+
+def test_anchor_survives_so_a_lab_can_target_a_section() -> None:
+    url = guide_url(_lab(doc_url="https://example.test/guide/#handlers"))
+    assert url is not None
+
+    assert urlparse(url).fragment == "handlers"
+    assert _params(url)["utm_campaign"] == ["lineinfile"]
+
+
+def test_the_page_itself_is_untouched() -> None:
+    """Only the query changes: same scheme, host and path."""
+    url = guide_url(_lab(doc_url="https://blog.example.test/docs/ansible/collections/"))
+    assert url is not None
+    parts = urlparse(url)
+
+    assert (parts.scheme, parts.netloc, parts.path) == (
+        "https",
+        "blog.example.test",
+        "/docs/ansible/collections/",
+    )
+
+
+def test_source_and_medium_can_be_overridden() -> None:
+    """A web front-end may want to distinguish itself from the CLI."""
+    url = guide_url(_lab(), source="dsoxlab-web", medium="lms")
+    assert url is not None
+
+    assert _params(url)["utm_source"] == ["dsoxlab-web"]
+    assert _params(url)["utm_medium"] == ["lms"]

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.15"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
# Summary

Ajoute `dsoxlab guide [<id>]`, qui ouvre le cours en ligne d'un lab dans le navigateur.

Le cours n'est pas embarqué dans le dépôt de labs : chaque lab déclare un `doc_url` qui pointe vers le site du formateur. Ouvrir la vraie page, plutôt que d'en rapatrier le contenu, la laisse s'afficher telle qu'elle est publiée (images, blocs de code, navigation) et évite d'avoir à suivre la structure HTML d'un site tiers.

```console
$ dsoxlab guide
ℹ Ouverture du guide de ecrire-code-lineinfile-vs-template dans le navigateur…
https://blog.stephane-robert.info/…/lineinfile-vs-template/?utm_source=dsoxlab&utm_medium=lab&utm_campaign=ecrire-code-lineinfile-vs-template
```

## Attribution des lectures

L'URL porte des paramètres de campagne (`utm_source=dsoxlab`, `utm_medium=lab`, `utm_campaign=<lab_id>`), ce qui permet de voir **quels labs amènent réellement des lecteurs vers quels guides**.

Ce marquage est nécessaire et pas décoratif : un lien suivi depuis une interface locale transmet au mieux `http://localhost:<port>` comme referrer, au pire rien du tout selon la politique du navigateur. Sans lui, ces lectures seraient indistinguables du trafic direct.

`guide_url()` est une fonction **pure** qui compose l'URL et n'ouvre rien : la CLI décide quoi en faire, et une future interface web pourra se distinguer via `source` / `medium` surchargeables. Les paramètres de requête déjà présents et les ancres `#section` sont préservés, donc un lab peut viser une section précise d'un guide.

## Deux détails d'usage

- **`--print`** écrit l'URL au lieu d'ouvrir un navigateur. C'est ce qu'on veut en SSH, où `webbrowser` n'a rien à ouvrir et rend `False` sans rien dire. Dans ce cas, l'URL reste affichée et un message le signale.
- **L'URL sort d'un seul tenant** (`soft_wrap`). Rich la coupait sur deux lignes, ce qui la rendait ni copiable ni exploitable dans un pipe.

## Type of change

- [x] New feature

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit)
- [x] `uv run mypy src/dsoxlab` passes (strict), 43 fichiers
- [x] `uv run pytest` passes, **60 passed** (51 avant, 9 ajoutés)
- [x] The engine stays domain-agnostic : `doc_url` est un champ du contrat, aucune logique de domaine
- [x] No hardcoded personal path or host : aucune URL codée en dur, tout vient de `lab.doc_url`
- [x] Manually tested against **two** lab repositories :
  - `ansible-training` : URL correcte avec campagne, FR et EN
  - `linux-dsoxlab-training` : idem, et `--print` vérifié dans un pipe

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.15 vers 0.1.16) and `uv lock` refreshed

### When a command or option is added, removed or changed

- [x] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py` (6 clés, parité vérifiée par script)
- [x] `help=_("…")` dans `cli.py` et section `fullhelp_commands` mise à jour en EN **et** FR
- [x] Vérifié avec `DSOXLAB_LANG=en` et `DSOXLAB_LANG=fr`
- [x] README **et** README.fr enrichis : table des commandes et section « Lire le cours »

### When `.github/workflows/` is touched

`N/A` : aucun workflow touché.

### When the declarative contract (`meta.yml` / `lab.yaml`) changes

`N/A` : contrat inchangé. `doc_url` existait déjà et est requis par le validator ; cette commande ne fait que l'exploiter.

## Related issues

Aucune.
