### PR TITLE
fix(terraform/kvm): fournir l'image cloud d'alma9 et d'ubuntu22

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,27 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.17] - 2026-07-20
+
+### Corrigé
+
+- **`alma9` et `ubuntu22` étaient déclarés mais inutilisables sur le provider
+  `kvm`.** Tous deux figurent dans la table Terraform `distro_to_template` : un
+  dépôt de labs pouvait donc légitimement écrire `distro: alma9` dans son
+  `meta.yml`, alors qu'aucun des deux n'avait d'entrée dans `default_image_urls`.
+  Le `coalesce()` qui résout l'image n'avait plus rien à quoi se raccrocher et le
+  plan échouait, sauf si le dépôt surchargeait à la main
+  `providers.kvm.image_url_<distro>`.
+
+  Les deux embarquent désormais leur image cloud amont, comme les distributions
+  déjà listées. Toute distribution que le provider mappe a de nouveau une URL ; le
+  provider `incus` gérait déjà `alma9` (`images:almalinux/9/cloud`), et `outscale`
+  attend légitimement une OMI pinée par le dépôt.
+
+  Le point compte particulièrement pour la formation RHCE : l'examen EX294 se passe
+  sur RHEL 9, donc un catalogue qui le vise a besoin que `alma9` fonctionne sans
+  bricolage.
+
 ## [0.1.16] - 2026-07-20
 
 ### Ajouté
@@ -412,7 +433,8 @@ Première version publique.
 - Diagnostics de l'environnement (`dsoxlab doctor [--fix]`).
 - Interface utilisateur bilingue (anglais/français) pilotée par `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.17...HEAD
+[0.1.17]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/stephrobert/dsoxlab/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/stephrobert/dsoxlab/compare/v0.1.13...v0.1.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17] - 2026-07-20
+
+### Fixed
+
+- **`alma9` and `ubuntu22` were declared but unusable on the `kvm` provider.** Both
+  appear in the Terraform `distro_to_template` map, so a lab repository could
+  legitimately write `distro: alma9` in its `meta.yml` — but neither had an entry in
+  `default_image_urls`. The `coalesce()` that resolves the image then had nothing to
+  fall back on and the plan failed, unless the repository happened to override
+  `providers.kvm.image_url_<distro>` by hand.
+
+  Both now ship their upstream cloud image, like the distributions already listed.
+  Every distribution the provider maps has a URL again; the `incus` provider already
+  handled `alma9` (`images:almalinux/9/cloud`), and `outscale` legitimately expects a
+  pinned OMI from the repository.
+
+  This matters for RHCE training in particular: the EX294 exam runs on RHEL 9, so a
+  catalogue targeting it needs `alma9` to work out of the box.
+
 ## [0.1.16] - 2026-07-20
 
 ### Added
@@ -387,7 +406,8 @@ Initial public release.
 - Environment diagnostics (`dsoxlab doctor [--fix]`).
 - Bilingual (English/French) user interface driven by `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.17...HEAD
+[0.1.17]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/stephrobert/dsoxlab/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/stephrobert/dsoxlab/compare/v0.1.13...v0.1.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.16"
+version = "0.1.17"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/templates/terraform/kvm/main.tf
+++ b/src/dsoxlab/templates/terraform/kvm/main.tf
@@ -34,7 +34,9 @@ locals {
   # peut surcharger via providers.kvm.image_url_<distro> dans meta.yml.
   default_image_urls = {
     alma10   = "https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/AlmaLinux-10-GenericCloud-latest.x86_64.qcow2"
+    alma9    = "https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2"
     ubuntu24 = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+    ubuntu22 = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
     debian12 = "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
   }
 

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
# Summary

`alma9` et `ubuntu22` étaient **déclarés mais inutilisables** sur le provider `kvm`.

Tous deux figurent dans la table Terraform `distro_to_template` : un dépôt de labs pouvait donc légitimement écrire `distro: alma9` dans son `meta.yml`. Mais aucun des deux n'avait d'entrée dans `default_image_urls`, si bien que le `coalesce()` qui résout l'image n'avait rien à quoi se raccrocher et que le plan échouait, sauf si le dépôt surchargeait à la main `providers.kvm.image_url_<distro>`.

Les deux embarquent désormais leur image cloud amont, comme les distributions déjà listées.

## Pourquoi maintenant

L'examen **RHCE EX294 se passe sur RHEL 9**. Un catalogue qui le vise a besoin qu'`alma9` fonctionne sans bricolage, et c'est exactement la bascule qu'engage `ansible-training`.

## État par provider

| Provider | `alma9` | Remarque |
|---|---|---|
| `kvm` | ✅ corrigé | l'URL manquait |
| `incus` | déjà géré | `images:almalinux/9/cloud` |
| `outscale` | inchangé | attend légitimement une OMI pinée par le dépôt |

Vérification faite : **plus aucune distribution mappée par le provider `kvm` n'est sans URL** (elles étaient deux à l'être). Les deux URLs amont répondent HTTP 200.

## Type of change

- [x] Bug fix

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes
- [x] `uv run mypy src/dsoxlab` passes (strict), 43 fichiers
- [x] `uv run pytest` passes, 61 passed
- [x] The engine stays domain-agnostic : une URL d'image cloud est une donnée d'infra, pas de domaine
- [x] No hardcoded personal path or host
- [x] Manually tested against **two** lab repositories : `ansible-training` et `linux-dsoxlab-training` (catalogues chargés, `validate-structure` vert)

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.16 vers 0.1.17) and `uv lock` refreshed

### When a command or option is added, removed or changed

`N/A` : aucune commande ni option touchée.

### When `.github/workflows/` is touched

`N/A` : aucun workflow touché.

### When the declarative contract (`meta.yml` / `lab.yaml`) changes

`N/A` : le contrat est inchangé. `distro: alma9` était déjà accepté par le contrat, c'est son implémentation côté `kvm` qui était incomplète.

## Note

`terraform fmt` signale un écart de formatage dans ce fichier, sur les blocs `locals` (l.59) et `libvirt_domain` (l.248). Il est **antérieur** à ce PR et hors des lignes touchées : je l'ai laissé pour garder le diff lisible. À traiter séparément si tu veux passer le dépôt au `fmt`.
