### PR TITLE
chore(release): 0.1.18

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,7 +9,12 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
-## [0.1.17] - 2026-07-20
+## [0.1.18] - 2026-07-20
+
+> **La 0.1.17 n'a jamais été publiée.** Son tag a été posé sur le commit de la
+> 0.1.16 : la Release GitHub `v0.1.17` porte donc des artefacts `dsoxlab-0.1.16`,
+> et PyPI est resté à la 0.1.16. Le correctif ci-dessous, annoncé pour la 0.1.17,
+> est livré par cette version.
 
 ### Corrigé
 
@@ -433,8 +438,8 @@ Première version publique.
 - Diagnostics de l'environnement (`dsoxlab doctor [--fix]`).
 - Interface utilisateur bilingue (anglais/français) pilotée par `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.17...HEAD
-[0.1.17]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...v0.1.17
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.18...HEAD
+[0.1.18]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...v0.1.18
 [0.1.16]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/stephrobert/dsoxlab/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/stephrobert/dsoxlab/compare/v0.1.13...v0.1.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.17] - 2026-07-20
+## [0.1.18] - 2026-07-20
+
+> **0.1.17 was never released.** Its tag landed on the 0.1.16 commit, so the
+> GitHub Release `v0.1.17` carries `dsoxlab-0.1.16` artifacts and PyPI stayed on
+> 0.1.16. The fix below, announced for 0.1.17, ships in this version instead.
 
 ### Fixed
 
@@ -406,8 +410,8 @@ Initial public release.
 - Environment diagnostics (`dsoxlab doctor [--fix]`).
 - Bilingual (English/French) user interface driven by `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.17...HEAD
-[0.1.17]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...v0.1.17
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.18...HEAD
+[0.1.18]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...v0.1.18
 [0.1.16]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/stephrobert/dsoxlab/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/stephrobert/dsoxlab/compare/v0.1.13...v0.1.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.17"
+version = "0.1.18"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
La 0.1.17 n'a jamais été publiée (tag posé sur le commit 0.1.16, artefacts 0.1.16 dans la Release GitHub, PyPI resté en 0.1.16). Le correctif alma9/ubuntu22 est livré par cette version. CHANGELOG EN+FR, bump, uv.lock.