### PR TITLE
fix(cloud-init): ne plus démarrer qemu-guest-agent au boot (--now)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,26 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.19] - 2026-07-20
+
+### Corrigé
+
+- **cloud-init finissait en `status: error` sur chaque nœud KVM, et `dsoxlab
+  provision` restait bloqué sur son attente.** Le runcmd lançait `systemctl enable
+  --now qemu-guest-agent`, or cette unité déclare
+  `BindsTo=dev-virtio\x2dports-org.qemu.guest_agent.0.device` et le provider KVM ne
+  déclare **aucun channel virtio**, délibérément (cf. la note dans
+  `templates/terraform/kvm/main.tf` : le schéma du provider libvirt le rendait
+  impraticable). Le device n'apparaît donc jamais : `--now` attendait **90 secondes
+  par nœud**, échouait, et le script runcmd sortait en 1, ce que cloud-init
+  rapporte comme un module `scripts_user` en échec.
+
+  Le nœud était pourtant pleinement fonctionnel (comptes créés, paquets installés,
+  sshd et firewalld actifs) : le symptôme était uniquement un provisionnement qui
+  ne rendait jamais la main. Retirer `--now` conserve l'activation pour le jour où
+  un channel existera, et la commande rend désormais la main en **0 s au lieu de
+  90**.
+
 ## [0.1.18] - 2026-07-20
 
 > **La 0.1.17 n'a jamais été publiée.** Son tag a été posé sur le commit de la
@@ -438,7 +458,8 @@ Première version publique.
 - Diagnostics de l'environnement (`dsoxlab doctor [--fix]`).
 - Interface utilisateur bilingue (anglais/français) pilotée par `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.18...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.19...HEAD
+[0.1.19]: https://github.com/stephrobert/dsoxlab/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...v0.1.18
 [0.1.16]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/stephrobert/dsoxlab/compare/v0.1.14...v0.1.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19] - 2026-07-20
+
+### Fixed
+
+- **cloud-init ended in `status: error` on every KVM node, and `dsoxlab provision`
+  hung on its readiness wait.** The runcmd ran `systemctl enable --now
+  qemu-guest-agent`, but that unit declares
+  `BindsTo=dev-virtio\x2dports-org.qemu.guest_agent.0.device` and the KVM provider
+  deliberately declares **no virtio channel** (see the note in
+  `templates/terraform/kvm/main.tf`: the libvirt provider's schema made it
+  impractical). The device therefore never appears: `--now` waited **90 seconds
+  per node**, failed, and the runcmd script exited 1 — which cloud-init reports as
+  a failed `scripts_user` module.
+
+  The node was fully functional throughout (accounts created, packages installed,
+  sshd and firewalld enabled), so the symptom was purely a provisioning that never
+  returned. Dropping `--now` keeps the unit enabled for the day a channel exists,
+  and the command now returns in **0 s instead of 90**.
+
 ## [0.1.18] - 2026-07-20
 
 > **0.1.17 was never released.** Its tag landed on the 0.1.16 commit, so the
@@ -410,7 +429,8 @@ Initial public release.
 - Environment diagnostics (`dsoxlab doctor [--fix]`).
 - Bilingual (English/French) user interface driven by `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.18...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.19...HEAD
+[0.1.19]: https://github.com/stephrobert/dsoxlab/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...v0.1.18
 [0.1.16]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/stephrobert/dsoxlab/compare/v0.1.14...v0.1.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.18"
+version = "0.1.19"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/templates/cloud-init/almalinux.yaml.tmpl
+++ b/src/dsoxlab/templates/cloud-init/almalinux.yaml.tmpl
@@ -91,4 +91,13 @@ runcmd:
   - [ usermod, -p, "*", ansible ]
   - [ systemctl, enable, --now, sshd ]
   - [ systemctl, enable, --now, firewalld ]
-  - [ systemctl, enable, --now, qemu-guest-agent ]
+  # `enable` SANS `--now` : l'unité déclare
+  # `BindsTo=dev-virtio\x2dports-org.qemu.guest_agent.0.device`, or le
+  # provider KVM ne déclare aucun channel virtio (cf. la note dans
+  # templates/terraform/kvm/main.tf). Le device n'existe donc jamais, et
+  # `--now` attendait 90 s avant d'échouer : le script runcmd sortait en 1,
+  # cloud-init finissait en `status: error`, et `dsoxlab provision` restait
+  # bloqué sur son attente alors que la VM était prête.
+  # L'activation est conservée : le jour où un channel est déclaré (ou sur
+  # un provider qui en fournit un), le service démarrera au boot.
+  - [ systemctl, enable, qemu-guest-agent ]

--- a/src/dsoxlab/templates/cloud-init/ubuntu.yaml.tmpl
+++ b/src/dsoxlab/templates/cloud-init/ubuntu.yaml.tmpl
@@ -69,7 +69,16 @@ runcmd:
   - [ usermod, -p, "*", student ]
   - [ usermod, -p, "*", ansible ]
   - [ systemctl, enable, --now, ssh ]
-  - [ systemctl, enable, --now, qemu-guest-agent ]
+  # `enable` SANS `--now` : l'unité déclare
+  # `BindsTo=dev-virtio\x2dports-org.qemu.guest_agent.0.device`, or le
+  # provider KVM ne déclare aucun channel virtio (cf. la note dans
+  # templates/terraform/kvm/main.tf). Le device n'existe donc jamais, et
+  # `--now` attendait 90 s avant d'échouer : le script runcmd sortait en 1,
+  # cloud-init finissait en `status: error`, et `dsoxlab provision` restait
+  # bloqué sur son attente alors que la VM était prête.
+  # L'activation est conservée : le jour où un channel est déclaré (ou sur
+  # un provider qui en fournit un), le service démarrera au boot.
+  - [ systemctl, enable, qemu-guest-agent ]
 
 # Sécurité par défaut : AppArmor reste activé. UFW est installé mais
 # pas activé par défaut — c'est aux labs LFCS de l'activer

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.18"
+version = "0.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
L'unité est BindsTo au channel virtio, que le provider KVM ne déclare pas : --now attendait 90 s par nœud puis échouait, cloud-init finissait en status: error et provision restait bloqué. Mesuré : rc=1 en 90 s -> rc=0 en 0 s. CHANGELOG EN+FR, bump 0.1.19, uv.lock.