### PR TITLE
fix(cloud-init,infra): installer lvm2 et attendre cloud-init avec sudo

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,25 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.20] - 2026-07-20
+
+### Corrigé
+
+- **`lvm2` est absent de l'image cloud AlmaLinux 9**, et tout lab de stockage
+  échouait sur `Failed to find required executable "vgs"` : pas au montage, mais dès
+  le premier appel de module LVM. Le commentaire du gabarit affirmait que « lvm2,
+  parted et xfsprogs sont dans l'image AlmaLinux Cloud » : vrai en 10, faux en 9. Il
+  dit désormais ce qui a été réellement vérifié sur la 9.8, et `lvm2` est installé
+  explicitement. Mesuré sur un catalogue de labs : **78 tests en erreur** dus à ce
+  seul paquet.
+
+- **`cloud-init status --wait` était lancé sans privilèges**, et sortait donc en
+  `PermissionError: /run/cloud-init/cloud.cfg` (rc=1) sur AlmaLinux 9. Le `|| true`
+  final avalait cet échec : `wait_for_hosts_ready` rendait la main *avant* la fin de
+  cloud-init tout en paraissant l'avoir attendue. C'est désormais `sudo -n`, qui
+  rend rc=0. Le `-n` garde la commande non interactive : un hôte où sudo réclamerait
+  un mot de passe bloquerait au lieu d'échouer.
+
 ## [0.1.19] - 2026-07-20
 
 ### Corrigé
@@ -458,7 +477,8 @@ Première version publique.
 - Diagnostics de l'environnement (`dsoxlab doctor [--fix]`).
 - Interface utilisateur bilingue (anglais/français) pilotée par `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.19...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.20...HEAD
+[0.1.20]: https://github.com/stephrobert/dsoxlab/compare/v0.1.19...v0.1.20
 [0.1.19]: https://github.com/stephrobert/dsoxlab/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...v0.1.18
 [0.1.16]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...v0.1.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20] - 2026-07-20
+
+### Fixed
+
+- **`lvm2` is missing from the AlmaLinux 9 cloud image**, and every storage lab
+  failed on `Failed to find required executable "vgs"` — not at mount time, but at
+  the very first LVM module call. The template's comment claimed "lvm2, parted and
+  xfsprogs ship in the AlmaLinux Cloud image": true on 10, false on 9. It now states
+  what was actually verified on 9.8, and installs `lvm2` explicitly. Measured on a
+  lab catalogue: **78 test errors** traced back to this single package.
+
+- **`cloud-init status --wait` was run without privileges**, so it exited
+  `PermissionError: /run/cloud-init/cloud.cfg` (rc=1) on AlmaLinux 9. The trailing
+  `|| true` swallowed that failure, so `wait_for_hosts_ready` returned *before*
+  cloud-init had finished while appearing to have waited for it. Now `sudo -n`,
+  which returns rc=0. `-n` keeps it non-interactive: a host where sudo asked for a
+  password would hang instead of failing.
+
 ## [0.1.19] - 2026-07-20
 
 ### Fixed
@@ -429,7 +447,8 @@ Initial public release.
 - Environment diagnostics (`dsoxlab doctor [--fix]`).
 - Bilingual (English/French) user interface driven by `DSOXLAB_LANG`.
 
-[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.19...HEAD
+[Unreleased]: https://github.com/stephrobert/dsoxlab/compare/v0.1.20...HEAD
+[0.1.20]: https://github.com/stephrobert/dsoxlab/compare/v0.1.19...v0.1.20
 [0.1.19]: https://github.com/stephrobert/dsoxlab/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/stephrobert/dsoxlab/compare/v0.1.16...v0.1.18
 [0.1.16]: https://github.com/stephrobert/dsoxlab/compare/v0.1.15...v0.1.16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.19"
+version = "0.1.20"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/infra/inventory.py
+++ b/src/dsoxlab/infra/inventory.py
@@ -327,9 +327,15 @@ def wait_for_hosts_ready(
     # `cloud-init status --wait` (best-effort) pour ne rendre la main qu'une fois
     # la VM entièrement configurée. Le `|| true` évite d'échouer sur un état
     # cloud-init « degraded » : ce qui compte, c'est qu'il ait terminé.
+    #
+    # `sudo -n` est indispensable : sans privilèges, la commande sort en
+    # `PermissionError: /run/cloud-init/cloud.cfg` (mesuré sur AlmaLinux 9), donc
+    # rc=1. Le `|| true` avalait cet échec et l'attente ne garantissait plus rien :
+    # on rendait la main avant la fin de cloud-init, en croyant l'avoir attendue.
+    # `-n` (non interactif) évite de bloquer si sudo réclamait un mot de passe.
     remote_cmd = (
         "command -v cloud-init >/dev/null 2>&1 "
-        "&& cloud-init status --wait >/dev/null 2>&1 || true"
+        "&& sudo -n cloud-init status --wait >/dev/null 2>&1 || true"
     )
 
     for fqdn in hosts:

--- a/src/dsoxlab/templates/cloud-init/almalinux.yaml.tmpl
+++ b/src/dsoxlab/templates/cloud-init/almalinux.yaml.tmpl
@@ -44,10 +44,11 @@ disable_root: true
 ssh_pwauth: false
 
 # Outils minimum pour les labs RHCSA — diagnostic et observabilité.
-# lvm2, parted, xfsprogs sont dans l'image AlmaLinux Cloud par défaut, mais
-# PAS firewalld (image minimale) : on l'installe explicitement, sinon tout lab
-# qui manipule le pare-feu échoue et `systemctl enable firewalld` plus bas cible
-# un service inexistant.
+# Ce que l'image cloud AlmaLinux fournit varie selon la MAJEURE : ne rien
+# supposer. parted, xfsprogs et e2fsprogs sont là en 9 comme en 10 ; firewalld
+# et lvm2 ne le sont pas (vérifié sur AlmaLinux 9.8), alors que la 10 livrait
+# lvm2. Sans eux, `systemctl enable firewalld` cible un service inexistant et
+# tout module LVM échoue sur « Failed to find required executable "vgs" ».
 packages:
   # openssh-server : NON préinstallé sur les images Incus cloud (Incus
   # assume incus exec via l'agent virtio). On l'installe pour avoir un
@@ -75,6 +76,10 @@ packages:
   # ports/contextes SELinux). Absente de l'image minimale, alors que c'est
   # l'outil RHCSA de référence pour SELinux (et ce que les tests inspectent).
   - policycoreutils-python-utils
+  # lvm2 : fournit vgs/lvs/pvs, requis par les modules community.general.lvg
+  # et lvol. Absent de l'image cloud AlmaLinux 9 (présent en 10) : sans lui,
+  # tout lab de stockage échoue au premier appel de module, pas au montage.
+  - lvm2
   # qemu-guest-agent : laisse libvirt récupérer l'IP via virtio channel
   # (``virsh domifaddr --source agent``). Indispensable côté provider kvm
   # quand on ne veut pas dépendre du DHCP lease (qui peut être lent ou

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
Deux défauts révélés par le passage à AlmaLinux 9. lvm2 absent de l'image 9 (présent en 10) : 78 tests en erreur, tout module LVM échouait sur « vgs » introuvable. cloud-init status --wait sans privilèges : PermissionError rc=1, avalé par le || true, donc l'attente ne garantissait plus rien. Mesuré : rc=0 avec sudo -n. CHANGELOG EN+FR, bump 0.1.20, uv.lock.