### PR TITLE
feat(runtimes,reporting): session locale pour les labs vm et sortie JSON

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,54 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.21] - 2026-07-22
+
+### Ajouté
+
+- **`runtime.session` dans `lab.yaml`** — un lab `vm` déclare désormais où
+  s'ouvre sa session interactive : `target` (défaut, session SSH sur
+  `targets[].host`, comportement inchangé) ou `local`, un sous-shell sur le
+  poste de l'apprenant, à la racine du dépôt.
+
+  Certains catalogues se pilotent **depuis** le poste et non **dans** la
+  machine : l'apprenant écrit son code dans le dépôt et lance ses commandes
+  vers les hôtes du lab, qui restent provisionnés et ciblés par le
+  `setup.yaml`. Pour ceux-là, `dsoxlab run` ouvrait une session SSH sur un
+  hôte ne contenant ni le dépôt ni ses outils : la session s'ouvrait, mais il
+  n'y avait rien à y faire. Le panneau d'accueil annonce maintenant où l'on
+  atterrit, et `validate-structure` refuse toute valeur hors des deux
+  acceptées, qui retomberait silencieusement sur le SSH.
+
+### Corrigé
+
+- **`dsoxlab run` annonçait un mauvais emplacement.** Le message de démarrage
+  affirmait « Vous êtes dans `challenge/work/` » quel que soit le runtime, y
+  compris pour les labs `vm`, où l'apprenant n'atterrit jamais dans ce
+  répertoire. Il nomme désormais l'endroit réel : le workdir pour `shell`,
+  l'hôte connecté pour une session `target`, la racine du dépôt pour une
+  session `local`. Le message `shell` lit en outre le vrai `runtime.workdir`
+  au lieu de supposer la valeur par défaut.
+
+- **Le panneau d'accueil listait des commandes intapables.** Pour un lab `vm`,
+  il affichait six commandes `dsoxlab …` puis ouvrait une session SSH sur
+  l'hôte du lab, où dsoxlab n'est pas installé et ne l'a jamais été : toutes
+  répondaient `command not found`. Le panneau nomme désormais l'hôte auquel
+  il va connecter et précise que ces commandes vivent sur le poste de
+  l'apprenant, derrière `exit`. Pour une session `local`, il nomme le
+  répertoire du lab auquel les chemins de la mission se rapportent, et amorce
+  par `dsoxlab challenge`.
+
+- **Sortie lisible par un programme** : `--json` sur `list-labs`, `progress`,
+  `check` et `status`. Chaque document porte une version de `schema`, et la
+  sortie standard ne contient rien d'autre que du JSON : les messages
+  d'ambiance, la barre de progression pytest et le rappel du contexte actif
+  sont tus dans ce mode.
+
+  C'est ce dont toute intégration a besoin : sans cela, une extension
+  d'éditeur, un tableau de bord ou un script de suivi devraient analyser la
+  sortie Rich, dont les tableaux, les couleurs et les retours à la ligne
+  dépendent de la largeur du terminal et ont vocation à changer.
+
 ## [0.1.20] - 2026-07-20
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21] - 2026-07-22
+
+### Added
+
+- **`runtime.session` in `lab.yaml`** — a `vm` lab can now declare where its
+  interactive session opens: `target` (default, SSH onto `targets[].host`,
+  unchanged behaviour) or `local`, a subshell on the learner's own machine, at
+  the repository root.
+
+  Some catalogues are driven *from* the workstation rather than *inside* the
+  machine: the learner writes code in the repository and runs commands against
+  the lab hosts, which stay provisioned and are still targeted by `setup.yaml`.
+  For those, `dsoxlab run` used to open an SSH session on a host holding
+  neither the repository nor its tooling — the session opened, but there was
+  nothing to do in it. The welcome panel now states where you landed, and
+  `validate-structure` rejects any value outside the two accepted ones, which
+  would otherwise fall back silently to SSH.
+
+### Fixed
+
+- **`dsoxlab run` announced the wrong location.** The ready message stated
+  "You are now in `challenge/work/`" for every runtime, including `vm` labs,
+  where that directory is never where the learner lands. It now names the
+  actual place: the workdir for `shell`, the connected host for a `target`
+  session, the repository root for a `local` one. The `shell` message also
+  reads the real `runtime.workdir` instead of assuming the default.
+
+- **The welcome panel listed commands that could not be typed.** For a `vm`
+  lab it displayed six `dsoxlab …` commands and then opened an SSH session on
+  the lab host, where dsoxlab is not installed and never has been: every one
+  of them answered `command not found`. The panel now names the host it is
+  about to connect to and states that those commands live on the learner's
+  own machine, behind `exit`. For a `local` session it names the lab
+  directory the mission paths are relative to, and points to `dsoxlab
+  challenge` as the starting point.
+
+- **Machine-readable output**: `--json` on `list-labs`, `progress`, `check` and
+  `status`. Each document carries a `schema` version, and standard output holds
+  nothing but JSON — the ambient messages, the pytest progress bar and the
+  active-context notice are all silenced in that mode.
+
+  This is what any integration needs: an editor extension, a dashboard or a
+  tracking script would otherwise have to parse the Rich output, whose tables,
+  colours and line wrapping depend on the terminal width and are meant to keep
+  changing.
+
 ## [0.1.20] - 2026-07-20
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.20"
+version = "0.1.21"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -72,6 +72,7 @@ from .models import (
     ProviderUnresolved,
     RepoMetadata,
 )
+from .reporting import machine
 from .runtimes.base import EventCallback
 from .services import (
     CheckResult,
@@ -427,6 +428,7 @@ def list_labs(
     section: Annotated[Optional[str], typer.Option("--section", "-s", help=_("opt_section"))] = None,
     lab_type: Annotated[Optional[str], typer.Option("--type", "-t", help=_("opt_type"))] = None,
     bloc: Annotated[Optional[int], typer.Option("--bloc", "-b", help=_("opt_bloc"))] = None,
+    as_json: Annotated[bool, typer.Option("--json", help=_("opt_json"))] = False,
 ) -> None:
     root = _root(lab_home)
     ctx = read_context(root)
@@ -434,7 +436,9 @@ def list_labs(
     effective_section = section or ctx.section
     effective_level = level or ctx.level
 
-    if ctx.section or ctx.level:
+    # En mode machine, aucun message d'ambiance : la sortie doit être un
+    # document JSON et rien d'autre.
+    if (ctx.section or ctx.level) and not as_json:
         info(_("context_active", label=ctx.label()))
 
     lang = _lang(root)
@@ -449,6 +453,12 @@ def list_labs(
         labs = [lab for lab in labs if lab.bloc == bloc]
     lab_ids = [lab.id for lab in labs]
     scores = get_best_scores(root, lab_ids)
+    if as_json:
+        machine.emit({
+            "labs": [machine.lab_dict(lab, scores.get(lab.id)) for lab in labs],
+            "count": len(labs),
+        })
+        return
     print_labs_table(labs, scores)
 
 
@@ -511,7 +521,24 @@ def run(
         raise typer.Exit(2)
 
     set_active_lab(root, lab.id)
-    success(_("lab_ready", lab_id=lab.id))
+    # Dire où l'on atterrit vraiment. Le message historique annonçait
+    # « challenge/work/ » quel que soit le runtime : faux pour tout lab vm,
+    # qui ouvre une session SSH ou, désormais, un shell à la racine du dépôt.
+    if lab.runtime.type.value in ("vm", "kvm", "incus"):
+        if lab.runtime.session == "local":
+            success(_("lab_ready_local", lab_id=lab.id))
+        else:
+            resolved = lab.runtime.target(target)
+            success(_("lab_ready_target", lab_id=lab.id,
+                      host=resolved.host if resolved else "?"))
+    else:
+        success(_("lab_ready", lab_id=lab.id, workdir=lab.runtime.workdir))
+    # La session SSH s'ouvre sur un hôte dépourvu de dsoxlab : une fois dedans,
+    # l'apprenant ne peut plus afficher sa mission. On la lui met sous les yeux
+    # avant d'entrer, elle reste dans le défilement du terminal.
+    if lab.runtime.type.value in ("vm", "kvm", "incus") and lab.runtime.session != "local":
+        print_lab_challenge(lab, lang=lang)
+
     print_lab_welcome(lab)
 
     open_lab_session(lab)   # bloquant : sous-shell interactif
@@ -520,7 +547,15 @@ def run(
     # ``dsoxlab check`` et ``dsoxlab submit`` (sans argument) sachent
     # quel lab valider. L'active_lab est libéré au submit (cf. cmd
     # submit) ou écrasé par un prochain ``dsoxlab run <autre_lab>``.
-    success(_("lab_session_ended", lab_id=lab.id))
+    # En session locale, on n'a jamais quitté son répertoire : annoncer un
+    # « retour » n'aurait aucun sens. Ce qui compte alors, c'est que le travail
+    # reste là et que check puisse être relancé.
+    if lab.runtime.session == "local":
+        success(_("lab_session_ended_local", lab_id=lab.id))
+    else:
+        success(_("lab_session_ended", lab_id=lab.id))
+
+
 
 
 # ── course ───────────────────────────────────────────────────────────────────
@@ -536,6 +571,8 @@ def course(
     root = _root(lab_home)
     lang = _lang(root)
     lab = _resolve_lab(root, lab_id, lang)
+
+
     manifest = CourseManifest.load(lab.path, lang=lang)
 
     if manifest is None:
@@ -695,7 +732,7 @@ def _resolve_lab(
 
 
 def _run_check_with_progress(
-    lab: LabDefinition, target: str | None = None
+    lab: LabDefinition, target: str | None = None, *, quiet: bool = False,
 ) -> CheckResult:
     """Lance ``check_lab`` en streamant les verdicts pytest dans une
     progress bar Rich.
@@ -716,6 +753,12 @@ def _run_check_with_progress(
     )
 
     state: dict[str, Any] = {"done": 0, "task_id": None}
+
+    # Mode machine : la barre et les verdicts partent sur stdout et
+    # rendraient le document JSON illisible. On lance les tests sans rien
+    # afficher — mesuré, sans cela la sortie commence par « ℹ Validation… ».
+    if quiet:
+        return check_lab(lab, target=target)
 
     with Progress(
         SpinnerColumn(),
@@ -763,7 +806,7 @@ def _run_check_with_progress(
 
 
 def _run_check(
-    root: Path, lab: LabDefinition, target: str | None = None
+    root: Path, lab: LabDefinition, target: str | None = None, *, quiet: bool = False,
 ) -> tuple[CheckResult, int, int]:
     """Lance les tests, enregistre le résultat, retourne (result, score, max_score).
 
@@ -806,14 +849,20 @@ def _run_check(
         if session_target and lab.runtime.target(session_target) is not None:
             target = session_target
 
-    info(_("validating", lab_id=lab.id))
-    result = _run_check_with_progress(lab, target)
+    if not quiet:
+        info(_("validating", lab_id=lab.id))
+    result = _run_check_with_progress(lab, target, quiet=quiet)
     if not result.ok:
         # En cas d'échec, dump l'output brut (tracebacks, summary pytest)
         # pour que l'apprenant voie les erreurs détaillées.
         console.print(result.output)
 
     evaluation = evaluate_lab(root, lab, result)
+    if quiet:
+        # Mode machine : le tableau Rich et le message de confirmation
+        # pollueraient le document JSON. Le résultat est tout de même
+        # enregistré, comme dans le mode normal.
+        return result, evaluation.score, evaluation.max_score
     print_check_result(
         lab.id,
         result.passed,
@@ -834,11 +883,29 @@ def check(
     lab_id: Annotated[Optional[str], typer.Argument(help=_("cmd_check_arg"), shell_complete=_complete_lab_id)] = None,
     target: Annotated[Optional[str], typer.Option("--target", "-t",
         help=_("opt_check_target"))] = None,
+    as_json: Annotated[bool, typer.Option("--json", help=_("opt_json"))] = False,
     lab_home: LabHomeOption = None,
 ) -> None:
     root = _root(lab_home)
     lab = _resolve_lab(root, lab_id, _lang(root))
-    result, _score, _max_score = _run_check(root, lab, target)
+    result, score, max_score = _run_check(root, lab, target, quiet=as_json)
+    if as_json:
+        # La sortie brute de pytest est conservée : c'est là que l'appelant
+        # trouve le détail des échecs, qu'aucun compteur ne résume.
+        machine.emit({
+            "lab": machine.lab_dict(lab),
+            "check": {
+                "ok": result.ok,
+                "passed": result.passed,
+                "total": result.total,
+                "score": score,
+                "max_score": max_score,
+                "output": result.output,
+            },
+        })
+        if not result.ok:
+            raise typer.Exit(1)
+        return
     if result.ok:
         success(_("all_tests_passed"))
         info(_("check_tip_submit"))
@@ -900,6 +967,7 @@ def progress(
     lab_home: LabHomeOption = None,
     section: Annotated[Optional[str], typer.Option("--section", "-s", help=_("opt_section"))] = None,
     level: Annotated[Optional[str], typer.Option("--level", "-l", help=_("opt_level"))] = None,
+    as_json: Annotated[bool, typer.Option("--json", help=_("opt_json"))] = False,
 ) -> None:
     root = _root(lab_home)
     ctx = read_context(root)
@@ -919,6 +987,18 @@ def progress(
 
     lab_ids = [lab.id for lab in labs]
     scores_data = get_best_scores(root, lab_ids)
+    if as_json:
+        faits = [i for i in lab_ids if i in scores_data]
+        machine.emit({
+            "labs": [machine.lab_dict(lab, scores_data.get(lab.id)) for lab in labs],
+            "summary": {
+                "total": len(labs),
+                "attempted": len(faits),
+                "points": sum(scores_data[i][0] for i in faits),
+                "max_points": sum(scores_data[i][1] for i in faits),
+            },
+        })
+        return
     print_progress_table(labs, scores_data)
 
 
@@ -1066,6 +1146,7 @@ def doctor(
 
     # Shell runtime
     checks.append((_("check_shell"), True, _("detail_shell_always"), None))
+
 
     # Incus : binaire + daemon + permissions user + init storage/network.
     # Le simple ``which incus`` ne suffit pas : sans daemon actif ni
@@ -1650,6 +1731,7 @@ def _run_terraform_with_progress(
 @app.command("status", help=_("cmd_status_help"))
 def status(
     lab_home: LabHomeOption = None,
+    as_json: Annotated[bool, typer.Option("--json", help=_("opt_json"))] = False,
 ) -> None:
     """Vérifie la connectivité SSH des hosts du meta.yml."""
     from .infra.inventory import build_inventory, read_terraform_outputs
@@ -1678,7 +1760,9 @@ def status(
         error(_("status_no_key", path=ssh_key))
         raise typer.Exit(1)
 
-    info(_("status_checking", count=len(hosts_dict)))
+    hotes: list[dict[str, Any]] = []
+    if not as_json:
+        info(_("status_checking", count=len(hosts_dict)))
     if bastion:
         info(_("status_via_bastion",
                bastion=bastion["fqdn"] or bastion["public_ip"]))
@@ -1719,14 +1803,30 @@ def status(
             ]
         cmd += [f"{host_vars.get('ansible_user', 'ansible')}@{ip}", "true"]
         result = subprocess.run(cmd, capture_output=True, timeout=15)  # noqa: S603
-        if result.returncode == 0:
+        joignable = result.returncode == 0
+        raison = None
+        if not joignable:
+            stderr_tail = result.stderr.decode(errors="replace").strip().splitlines()[-1:]
+            raison = stderr_tail[0] if stderr_tail else "timeout"
+        hotes.append({"fqdn": fqdn, "ip": ip, "reachable": joignable, "reason": raison})
+        if as_json:
+            ok_count += 1 if joignable else 0
+            continue
+        if joignable:
             success(f"  ✔ {fqdn} ({ip})")
             ok_count += 1
         else:
-            stderr_tail = result.stderr.decode(errors="replace").strip().splitlines()[-1:]
-            reason = stderr_tail[0] if stderr_tail else "timeout"
-            error(f"  ✘ {fqdn} ({ip}) — {reason}")
+            error(f"  ✘ {fqdn} ({ip}) — {raison}")
 
+    if as_json:
+        machine.emit({
+            "provider": provider,
+            "hosts": hotes,
+            "summary": {"reachable": ok_count, "total": len(hosts_dict)},
+        })
+        if ok_count != len(hosts_dict):
+            raise typer.Exit(1)
+        return
     if ok_count == len(hosts_dict):
         success(_("status_all_ok", count=ok_count))
     else:

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -7,6 +7,7 @@ STRINGS: dict[str, str] = {
     # ── Global options ────────────────────────────────────────────────────────
     "opt_help":     "Show this message and exit.",
     "opt_lab_home": "Root of the linux-training repo (default: auto-detected).",
+    "opt_json":           "JSON output, meant for programs (editor extension, dashboard). Nothing else is printed.",
     "opt_level":    "Filter by level (l1, l2, lfcs, rhcsa)",
     "opt_section":  "Filter by section (linux, ansible, terraform, docker…)",
     "opt_type":     "Filter by type: lab, challenge or capstone",
@@ -271,7 +272,9 @@ Lab titles and descriptions can be displayed in different languages.
 
     # ── run ───────────────────────────────────────────────────────────────────
     "lab_starting":       "Starting lab [bold]{lab_id}[/bold] (runtime: {runtime})…",
-    "lab_ready":          "Lab {lab_id} ready. You are now in [bold]challenge/work/[/bold] — your isolated working directory.",
+    "lab_ready":          "Lab {lab_id} ready. You are now in [bold]{workdir}/[/bold] — your isolated working directory.",
+    "lab_ready_local":    "Lab {lab_id} ready. You are on [bold]your own machine[/bold], at the repository root.",
+    "lab_ready_target":   "Lab {lab_id} ready. You are connected to [bold]{host}[/bold].",
     "lab_subshell_tip":   "Type [bold]dsoxlab check[/bold] to validate your work, or [bold]exit[/bold] to leave the session.",
     "lab_welcome_title":  "How this lab works",
     "lab_welcome_course": "[bold cyan]dsoxlab course[/bold cyan] [dim][<id>][/dim]   Read the guided exercises ([dim]scenario.md[/dim]).",
@@ -279,8 +282,14 @@ Lab titles and descriptions can be displayed in different languages.
     "lab_welcome_check":  "[bold cyan]dsoxlab check[/bold cyan] [dim][<id>][/dim]   Run tests and show your score — [bold]nothing is saved[/bold].",
     "lab_welcome_submit": "[bold cyan]dsoxlab submit[/bold cyan] [dim][<id>][/dim]  Final submission: run tests, [bold]save result[/bold] to database, then [bold]exit[/bold] the session.",
     "lab_welcome_hint":   "[bold cyan]dsoxlab hint[/bold cyan] [dim][<id>][/dim]   Reveal the next hint — [red]deducts points[/red] from your final score.",
+    "lab_welcome_session_local": "You are on [bold]your own machine[/bold], at the repository root: this is where you write your code and run your commands against the lab hosts.",
     "lab_welcome_exit":   "Type [bold]exit[/bold] at any time to leave the session without saving.",
+    "lab_welcome_session_target": "You are about to be connected to [bold]{host}[/bold]: work there as on a real machine.",
+    "lab_welcome_commands_here": "Your mission is printed just above: dsoxlab does not exist on the lab host, so keep it in sight. The commands below run from [bold]your own machine[/bold] — after [bold]exit[/bold], or in a second terminal.",
+    "lab_welcome_labdir":  "The lab lives in [bold]{labdir}/[/bold]: the paths in the mission are relative to that directory.",
+    "lab_welcome_start_here": "Start with [bold]dsoxlab challenge[/bold]: the mission states which files to create and what will be checked.",
     "lab_session_ended":  "Session ended for [bold]{lab_id}[/bold]. Back to your original directory.",
+    "lab_session_ended_local": "Session ended for [bold]{lab_id}[/bold]. Your work is kept: run [bold]dsoxlab check[/bold] again whenever you want.",
     "no_active_lab":      "No active lab in session. Run [bold]dsoxlab run <id>[/bold] first, or pass the lab identifier explicitly.",
     "course_missing":      "No scenario.md file found for this lab.",
     "course_tip":          "Challenge ready: dsoxlab challenge {id}",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -7,6 +7,7 @@ STRINGS: dict[str, str] = {
     # ── Options globales ──────────────────────────────────────────────────────
     "opt_help":       "Affiche ce message et quitte.",
     "opt_lab_home":   "Racine du dépôt linux-training (défaut : auto-détecté).",
+    "opt_json":           "Sortie JSON, destinée aux programmes (extension d'éditeur, tableau de bord). Aucun autre affichage.",
     "opt_level":      "Filtre par niveau (l1, l2, lfcs, rhcsa)",
     "opt_section":    "Filtre par section (linux, ansible, terraform, docker…)",
     "opt_type":       "Filtre par type : lab, challenge ou capstone",
@@ -269,7 +270,9 @@ Les titres et descriptions des labs peuvent s'afficher dans plusieurs langues.
 
     # ── run ───────────────────────────────────────────────────────────────────
     "lab_starting":       "Démarrage du lab [bold]{lab_id}[/bold] (runtime: {runtime})…",
-    "lab_ready":          "Lab {lab_id} prêt. Vous êtes dans [bold]challenge/work/[/bold] — votre répertoire de travail isolé.",
+    "lab_ready":          "Lab {lab_id} prêt. Vous êtes dans [bold]{workdir}/[/bold], votre répertoire de travail isolé.",
+    "lab_ready_local":    "Lab {lab_id} prêt. Vous êtes sur [bold]votre poste[/bold], à la racine du dépôt.",
+    "lab_ready_target":   "Lab {lab_id} prêt. Vous êtes connecté à [bold]{host}[/bold].",
     "lab_subshell_tip":   "Tapez [bold]dsoxlab check[/bold] pour valider votre travail, ou [bold]exit[/bold] pour quitter la session.",
     "lab_welcome_title":  "Comment fonctionne ce lab",
     "lab_welcome_course": "[bold cyan]dsoxlab course[/bold cyan] [dim][<id>][/dim]   Affiche les exercices guidés ([dim]scenario.md[/dim]).",
@@ -277,8 +280,14 @@ Les titres et descriptions des labs peuvent s'afficher dans plusieurs langues.
     "lab_welcome_check":  "[bold cyan]dsoxlab check[/bold cyan] [dim][<id>][/dim]   Lance les tests et affiche votre score — [bold]rien n'est enregistré[/bold].",
     "lab_welcome_submit": "[bold cyan]dsoxlab submit[/bold cyan] [dim][<id>][/dim]  Soumission finale : lance les tests, [bold]enregistre le résultat[/bold] en base, puis [bold]quitte[/bold] la session.",
     "lab_welcome_hint":   "[bold cyan]dsoxlab hint[/bold cyan] [dim][<id>][/dim]   Révèle l'indice suivant — [red]déduit des points[/red] de votre score final.",
+    "lab_welcome_session_local": "Vous êtes sur [bold]votre poste[/bold], à la racine du dépôt : c'est d'ici que vous écrivez votre code et lancez vos commandes vers les hôtes du lab.",
     "lab_welcome_exit":   "Tapez [bold]exit[/bold] à tout moment pour quitter la session sans enregistrer.",
+    "lab_welcome_session_target": "Vous allez être connecté à [bold]{host}[/bold] : travaillez-y comme sur une machine réelle.",
+    "lab_welcome_commands_here": "Votre mission est affichée juste au-dessus : dsoxlab n'existe pas sur la machine, gardez-la sous les yeux. Les commandes ci-dessous se lancent depuis [bold]votre poste[/bold] — après [bold]exit[/bold], ou dans un second terminal.",
+    "lab_welcome_labdir":  "Le lab vit dans [bold]{labdir}/[/bold] : les chemins de la mission sont relatifs à ce répertoire.",
+    "lab_welcome_start_here": "Commencez par [bold]dsoxlab challenge[/bold] : la mission dit quels fichiers créer et ce qui sera vérifié.",
     "lab_session_ended":  "Session terminée pour [bold]{lab_id}[/bold]. Retour à votre répertoire d'origine.",
+    "lab_session_ended_local": "Session terminée pour [bold]{lab_id}[/bold]. Votre travail est conservé : relancez [bold]dsoxlab check[/bold] quand vous voulez.",
     "no_active_lab":      "Aucun lab actif en session. Exécutez [bold]dsoxlab run <id>[/bold] d'abord, ou passez l'identifiant explicitement.",
     "course_missing":      "Aucun fichier scenario.md trouvé pour ce lab.",
     "course_tip":          "Challenge prêt : dsoxlab challenge {id}",

--- a/src/dsoxlab/models/lab.py
+++ b/src/dsoxlab/models/lab.py
@@ -109,6 +109,7 @@ class LabDefinition:
             targets=targets,
             default=str(runtime_data.get("default", "")),
             snapshot_required=bool(runtime_data.get("snapshot_required", False)),
+            session=str(runtime_data.get("session", "target")),
             workdir=runtime_data.get("workdir", "challenge/work"),
             fixtures=as_str_list(runtime_data.get("fixtures"), "runtime.fixtures", lab_yaml),
             topology=runtime_data.get("topology", "local"),

--- a/src/dsoxlab/models/runtime.py
+++ b/src/dsoxlab/models/runtime.py
@@ -97,6 +97,22 @@ class RuntimeConfig:
     """Si True, ``dsoxlab run`` prend un snapshot avant le ``setup.yaml``
     pour permettre un rollback simple via ``dsoxlab restore``."""
 
+    session: str = "target"
+    """Où s'ouvre la session interactive de ``dsoxlab run``.
+
+    - ``target`` (défaut) : session SSH sur ``targets[].host``. L'apprenant
+      travaille **dans** la machine, cas des labs système.
+    - ``local`` : sous-shell sur le poste, à la racine du dépôt. Le poste est
+      alors le poste de pilotage : l'apprenant y écrit son code et lance ses
+      commandes vers les hôtes du lab, qui restent provisionnés et ciblés par
+      le ``setup.yaml``.
+
+    Ce choix n'a de sens que pour ``runtime: vm`` : un lab ``shell`` ouvre
+    déjà un sous-shell local, dans son ``workdir``.
+
+    Sans ce champ, un lab piloté depuis le poste déposait l'apprenant en SSH
+    sur un hôte qui ne contient ni le dépôt ni ses outils."""
+
     # ── Pour runtime: shell ───────────────────────────────────────────
     workdir: str = "challenge/work"
     """Chemin relatif du répertoire de travail créé par ``dsoxlab run``.

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -456,7 +456,33 @@ def print_lab_welcome(lab: LabDefinition) -> None:
     from rich.panel import Panel
 
     title = _("lab_welcome_title")
-    lines = [
+    lines = []
+    # Dire où l'on atterrit ET où travailler. Sans ces deux lignes, l'apprenant
+    # arrive dans un shell à la racine du dépôt sans savoir quel répertoire le
+    # concerne : le panneau listait des commandes, jamais un point de départ.
+    if lab.runtime.session == "local":
+        parts = lab.path.parts
+        labdir = (
+            "/".join(parts[parts.index("labs"):]) if "labs" in parts else lab.path.name
+        )
+        lines += [
+            _("lab_welcome_session_local"),
+            _("lab_welcome_labdir", labdir=labdir),
+            "",
+            _("lab_welcome_start_here"),
+            "",
+        ]
+    elif lab.runtime.type.value in ("vm", "kvm", "incus"):
+        # La session s'ouvre en SSH sur la VM, où dsoxlab n'est PAS installé.
+        # Sans cet avertissement, le panneau annonce six commandes juste avant
+        # de déposer l'apprenant là où aucune ne répond.
+        tgt = lab.runtime.target()
+        lines += [
+            _("lab_welcome_session_target", host=tgt.host if tgt else "?"),
+            _("lab_welcome_commands_here"),
+            "",
+        ]
+    lines += [
         _("lab_welcome_course"),
         _("lab_welcome_challenge"),
         "",

--- a/src/dsoxlab/reporting/machine.py
+++ b/src/dsoxlab/reporting/machine.py
@@ -1,0 +1,68 @@
+"""Sorties JSON, destinées aux programmes et non aux yeux.
+
+Toute intégration — extension d'éditeur, tableau de bord web, script de suivi —
+a besoin de lire l'état du catalogue et de la progression. Sans ce module, elle
+devrait analyser la sortie Rich : des tableaux dont la largeur dépend du
+terminal, des couleurs, des retours à la ligne. Le moindre ajustement
+d'affichage casserait l'intégration, et l'affichage est fait pour bouger.
+
+Deux règles tiennent ce contrat :
+
+1. **Rien d'autre que du JSON sur la sortie standard.** En mode machine, les
+   messages d'ambiance (contexte actif, astuces) sont tus : un « ℹ » en tête de
+   flux rendrait le document illisible pour l'appelant.
+2. **Le format est versionné.** Chaque document porte un ``schema``, pour qu'un
+   consommateur sache s'il parle la même langue avant de lire le reste.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from ..models.lab import LabDefinition
+
+#: Version du format. À incrémenter dès qu'un champ change de sens ou disparaît
+#: — un ajout de champ, lui, reste compatible.
+SCHEMA = 1
+
+
+def emit(payload: dict[str, Any]) -> None:
+    """Écrit un document JSON sur la sortie standard, et rien d'autre."""
+    json.dump({"schema": SCHEMA, **payload}, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+
+
+def lab_dict(
+    lab: LabDefinition, score: tuple[int, int] | None = None
+) -> dict[str, Any]:
+    """Représentation d'un lab : ce qu'une interface a besoin de savoir.
+
+    Le chemin est absolu et le ``doc_url`` conservé : une extension d'éditeur
+    doit pouvoir ouvrir les fichiers du lab et le guide en ligne sans avoir à
+    reconstruire quoi que ce soit.
+    """
+    target = lab.runtime.target()
+    return {
+        "id": lab.id,
+        "title": lab.title,
+        "section": lab.section,
+        "level": lab.level,
+        "type": lab.lab_type,
+        "difficulty": lab.difficulty or None,
+        "estimated_time": lab.estimated_time or None,
+        "skills": list(lab.skills),
+        "distros": list(lab.distros),
+        "doc_url": lab.doc_url,
+        "path": str(lab.path),
+        "runtime": {
+            "type": lab.runtime.type.value,
+            "session": lab.runtime.session,
+            "target": target.host if target else None,
+            "workdir": lab.runtime.workdir,
+        },
+        # (obtenu, maximum) plutôt qu'un pourcentage : l'appelant décide de sa
+        # présentation, et un lab jamais tenté se distingue d'un lab à zéro.
+        "best_score": None if score is None else {"points": score[0], "max": score[1]},
+    }

--- a/src/dsoxlab/runtimes/vm.py
+++ b/src/dsoxlab/runtimes/vm.py
@@ -161,8 +161,20 @@ class VmRuntime(BaseRuntime):
         """
         from ..infra.inventory import bastion_info, build_inventory, read_terraform_outputs
 
-        target = self._resolve_target(lab, None)
         repo_meta = self._repo_meta(lab)
+
+        if lab.runtime.session == "local":
+            # Lab piloté depuis le poste : les hôtes restent provisionnés et
+            # travaillés par le setup.yaml, mais l'apprenant écrit son code ici,
+            # et ses commandes visent les cibles depuis la racine du dépôt —
+            # c'est de là que les chemins des énoncés sont relatifs.
+            return SessionSpec(
+                command=[os.environ.get("SHELL", "bash")],
+                cwd=repo_meta.path,
+                env={"DSOXLAB_LAB_SESSION": lab.id},
+            )
+
+        target = self._resolve_target(lab, None)
         tf_outputs = read_terraform_outputs(repo_meta)
         inventory = build_inventory(
             repo_meta,

--- a/src/dsoxlab/validators/structure.py
+++ b/src/dsoxlab/validators/structure.py
@@ -85,6 +85,20 @@ def validate_structure(lab: LabDefinition) -> StructureReport:
                         ),
                     )
                 )
+        # runtime.session : énuméré. Une valeur libre passerait silencieusement
+        # et retomberait sur la session SSH, soit l'inverse de l'intention.
+        if lab.runtime.session not in ("target", "local"):
+            report.issues.append(
+                StructureIssue(
+                    path=base / "lab.yaml",
+                    message=(
+                        f"runtime.session='{lab.runtime.session}' inconnu. "
+                        "Valeurs acceptées : 'target' (session SSH sur "
+                        "targets[].host, défaut) ou 'local' (sous-shell sur le "
+                        "poste, pour un lab piloté depuis le dépôt)."
+                    ),
+                )
+            )
         # Présence interdite de scripts bash legacy (signal de migration
         # incomplète vers le tout-déclaratif).
         _forbid_file(base / "cleanup.sh", report,

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,0 +1,81 @@
+"""Le contrat de la sortie machine.
+
+Une intégration — extension d'éditeur, tableau de bord — lit ces documents. Ce
+qui les casse ne se voit pas en utilisant la CLI à la main : d'où ces tests.
+
+Deux exigences, et une seule compte vraiment : que la sortie standard ne
+contienne QUE du JSON. Un message d'ambiance en tête de flux suffit à rendre le
+document illisible pour l'appelant, et c'est arrivé trois fois en l'écrivant :
+« ℹ Validation de… », la barre de progression pytest, puis le contexte actif.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dsoxlab.models.lab import LabDefinition, ValidationConfig
+from dsoxlab.models.runtime import RuntimeConfig, RuntimeType, Target
+from dsoxlab.reporting import machine
+
+
+def _lab() -> LabDefinition:
+    return LabDefinition(
+        id="demo-lab",
+        title="Demo",
+        level="l1",
+        skills=["swap"],
+        runtime=RuntimeConfig(
+            type=RuntimeType.VM,
+            targets=[Target(name="t", host="node1.lab")],
+            session="local",
+        ),
+        distros=["alma9"],
+        doc_url="https://example.test/doc",
+        validation=ValidationConfig(),
+        path=Path("/repo/labs/demo"),
+    )
+
+
+def test_the_document_is_versioned() -> None:
+    """Un consommateur doit savoir s'il parle la même langue avant de lire."""
+    assert machine.SCHEMA >= 1
+
+
+def test_a_lab_carries_what_an_editor_needs(capsys) -> None:
+    machine.emit({"labs": [machine.lab_dict(_lab(), (60, 100))]})
+    doc = json.loads(capsys.readouterr().out)
+
+    lab = doc["labs"][0]
+    assert doc["schema"] == machine.SCHEMA
+    assert lab["id"] == "demo-lab"
+    assert lab["path"] == "/repo/labs/demo", "chemin absolu : l'éditeur ouvre les fichiers"
+    assert lab["doc_url"].startswith("http")
+    assert lab["runtime"] == {
+        "type": "vm", "session": "local", "target": "node1.lab",
+        "workdir": "challenge/work",
+    }
+    assert lab["best_score"] == {"points": 60, "max": 100}
+
+
+def test_a_lab_never_attempted_is_not_a_zero(capsys) -> None:
+    """Distinguer « jamais tenté » de « tenté et raté » : ce n'est pas pareil."""
+    machine.emit({"labs": [machine.lab_dict(_lab(), None)]})
+
+    assert json.loads(capsys.readouterr().out)["labs"][0]["best_score"] is None
+
+
+def test_stdout_holds_nothing_but_json(capsys) -> None:
+    machine.emit({"labs": []})
+    sortie = capsys.readouterr().out
+
+    json.loads(sortie)  # lève si un message s'est glissé avant ou après
+    assert sortie.lstrip().startswith("{")
+
+
+def test_accents_are_not_escaped(capsys) -> None:
+    """`\\u00e9` partout rendrait les titres français illisibles au débogage."""
+    machine.emit({"titre": "Préparer les nœuds gérés"})
+    sortie = capsys.readouterr().out
+
+    assert "Préparer les nœuds gérés" in sortie

--- a/tests/test_session_spec.py
+++ b/tests/test_session_spec.py
@@ -64,3 +64,95 @@ def test_describing_a_session_does_not_create_the_workdir(tmp_path: Path) -> Non
     ShellRuntime().session_spec(_shell_lab(tmp_path))
 
     assert not (tmp_path / "challenge" / "work").exists()
+
+
+def _vm_lab(tmp_path: Path, session: str) -> LabDefinition:
+    """Un lab VM dont la session est déclarée `target` ou `local`."""
+    from dsoxlab.models.runtime import Target
+
+    return LabDefinition(
+        id="demo-vm",
+        title="Demo VM",
+        level="l1",
+        skills=["s"],
+        runtime=RuntimeConfig(
+            type=RuntimeType.VM,
+            targets=[Target(name="t", host="node1.lab")],
+            session=session,
+        ),
+        distros=["alma9"],
+        doc_url="https://example.test/doc",
+        validation=ValidationConfig(),
+        path=tmp_path / "labs" / "demo",
+    )
+
+
+def test_vm_session_local_stays_on_the_workstation(tmp_path: Path, monkeypatch) -> None:
+    """`session: local` ouvre un sous-shell ici, jamais un SSH.
+
+    Sans ce mode, un lab piloté depuis le poste déposait l'apprenant sur un
+    hôte dépourvu du dépôt et de ses outils : la session s'ouvrait, mais il n'y
+    avait rien à y faire.
+    """
+    from dsoxlab.runtimes.vm import VmRuntime
+
+    repo = tmp_path
+    (repo / "labs" / "demo").mkdir(parents=True)
+    runtime = VmRuntime()
+    monkeypatch.setattr(
+        runtime, "_repo_meta", lambda lab: type("M", (), {"path": repo})()
+    )
+
+    spec = runtime.session_spec(_vm_lab(tmp_path, "local"))
+
+    assert spec.command == [os.environ.get("SHELL", "bash")]
+    assert spec.cwd == repo, "la session doit s'ouvrir à la racine du dépôt"
+    assert spec.env == {"DSOXLAB_LAB_SESSION": "demo-vm"}
+    assert "ssh" not in spec.command
+
+
+def test_vm_session_defaults_to_the_target() -> None:
+    """Le défaut reste la session SSH : les labs système ne bougent pas."""
+    assert RuntimeConfig(type=RuntimeType.VM).session == "target"
+
+
+def _welcome(lab: LabDefinition) -> str:
+    """Le panneau d'accueil, rendu en texte brut."""
+    import importlib
+    import io
+
+    from rich.console import Console
+
+    # `dsoxlab.reporting` réexporte un objet nommé `console`, qui masque le
+    # sous-module du même nom : un import direct rendrait la Console, pas le
+    # module dont on veut remplacer la sortie.
+    reporting = importlib.import_module("dsoxlab.reporting.console")
+
+    buf = io.StringIO()
+    ancien = reporting.console
+    reporting.console = Console(file=buf, width=100, no_color=True)
+    try:
+        reporting.print_lab_welcome(lab)
+    finally:
+        reporting.console = ancien
+    return " ".join(buf.getvalue().split())
+
+
+def test_welcome_warns_that_dsoxlab_is_absent_from_the_lab_host(tmp_path: Path) -> None:
+    """Le panneau listait six commandes juste avant d'ouvrir une session SSH.
+
+    `dsoxlab` n'est installé sur aucune VM : sans cet avertissement, l'apprenant
+    les tape sur l'hôte et récolte des « command not found ».
+    """
+    texte = _welcome(_vm_lab(tmp_path, "target"))
+
+    assert "node1.lab" in texte, "le panneau doit nommer l'hôte de destination"
+    assert "exit" in texte
+
+
+def test_welcome_points_to_the_lab_directory_when_local(tmp_path: Path) -> None:
+    """En session locale, l'apprenant doit savoir où travailler."""
+    texte = _welcome(_vm_lab(tmp_path, "local"))
+
+    assert "labs/demo" in texte, "le panneau doit situer le répertoire du lab"
+    assert "challenge" in texte, "et amorcer par la lecture de la mission"

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
## Pourquoi

Deux ajouts indépendants, nés du même constat : dsoxlab supposait que tout lab
`vm` se joue **dans** la machine, et que sa sortie n'est lue que par des yeux.

## `runtime.session`

Un lab `vm` déclare désormais où s'ouvre sa session interactive : `target`
(défaut, session SSH sur `targets[].host`, comportement inchangé) ou `local`,
un sous-shell sur le poste, à la racine du dépôt.

Certains catalogues se pilotent depuis le poste et non dans la machine :
l'apprenant écrit son code dans le dépôt et lance ses commandes vers les hôtes
du lab, qui restent provisionnés et ciblés par le `setup.yaml`. Pour ceux-là,
`dsoxlab run` ouvrait une session SSH sur un hôte ne contenant ni le dépôt ni
ses outils : la session s'ouvrait, mais il n'y avait rien à y faire.

Le champ reste neutre vis-à-vis du domaine : il ne dit pas « ansible », il dit
« ce lab se pilote depuis le poste ». Le validator refuse toute valeur hors des
deux acceptées, qui retomberait silencieusement sur le SSH.

## Messages d'accueil enfin exacts

Le message de démarrage annonçait « Vous êtes dans `challenge/work/` » quel que
soit le runtime, donc **à tort pour tous les labs `vm`**. Il nomme désormais
l'endroit réel : le workdir pour `shell` (lu, plus supposé), l'hôte connecté
pour une session `target`, la racine du dépôt pour une session `local`.

Le panneau listait par ailleurs six commandes `dsoxlab …` juste avant d'ouvrir
une session SSH sur un hôte où la CLI **n'est pas installée et ne l'a jamais
été** : toutes répondaient `command not found`. Il annonce maintenant l'hôte de
destination, précise que ces commandes vivent sur le poste, et affiche la
mission avant d'entrer, puisqu'on ne pourra plus l'afficher une fois dedans. En
session locale, il situe le répertoire du lab et amorce par `dsoxlab challenge`.

## Sortie machine

`--json` sur `list-labs`, `progress`, `check` et `status`. Chaque document
porte une version de `schema`, et la sortie standard ne contient **rien d'autre
que du JSON** : les messages d'ambiance, la barre de progression pytest et le
rappel du contexte actif sont tus dans ce mode.

Sans cela, toute intégration (extension d'éditeur, tableau de bord, script de
suivi) devrait analyser la sortie Rich, dont les tableaux, les couleurs et les
retours à la ligne dépendent de la largeur du terminal et ont vocation à
changer.

## Vérifications

| | |
|---|---|
| `ruff` | All checks passed |
| `mypy --strict` | 44 fichiers, aucune erreur |
| tests | **70 passed** (5 nouveaux sur le contrat JSON, 4 sur les sessions) |
| `validate-structure` ansible-training | 113 labs valides |
| `validate-structure` linux-dsoxlab-training | 64 labs valides, **tous restés en `target`** |
| i18n | parité EN/FR |

Le dépôt Linux ne bouge pas d'un iota : le défaut `target` préserve son
comportement, ce qui était l'invariant à tenir.
