### PR TITLE
fix(reporting): « course » affiche le README du lab, pas seulement le scenario

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -37,6 +37,16 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- **`dsoxlab course` affiche désormais le README du lab, et non le seul
+  scenario.** Les deux fichiers sont complémentaires et étaient traités comme
+  concurrents : `scenario` pose la situation en quelques lignes, `README`
+  explique les commandes et déroule les exercices. Seul le premier était
+  affiché, si bien que la moitié la plus riche n'était atteignable par aucune
+  commande (mesuré : 10 465 lignes de code dans les README d'un seul dépôt,
+  exposées par rien). L'apprenant en concluait qu'il n'y avait pas de cours et
+  allait chercher la réponse dans l'énoncé du challenge. `course` affiche
+  maintenant le scenario, puis le README, dans la langue demandée.
+
 - **Un fragment SSH par formation, dans `~/.ssh/config.d/<repo-id>.conf`.**
   Écrit par `provision`, rafraîchi par `status`, retiré par `destroy`. Les
   énoncés demandent de se connecter à une machine par son nom, mais ce nom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`dsoxlab course` now shows the lab README, not just the scenario.** The two
+  files are complementary and were treated as rivals: `scenario` sets the
+  situation in a few lines, `README` explains the commands and walks through the
+  exercises. Only the first was ever displayed, so the richer half was reachable
+  by no command at all (measured: 10 465 lines of code sitting in the READMEs of
+  a single repository, exposed by nothing). Learners concluded there was no
+  course and went looking for the answer in the challenge brief. `course` now
+  prints the scenario, then the README, in the requested language.
+
 - **An SSH fragment per course, in `~/.ssh/config.d/<repo-id>.conf`.** Written
   by `provision`, refreshed by `status`, removed by `destroy`. Briefs ask
   learners to connect to a machine by name, but that name is in neither DNS nor

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -8,6 +8,7 @@ from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
 
+from pathlib import Path
 from typing import Any
 
 from ..models.lab import LabDefinition
@@ -433,16 +434,41 @@ def print_course_end(lab: "LabDefinition", manifest: "CourseManifest") -> None:
     )
 
 
+def _localised(base: Path, nom: str, lang: str) -> Path | None:
+    """``<nom>.<lang>.md`` s'il existe, sinon ``<nom>.md``, sinon rien."""
+    if lang != "en":
+        traduit = base / f"{nom}.{lang}.md"
+        if traduit.is_file():
+            return traduit
+    defaut = base / f"{nom}.md"
+    return defaut if defaut.is_file() else None
+
+
 def print_lab_course(lab: LabDefinition, lang: str = "en") -> None:
-    """Display the course content (scenario.md) for a lab — fallback when no course.yaml."""
+    """Affiche le cours du lab : le contexte, puis la partie qui enseigne.
+
+    Les deux fichiers sont complémentaires et étaient jusqu'ici traités comme
+    des concurrents : ``scenario`` pose la situation en quelques lignes,
+    ``README`` explique les commandes et déroule les exercices. Seul le premier
+    était affiché, si bien que la partie la plus riche n'était atteignable par
+    aucune commande (mesuré : 10 465 lignes de code dans les README d'un seul
+    dépôt, exposées par rien). L'apprenant en concluait qu'il n'y avait pas de
+    cours, et allait chercher la réponse dans l'énoncé du challenge.
+    """
     from rich.markdown import Markdown
     from rich.rule import Rule
 
-    localised = lab.path / f"scenario.{lang}.md"
-    course_file = localised if lang != "en" and localised.exists() else lab.path / "scenario.md"
     console.print(Rule(f"[bold cyan]{lab.id}[/bold cyan]"))
-    if course_file.exists():
-        console.print(Markdown(course_file.read_text()))
+    parties = [
+        f for f in (_localised(lab.path, "scenario", lang),
+                    _localised(lab.path, "README", lang))
+        if f is not None
+    ]
+    if parties:
+        for i, fichier in enumerate(parties):
+            if i:
+                console.print(Rule(style="dim"))
+            console.print(Markdown(fichier.read_text(encoding="utf-8")))
     else:
         msg = _("course_missing")
         console.print(f"[yellow]{msg}[/yellow]")


### PR DESCRIPTION
Le cours était écrit, mais aucune commande ne le montrait. 10 465 lignes de code dans les README d'ansible-training, exposées par rien : `dsoxlab course` n'affichait que le scenario. Le même lab passe de 15 à 361 lignes, ses 7 exercices guidés apparaissent. Aucun contenu écrit, il manquait le chemin.