### PR TITLE
chore(release): 0.1.23

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,7 +9,11 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
-## [0.1.22] - 2026-07-22
+## [0.1.23] - 2026-07-22
+
+> Le tag `v0.1.22` a été posé sur le mauvais commit, avant la fusion de sa pull
+> request : le workflow a republié la 0.1.21 et PyPI n'a jamais reçu de 0.1.22.
+> Tout ce que cette version portait est donc livré ici.
 
 ### Corrigé
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.22] - 2026-07-22
+## [0.1.23] - 2026-07-22
+
+> The `v0.1.22` tag was created on the wrong commit, before its pull request was
+> merged: the release workflow republished 0.1.21 and PyPI never received a
+> 0.1.22. Everything that version carried is therefore released here.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.22"
+version = "0.1.23"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.22"
+version = "0.1.23"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
Le tag v0.1.22 a été posé sur le mauvais commit, avant la fusion de sa PR : le workflow a republié la 0.1.21 et PyPI n'a jamais reçu de 0.1.22. Cette version reprend tout ce que la 0.1.22 devait livrer (fragment SSH par formation, provision rejouable, contrat JSON), augmenté de l'affichage du README par `dsoxlab course`.