### PR TITLE
fix(cli): confirmer destroy, corriger check sans provider actif

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,36 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.24] - 2026-07-23
+
+### Ajouté
+
+- **`destroy` demande désormais confirmation.** La commande effaçait un parc
+  entier sans un mot : tapée dans le mauvais dépôt, elle détruisait les VM et
+  leurs données sans retour possible. Elle demande maintenant confirmation, et
+  `--yes` / `-y` préserve l'usage scripté (CI, procédure de récupération
+  documentée).
+
+### Corrigé
+
+- **`check` ne plante plus sur un dépôt qui déclare plusieurs providers sans
+  qu'aucun soit actif.** La lecture des outputs Terraform lève
+  `ProviderUnresolved` et la traceback remontait telle quelle depuis
+  `inventory.py`. L'apprenant reçoit maintenant le même message actionnable que
+  pour les commandes d'infra : choisir un provider avec
+  `dsoxlab use --provider <nom>` ou `DSOXLAB_PROVIDER=<nom>`. Les labs shell,
+  qui n'ont besoin d'aucune infrastructure, ne sont concernés dans aucun cas.
+
+### Modifié
+
+- **`destroy --host` ne prétend plus isoler une VM.** Mesuré sur un parc de
+  trois hôtes : `terraform destroy -target` détruit aussi tout ce qui dépend de
+  la cible, si bien que demander un seul hôte planifiait **7** ressources à
+  détruire, et non 4. L'aide de l'option annonçait « détruit une seule VM », ce
+  qui est faux et dangereux. Elle décrit maintenant le comportement réel et
+  renvoie vers `destroy` + `provision`, seule façon fiable de récupérer une
+  machine inaccessible ; un avertissement est affiché à l'exécution.
+
 ## [0.1.23] - 2026-07-22
 
 > Le tag `v0.1.22` a été posé sur le mauvais commit, avant la fusion de sa pull

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.24] - 2026-07-23
+
+### Added
+
+- **`destroy` now asks for confirmation.** The command wiped a whole park
+  without a word: typed in the wrong repository, it destroyed the VMs and their
+  data with no way back. It now prompts, and `--yes` / `-y` keeps scripted use
+  (CI, the documented recovery procedure) working.
+
+### Fixed
+
+- **`check` no longer crashes on a repository that declares several providers
+  with none active.** Reading the Terraform outputs raises `ProviderUnresolved`;
+  the traceback surfaced raw from `inventory.py`. The learner now gets the same
+  actionable message as the infra commands: pick a provider with
+  `dsoxlab use --provider <name>` or `DSOXLAB_PROVIDER=<name>`. Shell labs,
+  which need no infrastructure at all, are unaffected either way.
+
+### Changed
+
+- **`destroy --host` no longer claims to isolate a VM.** Measured on a
+  three-host park: `terraform destroy -target` also destroys everything that
+  depends on the target, so asking for one host planned **7** resources for
+  destruction, not 4. The option help said "destroys a single VM", which is
+  false and dangerous. It now states the real behaviour and points to
+  `destroy` + `provision` as the reliable way to recover an unreachable
+  machine, and a warning is printed at run time.
+
 ## [0.1.23] - 2026-07-22
 
 > The `v0.1.22` tag was created on the wrong commit, before its pull request was

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.23"
+version = "0.1.24"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -832,6 +832,18 @@ def _run_check(
             except InfraNotProvisioned:
                 error(_("infra_not_provisioned"))
                 raise typer.Exit(2) from None
+            except ProviderUnresolved as exc:
+                # Un dépôt qui déclare plusieurs providers sans qu'aucun ne
+                # soit actif : lire les outputs Terraform est impossible, mais
+                # ce n'est pas une faute de l'apprenant. Sans ce garde-fou, la
+                # traceback remontait telle quelle depuis inventory.py.
+                if not exc.candidates:
+                    error(_("provider_none_declared"))
+                else:
+                    error(_("provider_required",
+                            candidates=", ".join(exc.candidates),
+                            first=exc.candidates[0]))
+                raise typer.Exit(2) from None
 
     # Un --target explicite et inconnu est une ERREUR : on sort avant de
     # lancer quoi que ce soit, sinon une faute de frappe enregistrerait un
@@ -1465,10 +1477,15 @@ def provision(
 def destroy(
     host: Annotated[Optional[list[str]], typer.Option(
         "--host",
-        help="Détruit une seule VM (fqdn meta.yml). Répétable. Le réseau "
-             "et les images de base partagées sont conservés. Sans option : "
-             "détruit toute l'infrastructure.",
+        help="Restreint la cible Terraform à un fqdn du meta.yml. Répétable. "
+             "ATTENTION : Terraform détruit aussi tout ce qui dépend de la "
+             "cible, donc cette option n'isole PAS une VM des autres. Pour "
+             "récupérer une machine, préférer destroy complet + provision.",
     )] = None,
+    yes: Annotated[bool, typer.Option(
+        "--yes", "-y",
+        help="Ne pas demander confirmation (usage non interactif).",
+    )] = False,
     lab_home: LabHomeOption = None,
 ) -> None:
     """Lance terraform destroy sur le provider courant avec progress bar."""
@@ -1496,6 +1513,17 @@ def destroy(
                 error(str(exc))
                 raise typer.Exit(2)
         info(f"Cible Terraform : {', '.join(host)} ({len(targets)} ressources)")
+        # Mesuré le 2026-07-23 : terraform détruit la cible ET tout ce qui en
+        # dépend. Les volumes et disques cloud-init étant chaînés aux domaines,
+        # cibler un seul hôte emporte les autres (7 ressources détruites pour
+        # 1 demandée). On prévient plutôt que de laisser croire à un ciblage fin.
+        warn(_("destroy_host_not_isolated"))
+
+    # destroy est irréversible et ne prévenait pas : un « dsoxlab destroy »
+    # tapé dans le mauvais dépôt effaçait le parc sans un mot. --yes garde
+    # l'usage scripté (CI, procédure de récupération documentée).
+    if not yes:
+        typer.confirm(_("confirm_destroy", provider=provider), abort=True)
 
     info(_("destroy_starting", provider=provider))
     try:

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -98,6 +98,14 @@ STRINGS: dict[str, str] = {
     "provision_waiting_ssh": "Waiting for hosts to become reachable (SSH + cloud-init)…",
     "provision_waiting_ssh_host": "Waiting for {host} (SSH + cloud-init), attempt {attempt}…",
     "provision_ssh_timeout": "Host readiness timed out: {error}\nThe VM may still be booting — retry `dsoxlab run` in a moment.",
+    "confirm_destroy":
+        "Destroy the whole {provider} infrastructure? "
+        "All VM data will be lost",
+    "destroy_host_not_isolated":
+        "Warning: Terraform also destroys everything that depends on the target. "
+        "Host targeting therefore does not isolate one VM from the others. To "
+        "recover an unreachable machine, prefer \"dsoxlab destroy\" then "
+        "\"dsoxlab provision\": the whole park is rebuilt from scratch.",
     "destroy_starting":    "Destroying infrastructure (provider: {provider})…",
     "ssh_fragment_failed":  "SSH fragment not written: {error}. Connecting by machine name will not work.",
     "ssh_fragment_written": "Direct connection enabled: [bold]ssh <machine>[/bold] now works (fragment {path}).",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -98,6 +98,14 @@ STRINGS: dict[str, str] = {
     "provision_waiting_ssh": "Attente que les hôtes soient joignables (SSH + cloud-init)…",
     "provision_waiting_ssh_host": "Attente de {host} (SSH + cloud-init), tentative {attempt}…",
     "provision_ssh_timeout": "Délai d'attente dépassé : {error}\nLa VM démarre peut-être encore — relance `dsoxlab run` dans un instant.",
+    "confirm_destroy":
+        "Détruire toute l'infrastructure du provider {provider} ? "
+        "Les données des VM seront perdues",
+    "destroy_host_not_isolated":
+        "Attention : Terraform détruit aussi tout ce qui dépend de la cible. "
+        "Le ciblage par hôte n'isole donc pas une VM des autres. Pour "
+        "récupérer une machine inaccessible, préfère « dsoxlab destroy » "
+        "puis « dsoxlab provision » : le parc entier est reconstruit à neuf.",
     "destroy_starting":    "Destruction de l'infrastructure (provider : {provider})…",
     "ssh_fragment_failed":  "Fragment SSH non écrit : {error}. La connexion par nom de machine ne fonctionnera pas.",
     "ssh_fragment_written": "Connexion directe activée : [bold]ssh <machine>[/bold] fonctionne désormais (fragment {path}).",

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.23"
+version = "0.1.24"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
## Pourquoi

Trois défauts trouvés en cherchant pourquoi `dsoxlab destroy --host <fqdn>` avait détruit un parc entier au lieu d'une seule VM.

### 1. `destroy` ne demandait aucune confirmation

La commande effaçait tout un parc sans un mot. Tapée dans le mauvais dépôt, elle détruisait les VM et leurs données sans retour possible. Elle demande maintenant confirmation ; `--yes` / `-y` préserve l'usage scripté (CI, procédure de récupération documentée).

### 2. L'aide de `--host` était fausse, et dangereuse

Elle annonçait « Détruit une seule VM ». Or `terraform destroy -target` détruit la cible **et tout ce qui en dépend**. Mesuré sur le parc à trois hôtes de `linux-dsoxlab-training` :

| Cible demandée | Ressources planifiées |
|---|---|
| `libvirt_domain.host[...]` | 1 |
| `libvirt_volume.host[...]` | 4 |
| `libvirt_volume.cloudinit[...]` | 4 |
| `libvirt_cloudinit_disk.host[...]` | **7** |

Les quatre cibles ensemble : **8 destructions pour une VM demandée**. Ce n'est pas un défaut de ciblage corrigeable, c'est une propriété de Terraform. L'option décrit donc maintenant son comportement réel, affiche un avertissement à l'exécution, et renvoie vers `destroy` + `provision`, seule voie fiable pour récupérer une machine inaccessible.

Au passage : la variable `target_hosts` est déclarée dans `templates/terraform/kvm/variables.tf` avec une docstring affirmant qu'elle restreint le `for_each`, mais elle n'est **jamais utilisée** dans `main.tf`. Elle n'est pas en cause ici (vérifié) ; à nettoyer séparément.

### 3. `check` plantait sans provider actif

Sur un dépôt qui déclare plusieurs providers sans qu'aucun soit actif, la lecture des outputs Terraform lève `ProviderUnresolved` et la traceback remontait telle quelle depuis `inventory.py`. L'apprenant reçoit désormais le même message actionnable que pour les commandes d'infra. Les labs shell, qui n'ont besoin d'aucune infrastructure, ne sont concernés dans aucun cas.

Côté catalogue, le `conftest.py` de `linux-dsoxlab-training` doit également dégrader proprement : c'est l'objet d'une modification séparée dans ce dépôt (issue stephrobert/linux-dsoxlab-training#21).

## Procédure de récupération, mesurée

```
dsoxlab destroy --yes     # 6 s
dsoxlab provision         # 222 s, les 3 hôtes reviennent sur les mêmes IP
```

Les VM d'un autre dépôt de labs provisionné en parallèle ne sont pas touchées : l'isolation du state par `repo-id` tient.

## Tests

- `ruff check` et `mypy --strict` verts
- 71 tests unitaires `dsoxlab`
- Les 14 commandes passées en revue en **FR et EN** (RC=0 partout), confirmation testée en acceptation et en refus
- Agnosticisme vérifié sur **deux** dépôts fournisseurs : `validate-structure` vert sur `linux-dsoxlab-training` (76 labs) et `ansible-training`
- 689 tests de contenu du catalogue Linux verts

## Release

CHANGELOG EN + FR, bump `0.1.24`, `uv.lock` inclus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
