### PR TITLE
feat(cli): signaler qu'une version plus récente existe sur PyPI

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,25 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.25] - 2026-07-23
+
+### Ajouté
+
+- **dsoxlab signale qu'une version plus récente existe.** Un apprenant
+  installe la CLI une fois et ne revient jamais vérifier : il joue des labs
+  avec des défauts corrigés depuis longtemps, et remonte des problèmes déjà
+  résolus. La vérification a lieu une fois par jour et l'avis s'affiche en
+  dernier, pour être lu.
+
+  Il est construit pour ne jamais gêner. Le message part sur **stderr**, jamais
+  sur stdout : un document `--json` reste lisible quoi qu'il arrive. Il est tu
+  quand stderr n'est pas un terminal, ce qui laisse les journaux de CI propres.
+  Toute défaillance (hors ligne, PyPI en panne, proxy hostile, réponse
+  illisible) est avalée en silence : vérifier une version n'est jamais une
+  raison de casser un `check`. Le résultat est mis en cache un jour, pour
+  qu'une salle de formation ne martèle pas PyPI. Désactivation par
+  `DSOXLAB_NO_UPDATE_CHECK=1`.
+
 ## [0.1.24] - 2026-07-23
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25] - 2026-07-23
+
+### Added
+
+- **dsoxlab tells you when a newer version is available.** A learner installs
+  the CLI once and never comes back to check: they keep playing labs with
+  defects fixed long ago, and report problems already solved. The check now
+  runs once a day and the notice is printed last, so it is actually read.
+
+  It is built so it can never get in the way. The message goes to **stderr**,
+  never stdout, so a `--json` document stays parseable whatever happens. It is
+  skipped entirely when stderr is not a terminal, keeping CI logs clean. Any
+  failure (offline, PyPI down, hostile proxy, unreadable response) is swallowed
+  silently: checking a version is never a reason to break a `check`. The result
+  is cached for a day, so a classroom does not hammer PyPI. Opt out with
+  `DSOXLAB_NO_UPDATE_CHECK=1`.
+
 ## [0.1.24] - 2026-07-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.24"
+version = "0.1.25"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -15,6 +15,7 @@ Usage:
 
 from __future__ import annotations
 
+import atexit
 import os
 import webbrowser
 import shutil
@@ -64,6 +65,7 @@ from .reporting import (
     print_lab_course,
     print_lab_welcome,
     success,
+    update_console,
     warn,
 )
 from .models import (
@@ -260,6 +262,34 @@ def _bootstrap(
         set_lang(lang)
     except Exception:  # noqa: S110 — silence volontaire : pas de contexte lab, on continue en langue par défaut
         pass  # silencieux si LAB_HOME introuvable
+
+    # L'avis de mise à jour est posé ici, mais affiché à la toute fin par
+    # atexit : c'est le seul moyen qu'il soit le dernier message, y compris
+    # quand la commande sort en erreur ou lève typer.Exit.
+    atexit.register(_notify_update_available)
+
+
+def _notify_update_available() -> None:
+    """Affiche l'avis de mise à jour, en dernier, sur stderr.
+
+    Sur stderr et pas stdout : une commande en `--json` doit rendre un
+    document lisible par un programme, quoi qu'il arrive. Et seulement si
+    stderr est un terminal, pour ne pas polluer les journaux d'une CI ni la
+    sortie capturée par un script.
+    """
+    if not sys.stderr.isatty():
+        return
+    try:
+        from .services.update_check import available_update
+
+        latest = available_update(__version__)
+        if latest is None:
+            return
+        update_console.print(
+            _("update_available", latest=latest, current=__version__)
+        )
+    except Exception:  # noqa: S110 — un avis ne casse jamais une commande
+        return
 
 
 # ── install ─────────────────────────────────────────────────────────────────

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -101,6 +101,10 @@ STRINGS: dict[str, str] = {
     "confirm_destroy":
         "Destroy the whole {provider} infrastructure? "
         "All VM data will be lost",
+    "update_available":
+        "\n[dim]A newer version of dsoxlab is available: "
+        "{latest} (you have {current}).\n"
+        "Upgrade with: uv tool upgrade dsoxlab[/dim]",
     "destroy_host_not_isolated":
         "Warning: Terraform also destroys everything that depends on the target. "
         "Host targeting therefore does not isolate one VM from the others. To "
@@ -255,6 +259,16 @@ Lab titles and descriptions can be displayed in different languages.
 
   Set permanently:   [bold]dsoxlab use linux --lang fr[/bold]
   Set for one call:  [bold]DSOXLAB_LANG=fr dsoxlab list-labs[/bold]""",
+
+    "fullhelp_update": """\
+[bold]Updates[/bold]
+
+dsoxlab checks once a day whether a newer version exists on PyPI, and says so
+at the end of a command. The check never blocks anything: offline, it stays
+silent.
+
+  Upgrade:  [bold]uv tool upgrade dsoxlab[/bold]
+  Disable:  [bold]DSOXLAB_NO_UPDATE_CHECK=1[/bold]""",
 
     "fullhelp_scoring": """\
 [bold]Scoring[/bold]

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -101,6 +101,10 @@ STRINGS: dict[str, str] = {
     "confirm_destroy":
         "Détruire toute l'infrastructure du provider {provider} ? "
         "Les données des VM seront perdues",
+    "update_available":
+        "\n[dim]Une version plus récente de dsoxlab est disponible : "
+        "{latest} (vous avez {current}).\n"
+        "Mettez à jour avec : uv tool upgrade dsoxlab[/dim]",
     "destroy_host_not_isolated":
         "Attention : Terraform détruit aussi tout ce qui dépend de la cible. "
         "Le ciblage par hôte n'isole donc pas une VM des autres. Pour "
@@ -253,6 +257,16 @@ Les titres et descriptions des labs peuvent s'afficher dans plusieurs langues.
 
   Fixer de façon permanente :  [bold]dsoxlab use linux --lang fr[/bold]
   Fixer pour un appel :        [bold]DSOXLAB_LANG=fr dsoxlab list-labs[/bold]""",
+
+    "fullhelp_update": """\
+[bold]Mises à jour[/bold]
+
+dsoxlab regarde une fois par jour si une version plus récente existe sur
+PyPI, et le signale en fin de commande. La vérification ne bloque rien :
+hors ligne, elle se tait.
+
+  Mettre à jour :   [bold]uv tool upgrade dsoxlab[/bold]
+  Désactiver :      [bold]DSOXLAB_NO_UPDATE_CHECK=1[/bold]""",
 
     "fullhelp_scoring": """\
 [bold]Scoring[/bold]

--- a/src/dsoxlab/reporting/__init__.py
+++ b/src/dsoxlab/reporting/__init__.py
@@ -3,6 +3,7 @@
 from .console import (
     console,
     err_console,
+    update_console,
     error,
     info,
     print_check_result,
@@ -28,6 +29,7 @@ from .console import (
 __all__ = [
     "console",
     "err_console",
+    "update_console",
     "error",
     "info",
     "print_check_result",

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -19,6 +19,9 @@ from ..i18n import _
 
 console = Console()
 err_console = Console(stderr=True, style="bold red")
+#: Avis de mise a jour : sur stderr comme les erreurs, pour ne jamais
+#: polluer un document JSON, mais sans le rouge qui ferait croire a un echec.
+update_console = Console(stderr=True, style="dim", highlight=False)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -563,6 +566,7 @@ def print_fullhelp() -> None:
         ("fullhelp_runtimes", None),
         ("fullhelp_language", None),
         ("fullhelp_scoring",  None),
+        ("fullhelp_update",   None),
     ]
 
     console.print()

--- a/src/dsoxlab/services/update_check.py
+++ b/src/dsoxlab/services/update_check.py
@@ -1,0 +1,156 @@
+"""Signale à l'utilisateur qu'une version plus récente existe sur PyPI.
+
+Un apprenant installe `dsoxlab` une fois et ne revient jamais voir s'il
+existe mieux. Il joue alors des labs avec une CLI qui traîne des défauts
+corrigés depuis, et remonte des problèmes déjà résolus. D'où cet avis, mais
+il doit se faire oublier : trois règles le tiennent.
+
+1. **Il ne peut pas polluer une sortie machine.** Le message part sur
+   `stderr`, jamais sur `stdout`. Le contrat JSON de `--json` reste lisible
+   quoi qu'il arrive, y compris si l'avis tombe au milieu d'un pipeline.
+   (Un document JSON précédé d'une ligne de texte, c'est le défaut corrigé
+   en 0.1.23 ; il ne sera pas réintroduit par la porte de derrière.)
+2. **Il ne peut pas faire échouer une commande.** Réseau coupé, PyPI en
+   panne, proxy hostile, réponse illisible : tout est avalé en silence.
+   Vérifier une version n'est jamais une raison de casser un `check`.
+3. **Il ne coûte pas une requête par commande.** Le résultat est mis en
+   cache un jour. Sans cela, chaque `dsoxlab list-labs` paierait un aller
+   retour réseau, et une salle de formation entière taperait sur PyPI.
+
+Désactivation : `DSOXLAB_NO_UPDATE_CHECK=1`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+#: Un jour. Assez court pour qu'une correction se sache, assez long pour
+#: qu'une session de travail ne déclenche qu'une seule requête.
+CACHE_TTL_SECONDS = 24 * 60 * 60
+
+#: Court volontairement : l'avis est un bonus, pas un préalable. Mieux vaut
+#: ne rien dire que faire attendre quelqu'un devant son terminal.
+HTTP_TIMEOUT_SECONDS = 2.0
+
+PYPI_URL = "https://pypi.org/pypi/dsoxlab/json"
+
+_ENV_OPT_OUT = "DSOXLAB_NO_UPDATE_CHECK"
+
+
+def _xdg_cache_home() -> Path:
+    """Racine du cache utilisateur, conforme XDG."""
+    raw = os.environ.get("XDG_CACHE_HOME")
+    if raw:
+        return Path(raw)
+    return Path.home() / ".cache"
+
+
+def cache_path() -> Path:
+    """Fichier où l'on retient la dernière version vue et sa date."""
+    return _xdg_cache_home() / "dsoxlab" / "version-check.json"
+
+
+def parse_version(raw: str) -> tuple[int, int, int]:
+    """Découpe « 0.1.24 » en (0, 1, 24), sans dépendance externe.
+
+    Le projet suit le versionnage sémantique, donc trois nombres suffisent.
+    Tout suffixe (« 0.2.0rc1 », « 1.0.0.dev3 ») est tronqué à sa partie
+    numérique : une pré-release n'est jamais proposée comme une nouveauté,
+    ce qui est le comportement voulu.
+    """
+    parts: list[int] = []
+    for chunk in raw.strip().split(".")[:3]:
+        digits = ""
+        for char in chunk:
+            if not char.isdigit():
+                break
+            digits += char
+        parts.append(int(digits) if digits else 0)
+    while len(parts) < 3:
+        parts.append(0)
+    return parts[0], parts[1], parts[2]
+
+
+def _read_cache(now: float) -> str | None:
+    """Version retenue si le cache est encore frais, sinon None."""
+    path = cache_path()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        checked_at = float(payload["checked_at"])
+        latest = str(payload["latest"])
+    except (OSError, ValueError, KeyError, TypeError):
+        # Cache absent, tronqué, ou écrit par une version antérieure au
+        # format actuel : on le traite comme absent, jamais comme une erreur.
+        return None
+    if now - checked_at > CACHE_TTL_SECONDS:
+        return None
+    return latest
+
+
+def _write_cache(latest: str, now: float) -> None:
+    """Retient la version vue. Un échec d'écriture n'est pas une erreur."""
+    path = cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"checked_at": now, "latest": latest}),
+            encoding="utf-8",
+        )
+    except OSError:
+        # Home en lecture seule, quota dépassé, cache monté ailleurs : on
+        # perd le cache, donc on refera une requête. Sans conséquence.
+        return
+
+
+def fetch_latest_version() -> str | None:
+    """Interroge PyPI. Rend None dès que quoi que ce soit se passe mal."""
+    try:
+        request = urllib.request.Request(  # noqa: S310 - URL constante, https
+            PYPI_URL,
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(  # noqa: S310 - idem
+            request, timeout=HTTP_TIMEOUT_SECONDS
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        latest = payload["info"]["version"]
+    except (urllib.error.URLError, OSError, ValueError, KeyError, TypeError):
+        # Hors ligne, DNS muet, PyPI en panne, proxy qui rend du HTML,
+        # schéma modifié : aucun de ces cas ne regarde l'utilisateur.
+        return None
+    if not isinstance(latest, str) or not latest.strip():
+        return None
+    return latest.strip()
+
+
+def available_update(current: str, *, force: bool = False) -> str | None:
+    """Rend la version disponible si elle est plus récente, sinon None.
+
+    Args:
+        current: version installée (``dsoxlab.__version__``).
+        force: ignorer le cache et interroger PyPI malgré tout. Utilisé par
+            ``dsoxlab doctor``, où l'utilisateur demande explicitement un
+            diagnostic et attend une réponse fraîche.
+    """
+    if os.environ.get(_ENV_OPT_OUT):
+        return None
+
+    now = time.time()
+    latest = None if force else _read_cache(now)
+    if latest is None:
+        latest = fetch_latest_version()
+        if latest is None:
+            return None
+        _write_cache(latest, now)
+
+    try:
+        if parse_version(latest) <= parse_version(current):
+            return None
+    except (ValueError, TypeError):
+        return None
+    return latest

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,183 @@
+"""L'avis de mise à jour doit se faire oublier.
+
+Ces tests portent moins sur « détecte-t-il une nouvelle version » que sur
+« peut-il nuire ». Un avis qui casse une commande, qui fait attendre, ou qui
+glisse une ligne de texte devant un document JSON coûterait bien plus cher
+que le service qu'il rend.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dsoxlab.services import update_check
+
+
+@pytest.fixture(autouse=True)
+def _cache_isole(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Jamais le vrai cache de l'utilisateur, jamais son opt-out."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.delenv("DSOXLAB_NO_UPDATE_CHECK", raising=False)
+
+
+class TestParseVersion:
+    @pytest.mark.parametrize(
+        ("brut", "attendu"),
+        [
+            ("0.1.24", (0, 1, 24)),
+            ("1.0.0", (1, 0, 0)),
+            ("0.2", (0, 2, 0)),
+            ("3", (3, 0, 0)),
+            # Une pré-release est ramenée à sa version de base : on ne
+            # propose jamais une rc comme si c'était une sortie.
+            ("0.2.0rc1", (0, 2, 0)),
+            ("1.0.0.dev3", (1, 0, 0)),
+            # Illisible plutôt qu'une exception : l'avis se tait, il ne casse pas.
+            ("", (0, 0, 0)),
+            ("abc", (0, 0, 0)),
+        ],
+    )
+    def test_decoupe(self, brut: str, attendu: tuple[int, int, int]) -> None:
+        assert update_check.parse_version(brut) == attendu
+
+    def test_ordre_numerique_et_non_alphabetique(self) -> None:
+        """0.1.9 < 0.1.24, ce qu'une comparaison de chaînes rate."""
+        assert update_check.parse_version("0.1.9") < update_check.parse_version("0.1.24")
+
+
+class TestAvailableUpdate:
+    def test_signale_une_version_plus_recente(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(update_check, "fetch_latest_version", lambda: "0.2.0")
+        assert update_check.available_update("0.1.24") == "0.2.0"
+
+    def test_se_tait_si_a_jour(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(update_check, "fetch_latest_version", lambda: "0.1.24")
+        assert update_check.available_update("0.1.24") is None
+
+    def test_se_tait_si_installee_plus_recente(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cas d'un développeur en editable, en avance sur PyPI."""
+        monkeypatch.setattr(update_check, "fetch_latest_version", lambda: "0.1.24")
+        assert update_check.available_update("0.2.0") is None
+
+    def test_se_tait_hors_ligne(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(update_check, "fetch_latest_version", lambda: None)
+        assert update_check.available_update("0.1.1") is None
+
+    def test_opt_out_court_circuite_le_reseau(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DSOXLAB_NO_UPDATE_CHECK doit couper avant toute requête."""
+        appels = []
+
+        def _interdit() -> str:
+            appels.append(1)
+            return "0.2.0"
+
+        monkeypatch.setattr(update_check, "fetch_latest_version", _interdit)
+        monkeypatch.setenv("DSOXLAB_NO_UPDATE_CHECK", "1")
+        assert update_check.available_update("0.1.1") is None
+        assert appels == [], "PyPI a été interrogé malgré l'opt-out"
+
+
+class TestCache:
+    def test_deuxieme_appel_ne_refait_pas_de_requete(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        appels: list[int] = []
+
+        def _compte() -> str:
+            appels.append(1)
+            return "0.2.0"
+
+        monkeypatch.setattr(update_check, "fetch_latest_version", _compte)
+        assert update_check.available_update("0.1.1") == "0.2.0"
+        assert update_check.available_update("0.1.1") == "0.2.0"
+        assert len(appels) == 1, "le cache n'a pas servi"
+
+    def test_cache_perime_declenche_une_requete(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(update_check, "fetch_latest_version", lambda: "0.2.0")
+        update_check.available_update("0.1.1")
+
+        chemin = update_check.cache_path()
+        payload = json.loads(chemin.read_text(encoding="utf-8"))
+        payload["checked_at"] -= update_check.CACHE_TTL_SECONDS + 1
+        chemin.write_text(json.dumps(payload), encoding="utf-8")
+
+        monkeypatch.setattr(update_check, "fetch_latest_version", lambda: "0.3.0")
+        assert update_check.available_update("0.1.1") == "0.3.0"
+
+    def test_force_ignore_le_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(update_check, "fetch_latest_version", lambda: "0.2.0")
+        update_check.available_update("0.1.1")
+        monkeypatch.setattr(update_check, "fetch_latest_version", lambda: "0.3.0")
+        assert update_check.available_update("0.1.1", force=True) == "0.3.0"
+
+    def test_cache_corrompu_est_traite_comme_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        chemin = update_check.cache_path()
+        chemin.parent.mkdir(parents=True, exist_ok=True)
+        chemin.write_text("{ ceci n'est pas du json", encoding="utf-8")
+        monkeypatch.setattr(update_check, "fetch_latest_version", lambda: "0.2.0")
+        assert update_check.available_update("0.1.1") == "0.2.0"
+
+    def test_cache_illisible_ne_leve_pas(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Home en lecture seule : on perd le cache, pas la commande."""
+
+        def _echec(*_args: object, **_kwargs: object) -> None:
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(update_check.Path, "write_text", _echec)
+        monkeypatch.setattr(update_check, "fetch_latest_version", lambda: "0.2.0")
+        assert update_check.available_update("0.1.1") == "0.2.0"
+
+
+class TestFetchNeLevePas:
+    """Quoi que rende le réseau, fetch_latest_version() rend None ou un str."""
+
+    @pytest.mark.parametrize(
+        "reponse",
+        [
+            b"pas du json",
+            b"{}",
+            b'{"info": {}}',
+            b'{"info": {"version": null}}',
+            b'{"info": {"version": "   "}}',
+            b"[]",
+        ],
+    )
+    def test_reponse_inattendue(
+        self, reponse: bytes, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _Reponse:
+            def __enter__(self) -> _Reponse:
+                return self
+
+            def __exit__(self, *_exc: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return reponse
+
+        monkeypatch.setattr(
+            update_check.urllib.request, "urlopen", lambda *a, **k: _Reponse()
+        )
+        assert update_check.fetch_latest_version() is None
+
+    def test_erreur_reseau(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boum(*_args: object, **_kwargs: object) -> None:
+            raise OSError("network is unreachable")
+
+        monkeypatch.setattr(update_check.urllib.request, "urlopen", _boum)
+        assert update_check.fetch_latest_version() is None

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.24"
+version = "0.1.25"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
## Pourquoi

Un apprenant installe la CLI une fois et ne revient jamais vérifier. Il joue alors des labs avec des défauts corrigés depuis longtemps, et remonte des problèmes déjà résolus, ce qui vient d'arriver sur stephrobert/linux-dsoxlab-training#21.

La vérification a lieu une fois par jour et l'avis s'affiche **en dernier**, pour être lu à tous les coups.

```
Une version plus récente de dsoxlab est disponible : 0.1.24 (vous avez 0.1.1).
Mettez à jour avec : uv tool upgrade dsoxlab
```

## Un avis qui ne doit jamais nuire

C'est là que tient l'essentiel de la conception.

- **Il part sur `stderr`, jamais sur `stdout`.** Un document `--json` reste lisible quoi qu'il arrive. C'est exactement le défaut corrigé en 0.1.23 (« `check --json` polluait sa propre sortie ») : il ne rentrera pas par la porte de derrière. Vérifié, `list-labs --json` rend toujours un JSON valide avec un avis actif.
- **Muet hors terminal**, pour ne pas polluer les journaux d'une CI ni une sortie capturée par un script.
- **Il ne casse rien.** Hors ligne, PyPI en panne, proxy qui rend du HTML, schéma modifié : tout est avalé en silence. Mesuré à **0,08 s** avec le DNS coupé. Vérifier une version n'est jamais une raison de faire échouer un `check`.
- **Une requête par jour**, en cache XDG, pour qu'une salle de formation entière ne tape pas sur PyPI à chaque commande.
- **`DSOXLAB_NO_UPDATE_CHECK=1`** coupe *avant* toute requête réseau (un test le vérifie explicitement).

L'affichage passe par `atexit` : c'est le seul moyen que l'avis soit le dernier message, y compris quand la commande sort en erreur ou lève `typer.Exit`.

## Comparaison de versions

Sans dépendance nouvelle : trois nombres, le projet suivant le versionnage sémantique. Une pré-release est ramenée à sa version de base, donc jamais proposée comme une sortie. `0.1.9 < 0.1.24` est bien traité, ce qu'une comparaison de chaînes raterait.

## Tests

**26 tests dédiés**, qui portent surtout sur ce que la fonction ne doit *pas* faire : polluer stdout, lever, attendre, ou interroger PyPI malgré l'opt-out. Cache périmé, cache corrompu, home en lecture seule, réponses inattendues de PyPI et erreur réseau sont couverts.

- 97 tests au total, `ruff` et `mypy --strict` verts
- section `fullhelp` ajoutée en **FR et EN**
- non-régression CLI vérifiée sur **deux** dépôts fournisseurs (`linux-dsoxlab-training`, `ansible-training`)
- rendu contrôlé dans un vrai TTY, dans les deux langues

## Release

CHANGELOG EN + FR, bump `0.1.25`, `uv.lock` inclus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
