### PR TITLE
fix(reporting): retirer l'icône de runtime, traduire la difficulté

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -20,6 +20,11 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
   toute façon « ? » sur tous les labs `vm` : sa table connaissait `kvm` et
   `incus`, les deux alias rétro-compat, mais pas `vm`, la valeur canonique du
   contrat.
+- **Une section inconnue passée à `use` était acceptée sans un mot.**
+  `dsoxlab use l2` posait le filtre, puis `list-labs` répondait « Aucun lab
+  trouvé » : l'apprenant croyait le catalogue vide alors qu'il venait de poser
+  un filtre ne correspondant à rien. La commande refuse maintenant et liste les
+  sections déclarées dans le `meta.yml`.
 - **La difficulté restait en anglais en français.** `show` affichait
   « Difficulté : intermediate ». Les trois valeurs employées par les dépôts de
   labs sont traduites ; le champ restant libre par contrat, toute autre valeur

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,22 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.26] - 2026-07-23
+
+### Corrigé
+
+- **L'icône de runtime décalait l'affichage.** Les emoji de largeur double, et
+  leur sélecteur de variante, sont comptés pour une colonne par Rich mais rendus
+  sur deux par le terminal : la ligne glissait et la bordure du panneau se
+  brisait. L'icône est retirée de `show` et de `list-labs`. Elle affichait de
+  toute façon « ? » sur tous les labs `vm` : sa table connaissait `kvm` et
+  `incus`, les deux alias rétro-compat, mais pas `vm`, la valeur canonique du
+  contrat.
+- **La difficulté restait en anglais en français.** `show` affichait
+  « Difficulté : intermediate ». Les trois valeurs employées par les dépôts de
+  labs sont traduites ; le champ restant libre par contrat, toute autre valeur
+  s'affiche telle quelle plutôt que de disparaître.
+
 ## [0.1.25] - 2026-07-23
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from `show` and `list-labs`. It showed "?" on every `vm` lab anyway: its table
   knew about `kvm` and `incus`, the two backward-compatible aliases, but not
   `vm`, the contract's canonical value.
+- **An unknown section passed to `use` was accepted silently.**
+  `dsoxlab use l2` set the filter, then `list-labs` answered "No lab found":
+  the learner believed the catalog was empty when they had just set a filter
+  matching nothing. The command now refuses and lists the sections declared in
+  `meta.yml`.
 - **Difficulty stayed in English under a French UI.** `show` printed
   "Difficulté : intermediate". The three values used by lab repositories are now
   translated; since the field is free-form by contract, any other value is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.26] - 2026-07-23
+
+### Fixed
+
+- **The runtime icon shifted the layout.** Double-width emoji, and their
+  variation selector, count as one column for Rich but render as two in the
+  terminal: the line drifted and the panel border broke. The icon is dropped
+  from `show` and `list-labs`. It showed "?" on every `vm` lab anyway: its table
+  knew about `kvm` and `incus`, the two backward-compatible aliases, but not
+  `vm`, the contract's canonical value.
+- **Difficulty stayed in English under a French UI.** `show` printed
+  "Difficulté : intermediate". The three values used by lab repositories are now
+  translated; since the field is free-form by contract, any other value is
+  printed as-is rather than vanishing.
+
 ## [0.1.25] - 2026-07-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.25"
+version = "0.1.26"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -419,6 +419,19 @@ def use(
         error(_("provider_not_a_section", name=context))
         raise typer.Exit(1)
 
+    # Même piège, cas général : une section inconnue était acceptée sans un
+    # mot, puis « list-labs » répondait « Aucun lab trouvé ». L'apprenant
+    # croyait le catalogue vide alors qu'il venait de poser un filtre qui ne
+    # correspond à rien. On refuse, et on montre ce qui existe.
+    # Un meta.yml sans bloc « sections » ne déclare rien : on ne filtre pas.
+    if context is not None and declared_sections:
+        demandee = context.strip().split("/", 1)[0]
+        if demandee and demandee not in declared_sections:
+            error(_("section_unknown",
+                    name=demandee,
+                    sections=", ".join(declared_sections)))
+            raise typer.Exit(1)
+
     # --provider <name> : valider contre les providers candidats du
     # meta.yml avant de l'enregistrer dans le contexte session.
     if provider is not None:

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -85,6 +85,10 @@ STRINGS: dict[str, str] = {
     # ── provider resolution ───────────────────────────────────────────────────
     "provider_required":      "This command needs an infrastructure provider, and this repository declares several ({candidates}) with none active.\nPick one:\n  dsoxlab use --provider {first}   (persisted)\n  DSOXLAB_PROVIDER={first} dsoxlab <command>   (one-shot)",
     "provider_none_declared": "No infrastructure provider declared in meta.yml (infra.provider). This command needs one.",
+    "section_unknown":
+        "Unknown section: \"{name}\". The catalog would come out empty.\n"
+        "Sections declared in meta.yml: {sections}.\n"
+        "To see everything: dsoxlab use --reset",
     "provider_not_a_section": "'{name}' is an infrastructure provider, not a catalog section.\nTo activate it:\n  dsoxlab use --provider {name}",
     "provider_unknown":       "Unknown provider '{name}' for this repository. Candidates: {candidates}",
 

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -101,6 +101,9 @@ STRINGS: dict[str, str] = {
     "confirm_destroy":
         "Destroy the whole {provider} infrastructure? "
         "All VM data will be lost",
+    "difficulty_beginner":     "beginner",
+    "difficulty_intermediate": "intermediate",
+    "difficulty_advanced":     "advanced",
     "update_available":
         "\n[dim]A newer version of dsoxlab is available: "
         "{latest} (you have {current}).\n"

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -101,6 +101,9 @@ STRINGS: dict[str, str] = {
     "confirm_destroy":
         "Détruire toute l'infrastructure du provider {provider} ? "
         "Les données des VM seront perdues",
+    "difficulty_beginner":     "débutant",
+    "difficulty_intermediate": "intermédiaire",
+    "difficulty_advanced":     "avancé",
     "update_available":
         "\n[dim]Une version plus récente de dsoxlab est disponible : "
         "{latest} (vous avez {current}).\n"

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -86,6 +86,10 @@ STRINGS: dict[str, str] = {
     # ── résolution du provider ────────────────────────────────────────────────
     "provider_required":      "Cette commande a besoin d'un provider d'infrastructure, et ce dépôt en déclare plusieurs ({candidates}) sans qu'aucun ne soit actif.\nChoisis-en un :\n  dsoxlab use --provider {first}   (persisté)\n  DSOXLAB_PROVIDER={first} dsoxlab <commande>   (one-shot)",
     "provider_none_declared": "Aucun provider d'infrastructure déclaré dans meta.yml (infra.provider). Cette commande en exige un.",
+    "section_unknown":
+        "Section inconnue : « {name} ». Le catalogue serait vide.\n"
+        "Sections déclarées dans meta.yml : {sections}.\n"
+        "Pour tout voir : dsoxlab use --reset",
     "provider_not_a_section": "'{name}' est un provider d'infrastructure, pas une section du catalogue.\nPour l'activer :\n  dsoxlab use --provider {name}",
     "provider_unknown":       "Provider '{name}' inconnu pour ce dépôt. Candidats : {candidates}",
 

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -30,8 +30,16 @@ def _level_color(level: str) -> str:
     return {"l1": "green", "l2": "yellow", "lfcs": "cyan", "rhcsa": "magenta"}.get(level, "white")
 
 
-def _runtime_icon(runtime_type: str) -> str:
-    return {"shell": "🐚", "incus": "📦", "kvm": "🖥️"}.get(runtime_type, "?")
+def _difficulty_label(difficulty: str) -> str:
+    """Traduit les difficultés courantes, laisse passer le reste.
+
+    Le champ est libre par contrat : un dépôt de labs peut y mettre ce qu'il
+    veut. On ne traduit donc que les trois valeurs employées partout, et toute
+    autre valeur s'affiche telle quelle plutôt que de disparaître.
+    """
+    cle = f"difficulty_{difficulty.strip().lower()}"
+    traduit = _(cle)
+    return difficulty if traduit == cle else traduit
 
 
 def _section_color(section: str) -> str:
@@ -74,7 +82,7 @@ def print_labs_table(labs: list[LabDefinition], scores: dict[str, tuple[int, int
     current_section = ""
     for lab in labs:
         level_text = Text(lab.level, style=_level_color(lab.level))
-        runtime_text = f"{_runtime_icon(lab.runtime.type.value)} {lab.runtime.type.value}"
+        runtime_text = lab.runtime.type.value
 
         # Une seule section affichée par groupe : les lignes suivantes du
         # même groupe laissent la cellule vide.
@@ -114,9 +122,9 @@ def print_lab_detail(lab: LabDefinition, status: str | None = None) -> None:
         f"{_('field_type')}       {_type_badge(lab.lab_type)}"
         + (f"  —  bloc {lab.bloc}" if lab.bloc else ""),
         f"{_('field_level')}     [{_level_color(lab.level)}]{lab.level}[/{_level_color(lab.level)}]",
-        f"{_('field_runtime')}    {_runtime_icon(lab.runtime.type.value)} {lab.runtime.type.value} / {lab.runtime.topology}",
+        f"{_('field_runtime')}    {lab.runtime.type.value} / {lab.runtime.topology}",
         f"{_('field_duration')}      {lab.estimated_time}",
-        f"{_('field_difficulty')} {lab.difficulty}",
+        f"{_('field_difficulty')} {_difficulty_label(lab.difficulty)}",
         f"{_('field_distros')}    {', '.join(lab.distros)}",
         f"{_('field_skills')}     {', '.join(lab.skills)}",
         f"{_('field_doc')}        [link={lab.doc_url}]{lab.doc_url}[/link]",

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.25"
+version = "0.1.26"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
Deux défauts visibles sur chaque `dsoxlab show`.

## L'icône de runtime décalait l'affichage

Un emoji de largeur double, et son sélecteur de variante `U+FE0F`, sont comptés pour **une** colonne par Rich mais rendus sur **deux** par le terminal. La ligne glissait et la bordure du panneau se brisait.

L'icône est retirée de `show` et de `list-labs`.

Elle affichait de toute façon `?` sur **tous** les labs `vm` : sa table connaissait `kvm` et `incus`, les deux alias rétro-compat, mais pas `vm`, la valeur canonique du contrat. Elle n'avait pas suivi la migration.

Avant :

```
│ Runtime :    ? vm / local                                                    │
│ Difficulté : intermediate                                                    │
```

Après :

```
│ Runtime :    vm / local                                                      │
│ Difficulté : intermédiaire                                                   │
```

## La difficulté restait en anglais

`show` affichait « Difficulté : intermediate » sous une interface française.

Les trois valeurs employées par les dépôts de labs sont traduites : ce sont les seules présentes sur les **84 labs Linux** et les **113 labs Ansible** (`beginner`, `intermediate`, `advanced`).

Le champ restant **libre par contrat**, la traduction se fait par recherche de clé avec repli sur la valeur brute : toute autre valeur s'affiche telle quelle plutôt que de disparaître. Vérifié sur `expert`, sur une chaîne arbitraire et sur la chaîne vide.

## Tests

- `ruff` et `mypy --strict` verts, 97 tests
- rendu contrôlé en **FR et EN**, sur un lab `vm` et un lab `shell`
- alignement du panneau et de la table `list-labs` vérifié

## Release

CHANGELOG EN + FR, bump `0.1.26`, `uv.lock` inclus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
