### PR TITLE
fix(ci): refuser un tag qui ne correspond pas à la version empaquetée

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,26 @@ jobs:
           version: "0.11.26"
           enable-cache: false   # no cache in the publishing path (cache-poisoning hardening)
 
+      # The tag must match the version inside pyproject.toml. Twice now, a tag
+      # was pushed at a commit whose version had already moved on: v0.1.22 built
+      # the previous version, and v0.1.25 built 0.1.26 and published it under
+      # the wrong tag, so PyPI never received a 0.1.25 at all. Nothing in the
+      # pipeline objected, because the build reads pyproject and the tag is only
+      # used for the release notes. Fail loudly instead.
+      - name: Tag must match the packaged version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          packaged=$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)
+          if [ "${TAG#v}" != "$packaged" ]; then
+            echo "::error::Tag $TAG does not match pyproject version $packaged." \
+                 "Tag the commit that carries the matching version bump," \
+                 "or bump pyproject to ${TAG#v} before tagging."
+            exit 1
+          fi
+          echo "Tag $TAG matches the packaged version $packaged."
+
       - name: Build sdist and wheel
         run: uv build
 

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,7 +9,23 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.27] - 2026-07-23
+
+### Corrigé
+
+- **Le workflow de release publiait sous un tag qui ne correspondait pas à la
+  version empaquetée.** Le build lit `pyproject.toml`, le tag ne sert qu'aux
+  notes : rien ne vérifiait qu'ils concordent. Deux fois de suite, un tag posé
+  sur un commit dont la version avait déjà bougé a produit une publication
+  fausse. `v0.1.22` a republié 0.1.21, et `v0.1.25` a construit puis publié
+  0.1.26 sous le mauvais tag, si bien que PyPI n'a jamais reçu de 0.1.25. Le
+  workflow refuse désormais et dit quoi faire.
+
 ## [0.1.26] - 2026-07-23
+
+> Publiée sous le tag `v0.1.25`, posé sur un commit qui portait déjà le bump
+> 0.1.26 : PyPI n'a donc jamais reçu de 0.1.25, et tout ce que cette version
+> annonçait est présent ici.
 
 ### Corrigé
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.27] - 2026-07-23
+
+### Fixed
+
+- **The release workflow published under a tag that did not match the packaged
+  version.** The build reads `pyproject.toml`, the tag only feeds the release
+  notes, and nothing checked that they agree. Twice in a row, a tag pushed at a
+  commit whose version had already moved on produced a wrong publication:
+  `v0.1.22` republished 0.1.21, and `v0.1.25` built and published 0.1.26 under
+  the wrong tag, so PyPI never received a 0.1.25 at all. The workflow now fails
+  loudly and says what to do.
+
 ## [0.1.26] - 2026-07-23
+
+> Published under the `v0.1.25` tag, which was pushed at a commit already
+> carrying the 0.1.26 bump: PyPI never received a 0.1.25, and everything that
+> version announced is present here.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.26"
+version = "0.1.27"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.26"
+version = "0.1.27"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
## Ce qui vient de se passer

Le tag `v0.1.25` a été posé sur `3ac969a`, commit qui portait déjà le bump `0.1.26` fusionné par #38. Le workflow a construit **`dsoxlab-0.1.26`** et l'a publié sous le tag **`v0.1.25`**, sans qu'aucune étape ne proteste :

| | |
|---|---|
| Release GitHub | `v0.1.25` |
| Assets | `dsoxlab-0.1.26-py3-none-any.whl`, `dsoxlab-0.1.26.tar.gz` |
| PyPI | `0.1.26` publiée, **`0.1.25` n'existe pas** |

Les trois jobs sont pourtant au vert : *Build distribution*, *Publish to PyPI*, *Create GitHub Release*. Le contenu publié est correct (0.1.26 contient tout ce qu'annonçait 0.1.25), seul l'étiquetage est faux.

**C'est la deuxième fois.** Le CHANGELOG documente déjà `v0.1.22`, posé sur le mauvais commit, qui avait republié 0.1.21 : PyPI n'a jamais reçu de 0.1.22. La liste des versions publiées porte les deux trous :

```
0.1.21 · 0.1.23 · 0.1.24 · 0.1.26
```

## La cause

Le build lit la version dans `pyproject.toml`. Le tag ne sert qu'à extraire la section du CHANGELOG pour les notes de release. **Rien ne vérifiait qu'ils concordent**, alors que ce sont deux sources indépendantes qui doivent dire la même chose.

## Le correctif

Une étape ajoutée avant le build compare le tag à la version empaquetée et s'arrête net en indiquant laquelle des deux corriger.

Vérifié sur les deux incidents réels :

```
v0.1.25 vs pyproject 0.1.26  ->  REFUSÉ
v0.1.22 vs pyproject 0.1.21  ->  REFUSÉ
v0.1.26 vs pyproject 0.1.26  ->  accepté
v1.0.0  vs pyproject 1.0.0   ->  accepté
```

## Documentation

Le CHANGELOG note désormais, en tête de `0.1.26`, qu'elle a été publiée sous le tag `v0.1.25` et que `0.1.25` n'existe pas sur PyPI — même traitement que celui déjà appliqué à `0.1.22`.

## À décider de votre côté

Le contenu étant publié et correct, rien n'est cassé pour les utilisateurs : `uv tool upgrade dsoxlab` donne bien 0.1.26. Reste l'étiquetage. Reposer un tag `v0.1.26` sur le même commit ferait échouer le job PyPI, cette version y étant déjà présente. Le plus simple est sans doute de laisser la Release `v0.1.25` en place avec la note du CHANGELOG, ou de la renommer à la main.

## Release

CHANGELOG EN + FR, bump `0.1.27`, `uv.lock` inclus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
