### PR TITLE
fix(ci): ne plus conclure « tout est bon » quand la CI tourne encore

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,18 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.29] - 2026-07-23
+
+### Corrigé
+
+- **`check-release.py` concluait « Tout est bon » alors qu'il venait de
+  signaler une CI en cours.** Son premier usage réel l'a montré : le message
+  final contredisait l'avertissement, et invitait à taguer précisément quand
+  `RELEASING` demande d'attendre. Une CI en cours est désormais une
+  **attente** et non une simple note : le script sort en 2 avec « il est trop
+  tôt », distinct de l'échec (1) où quelque chose est à corriger, et du feu
+  vert (0).
+
 ## [0.1.28] - 2026-07-23
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.29] - 2026-07-23
+
+### Fixed
+
+- **`check-release.py` concluded "All good" right after warning that CI was
+  still running.** Its first real use showed it: the closing message
+  contradicted the warning and invited tagging exactly when `RELEASING` says
+  to wait. A running CI is now a **wait** rather than a plain note: the script
+  exits 2 with "too early", distinct from failure (1), where something needs
+  fixing, and from the green light (0).
+
 ## [0.1.28] - 2026-07-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.28"
+version = "0.1.29"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/check-release.py
+++ b/scripts/check-release.py
@@ -41,6 +41,7 @@ class Rapport:
 
     def __init__(self) -> None:
         self.echecs: list[str] = []
+        self.attentes: list[str] = []
 
     def ok(self, titre: str, detail: str = "") -> None:
         suffixe = f" {detail}" if detail else ""
@@ -52,8 +53,20 @@ class Rapport:
         self.echecs.append(titre)
 
     def note(self, titre: str, detail: str) -> None:
+        """Information : n'empêche pas de taguer."""
         print(f"  {JAUNE}!{RAZ} {titre}")
         print(f"      {detail}")
+
+    def attendre(self, titre: str, detail: str) -> None:
+        """Rien n'est faux, mais il est trop tôt pour taguer.
+
+        Distinct d'un échec : il n'y a rien à corriger, seulement à
+        attendre. Distinct d'une note : conclure « tout est bon » ici
+        reviendrait à encourager ce que RELEASING interdit.
+        """
+        print(f"  {JAUNE}⏳{RAZ} {titre}")
+        print(f"      {detail}")
+        self.attentes.append(titre)
 
 
 def git(*args: str) -> str:
@@ -207,9 +220,9 @@ def _verifier_ci(r: Rapport) -> None:
             "Corrige avant de taguer : le tag publie ce commit tel quel.",
         )
     elif en_cours:
-        r.note(
+        r.attendre(
             f"CI encore en cours : {', '.join(sorted(set(en_cours)))}",
-            "Attends la fin. PyPI est définitif.",
+            "Attends la fin, puis relance ce contrôle. PyPI est définitif.",
         )
     else:
         r.ok("CI verte sur ce commit")
@@ -237,6 +250,10 @@ def main() -> int:
         print(f"{ROUGE}{GRAS}{len(r.echecs)} contrôle(s) en échec.{RAZ} "
               "Ne pose pas le tag.\n")
         return 1
+    if r.attentes:
+        print(f"{JAUNE}{GRAS}Rien n'est faux, mais il est trop tôt.{RAZ} "
+              "Attends puis relance ce contrôle.\n")
+        return 2
     print(f"{VERT}{GRAS}Tout est bon.{RAZ} Pose le tag :\n")
     print(f'    git tag -a {tag} -m "{tag}" && git push origin {tag}\n')
     return 0

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.28"
+version = "0.1.29"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
Défaut trouvé au **premier usage réel** du script livré en 0.1.28.

Il affichait l'avertissement, puis se contredisait :

```
  ! CI encore en cours : CI, OpenSSF Scorecard, Plumber compliance
      Attends la fin. PyPI est définitif.

  Tout est bon. Pose le tag :          ← et sortie 0
```

Le message final invitait à taguer précisément dans le cas où `RELEASING` demande d'attendre, alors que PyPI est définitif. Un script censé empêcher les publications hâtives ne peut pas les encourager.

## Le correctif

Une CI en cours devient une **attente**, distincte des deux autres issues : rien n'est à corriger, il est seulement trop tôt.

| Code | Sens |
|---|---|
| `0` | prêt à taguer, la commande est affichée |
| `1` | quelque chose est à corriger, ne pose pas le tag |
| `2` | rien n'est faux, mais il est trop tôt : attends et relance |

## Vérifié sur les deux chemins

**CI en cours, aucun autre problème** :

```
  ⏳ CI encore en cours : CI
      Attends la fin, puis relance ce contrôle. PyPI est définitif.

Rien n'est faux, mais il est trop tôt. Attends puis relance ce contrôle.
→ code 2
```

**Échecs présents** :

```
4 contrôle(s) en échec. Ne pose pas le tag.
→ code 1
```

## Note

La 0.1.28 a été publiée avec la version fautive du script, mais sans conséquence : la CI était terminée au moment du tag, et les neuf contrôles étaient verts. La cohérence tag/version/PyPI a été vérifiée après coup.

## Release

CHANGELOG EN + FR, bump `0.1.29`, `uv.lock` inclus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
