### PR TITLE
feat(validators): porter les contrôles de contenu dans l'outil

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -13,6 +13,17 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- **Trois contrôles de structure supplémentaires.** Le **barème** d'abord :
+  dsoxlab note **par test**, donc un lab qui annonce cinq tâches à 20 points
+  mais compte six tests attribue en réalité 16,7 points par tâche, et le
+  barème affiché ment sans que personne puisse le deviner. Il ne se déclenche
+  que si l'énoncé annonce des points par tâche : un examen blanc qui vérifie
+  plusieurs points par tâche fait un autre choix, tout aussi valable. La
+  **parité des langues** ensuite, un `.fr.md` sans équivalent laissant
+  l'autre moitié des apprenants sur un contenu absent ou périmé. Les
+  **cibles vm** enfin, dont le FQDN ne se vérifiait qu'au moment de jouer le
+  lab, sur la machine de l'apprenant et après provisionnement, alors qu'il
+  est lisible dans le contrat.
 - **`validate-structure` contrôle désormais le contenu, pas seulement la
   présence des fichiers.** Trois dérives silencieuses, qu'aucun test
   fonctionnel n'attrape parce qu'elles ne cassent pas l'exécution d'un lab :

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,22 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.30] - 2026-07-23
+
+### Ajouté
+
+- **`validate-structure` contrôle désormais le contenu, pas seulement la
+  présence des fichiers.** Trois dérives silencieuses, qu'aucun test
+  fonctionnel n'attrape parce qu'elles ne cassent pas l'exécution d'un lab :
+  un **lien relatif mort** dans un Markdown (le dépôt Ansible en comptait 150
+  le jour où le contrôle y a été écrit), une **solution laissée en clair**
+  (irrattrapable : git la garde pour toujours), et un **`doc_url` qui ne
+  répond plus**, via l'option `--check-urls` puisqu'elle sort sur le réseau.
+  Ces contrôles étaient recopiés à la main dans chaque dépôt de labs ; ils
+  profitent maintenant à tous. Le contrôle des solutions ne s'applique qu'aux
+  dépôts qui tiennent un répertoire `solution/` : son absence n'est pas une
+  faute, c'est un autre choix.
+
 ## [0.1.29] - 2026-07-23
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30] - 2026-07-23
+
+### Added
+
+- **`validate-structure` now checks content, not just file presence.** Three
+  silent drifts that no functional test catches, because they do not break a
+  lab's execution: a **dead relative link** in a Markdown file (the Ansible
+  repo had 150 the day the check was written there), a **solution left in
+  plain text** (unrecoverable: git keeps it forever), and a **`doc_url` that
+  no longer answers**, behind the `--check-urls` flag since it hits the
+  network. These checks were hand-copied into each lab repository; they now
+  benefit all of them. The solution check only applies to repositories that
+  keep a `solution/` directory: its absence is not a fault, just another
+  choice.
+
 ## [0.1.29] - 2026-07-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Three more structural checks.** **Scoring** first: dsoxlab scores **per
+  test**, so a lab announcing five tasks at 20 points while shipping six
+  tests really awards 16.7 per task, and the printed scale lies with no way
+  for anyone to notice. It only fires when the statement announces per-task
+  points: a mock exam checking several things per task is making another,
+  equally valid choice. **Language parity** next, since a `.fr.md` with no
+  counterpart leaves the other half of learners on missing or stale content.
+  **VM targets** last, whose FQDN was only verified when playing the lab, on
+  the learner's machine and after provisioning, though it is readable
+  straight from the contract.
 - **`validate-structure` now checks content, not just file presence.** Three
   silent drifts that no functional test catches, because they do not break a
   lab's execution: a **dead relative link** in a Markdown file (the Ansible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.29"
+version = "0.1.30"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -1166,12 +1166,65 @@ def clean(
 @app.command("validate-structure", help=_("cmd_validate_help"))
 def validate_structure_cmd(
     lab_home: LabHomeOption = None,
+    check_urls: Annotated[bool, typer.Option(
+        "--check-urls", help=_("opt_check_urls"),
+    )] = False,
 ) -> None:
+    from .discovery.scanner import discover_labs
+    from .validators.content import (
+        check_doc_url,
+        validate_internal_links,
+        validate_solutions_encrypted,
+    )
+
     root = _root(lab_home)
     structure_reports = validate_all_structure(root)
     metadata_reports = validate_all_metadata(root)
 
     print_structure_reports(structure_reports)
+
+    # Contrôles de contenu : locaux, donc jouables hors ligne et par défaut.
+    # Un lien mort ou une solution en clair ne casse aucun test fonctionnel,
+    # c'est bien pourquoi rien ne les attrapait.
+    labs = discover_labs(root)
+    content_issues: list[tuple[str, Path, str]] = []
+    for lab in labs:
+        rapports = [validate_internal_links(lab)]
+        # « solution/<chemin du lab depuis labs/> » : convention respectée par
+        # les dépôts qui tiennent leurs corrigés hors des labs. Absent = pas
+        # de contrôle, ce n'est pas une faute.
+        try:
+            relatif = lab.path.relative_to(root / "labs")
+        except ValueError:
+            relatif = None
+        if relatif is not None:
+            rapports.append(
+                validate_solutions_encrypted(lab, root / "solution" / relatif)
+            )
+        for rapport in rapports:
+            for souci in rapport.issues:
+                content_issues.append((lab.id, souci.path, souci.message))
+
+    if content_issues:
+        console.print(_("content_issues_header"))
+        for lab_id, chemin, message in content_issues:
+            try:
+                affiche = chemin.relative_to(root)
+            except ValueError:
+                affiche = chemin
+            console.print(f"  [red]✘[/red] {lab_id} — {affiche}: {message}")
+
+    url_issues: list[tuple[str, str]] = []
+    if check_urls:
+        info(_("checking_doc_urls", count=len(labs)))
+        for lab in labs:
+            motif = check_doc_url(lab)
+            if motif is not None:
+                url_issues.append((lab.id, f"{lab.doc_url} — {motif}"))
+        if url_issues:
+            console.print(_("doc_url_issues_header"))
+            for lab_id, detail in url_issues:
+                console.print(f"  [red]✘[/red] {lab_id} — {detail}")
 
     issues = [r for r in metadata_reports if not r.ok]
     if issues:
@@ -1180,7 +1233,12 @@ def validate_structure_cmd(
             for issue in report.issues:
                 console.print(f"  [red]✘[/red] {report.lab_id} — {issue.field}: {issue.message}")
 
-    all_ok = all(r.ok for r in structure_reports) and not issues
+    all_ok = (
+        all(r.ok for r in structure_reports)
+        and not issues
+        and not content_issues
+        and not url_issues
+    )
     if all_ok:
         success(_("all_labs_valid"))
     else:

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -1171,10 +1171,14 @@ def validate_structure_cmd(
     )] = False,
 ) -> None:
     from .discovery.scanner import discover_labs
+    from .discovery.repo import read_repo_metadata
     from .validators.content import (
         check_doc_url,
         validate_internal_links,
+        validate_language_parity,
+        validate_scoring,
         validate_solutions_encrypted,
+        validate_targets,
     )
 
     root = _root(lab_home)
@@ -1187,9 +1191,22 @@ def validate_structure_cmd(
     # Un lien mort ou une solution en clair ne casse aucun test fonctionnel,
     # c'est bien pourquoi rien ne les attrapait.
     labs = discover_labs(root)
+    # Les cibles vm se valident contre infra.hosts : un FQDN inconnu ne se
+    # voyait qu'au run, sur la machine de l'apprenant, après provisionnement.
+    try:
+        repo_meta = read_repo_metadata(root)
+        host_names = {h.name for h in repo_meta.infra.hosts} if repo_meta else set()
+    except Exception:  # noqa: BLE001 - meta.yml illisible : les autres contrôles restent utiles
+        host_names = set()
+
     content_issues: list[tuple[str, Path, str]] = []
     for lab in labs:
-        rapports = [validate_internal_links(lab)]
+        rapports = [
+            validate_internal_links(lab),
+            validate_scoring(lab),
+            validate_language_parity(lab),
+            validate_targets(lab, host_names),
+        ]
         # « solution/<chemin du lab depuis labs/> » : convention respectée par
         # les dépôts qui tiennent leurs corrigés hors des labs. Absent = pas
         # de contrôle, ce n'est pas une faute.

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -361,6 +361,14 @@ silent.
     # ── validate-structure ────────────────────────────────────────────────────
     "all_labs_valid":         "All labs are valid.",
     "labs_have_issues":       "Some labs have structure or metadata issues.",
+    "opt_check_urls":
+        "Also check that every doc_url answers (hits the network).",
+    "content_issues_header":
+        "\n[bold]Content:[/bold]",
+    "doc_url_issues_header":
+        "\n[bold]Unreachable guides:[/bold]",
+    "checking_doc_urls":
+        "Checking doc_url for {count} lab(s)…",
     "metadata_issues_header": "\n[bold red]Metadata issues:[/bold red]",
 
     # ── doctor — component labels ─────────────────────────────────────────────

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -359,6 +359,14 @@ hors ligne, elle se tait.
     # ── validate-structure ────────────────────────────────────────────────────
     "all_labs_valid":         "Tous les labs sont valides.",
     "labs_have_issues":       "Des labs ont des problèmes de structure ou de métadonnées.",
+    "opt_check_urls":
+        "Vérifier aussi que chaque doc_url répond (sort sur le réseau).",
+    "content_issues_header":
+        "\n[bold]Contenu :[/bold]",
+    "doc_url_issues_header":
+        "\n[bold]Guides injoignables :[/bold]",
+    "checking_doc_urls":
+        "Vérification des doc_url de {count} lab(s)…",
     "metadata_issues_header": "\n[bold red]Problèmes de métadonnées :[/bold red]",
 
     # ── doctor — libellés composants ─────────────────────────────────────────

--- a/src/dsoxlab/validators/__init__.py
+++ b/src/dsoxlab/validators/__init__.py
@@ -1,6 +1,23 @@
 """Package validators."""
 
+from .content import (
+    ContentIssue,
+    ContentReport,
+    check_doc_url,
+    validate_internal_links,
+    validate_solutions_encrypted,
+)
 from .metadata import MetadataReport, validate_metadata
 from .structure import StructureReport, validate_structure
 
-__all__ = ["validate_structure", "StructureReport", "validate_metadata", "MetadataReport"]
+__all__ = [
+    "ContentIssue",
+    "ContentReport",
+    "MetadataReport",
+    "StructureReport",
+    "check_doc_url",
+    "validate_internal_links",
+    "validate_metadata",
+    "validate_solutions_encrypted",
+    "validate_structure",
+]

--- a/src/dsoxlab/validators/__init__.py
+++ b/src/dsoxlab/validators/__init__.py
@@ -5,7 +5,10 @@ from .content import (
     ContentReport,
     check_doc_url,
     validate_internal_links,
+    validate_language_parity,
+    validate_scoring,
     validate_solutions_encrypted,
+    validate_targets,
 )
 from .metadata import MetadataReport, validate_metadata
 from .structure import StructureReport, validate_structure
@@ -17,7 +20,10 @@ __all__ = [
     "StructureReport",
     "check_doc_url",
     "validate_internal_links",
+    "validate_language_parity",
+    "validate_scoring",
     "validate_metadata",
     "validate_solutions_encrypted",
+    "validate_targets",
     "validate_structure",
 ]

--- a/src/dsoxlab/validators/content.py
+++ b/src/dsoxlab/validators/content.py
@@ -1,0 +1,168 @@
+"""Contrôles de contenu : liens internes, doc_url, solutions chiffrées.
+
+`validate_structure` répond à « les fichiers du contrat sont-ils là ? ». Ces
+contrôles-ci répondent à « ce qu'ils contiennent tient-il debout ? ». Trois
+dérives silencieuses, qu'aucun test fonctionnel n'attrape parce qu'elles ne
+cassent pas l'exécution d'un lab, seulement l'expérience de l'apprenant :
+
+- **un lien interne mort** ne casse que la navigation. Le dépôt Ansible en
+  comptait 150 le jour où le contrôle y a été écrit ;
+- **un `doc_url` mort** envoie l'apprenant vers une page disparue, alors que le
+  contrat exige ce champ précisément pour le renvoyer au guide ;
+- **une solution en clair** est irrattrapable : git la garde pour toujours, et
+  le lab est gâché pour quiconque lit le dépôt.
+
+Ces trois contrôles étaient écrits à la main dans chaque dépôt de labs. Ils
+vivent ici pour que tout dépôt en bénéficie sans les recopier.
+
+Rien ici n'est spécifique à un domaine : on ne lit que le contrat déclaratif et
+l'arborescence.
+"""
+
+from __future__ import annotations
+
+import re
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import urlparse
+
+from ..models.lab import LabDefinition
+
+#: `[libellé](cible)` où la cible est relative. Les URL absolues relèvent du
+#: contrôle des doc_url, pas de celui-ci.
+_LIEN_RELATIF = re.compile(r"\[[^\]]*\]\((\.\.?/[^)]+)\)")
+
+#: En-tête que `ansible-vault` écrit en première ligne d'un fichier chiffré.
+#: Le vérifier vaut mieux que faire confiance à l'auteur.
+_ENTETE_VAULT = "$ANSIBLE_VAULT"
+
+#: Extensions considérées comme du contenu de solution. Une image ou un
+#: README dans `solution/` n'a pas à être chiffré.
+_EXTENSIONS_SOLUTION = {".yaml", ".yml", ".sh", ".py", ".bash", ".txt"}
+
+_TIMEOUT_HTTP = 10.0
+
+#: Beaucoup de sites refusent une requête sans User-Agent identifiable et
+#: rendent 403. Sans cet en-tête, le contrôle déclarait morts des guides qui
+#: répondent parfaitement dans un navigateur.
+_ENTETES = {"User-Agent": "dsoxlab-doc-url-check/1.0"}
+
+
+@dataclass
+class ContentIssue:
+    path: Path
+    message: str
+
+
+@dataclass
+class ContentReport:
+    lab_id: str
+    issues: list[ContentIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return len(self.issues) == 0
+
+
+def _liens_casses(fichier: Path) -> list[str]:
+    """Cibles relatives introuvables depuis ce fichier.
+
+    L'ancre (`#section`) est retirée avant le test : elle est résolue par le
+    lecteur Markdown, pas par le système de fichiers.
+    """
+    try:
+        contenu = fichier.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return []
+    casses = []
+    for cible in _LIEN_RELATIF.findall(contenu):
+        if not (fichier.parent / cible.split("#")[0]).resolve().exists():
+            casses.append(cible)
+    return casses
+
+
+def validate_internal_links(lab: LabDefinition) -> ContentReport:
+    """Tout lien relatif d'un Markdown du lab doit pointer sur un fichier."""
+    report = ContentReport(lab_id=lab.id)
+    for fichier in sorted(lab.path.rglob("*.md")):
+        casses = _liens_casses(fichier)
+        if casses:
+            report.issues.append(ContentIssue(
+                path=fichier,
+                message=(
+                    f"{len(casses)} lien(s) relatif(s) mort(s) : "
+                    + ", ".join(casses)
+                ),
+            ))
+    return report
+
+
+def validate_solutions_encrypted(
+    lab: LabDefinition, solutions_root: Path
+) -> ContentReport:
+    """Aucun fichier de solution ne doit être lisible en clair.
+
+    Le contrôle ne s'applique qu'aux dépôts qui tiennent un répertoire de
+    solutions : un dépôt sans `solution/` n'est pas en faute, il a simplement
+    fait un autre choix.
+    """
+    report = ContentReport(lab_id=lab.id)
+    if not solutions_root.is_dir():
+        return report
+    for fichier in sorted(solutions_root.rglob("*")):
+        if not fichier.is_file() or fichier.suffix not in _EXTENSIONS_SOLUTION:
+            continue
+        try:
+            with fichier.open("r", encoding="utf-8", errors="ignore") as flux:
+                premiere = flux.readline()
+        except OSError as exc:
+            report.issues.append(ContentIssue(fichier, f"illisible : {exc}"))
+            continue
+        if not premiere.startswith(_ENTETE_VAULT):
+            report.issues.append(ContentIssue(
+                path=fichier,
+                message=(
+                    "solution en clair : chiffre-la avec "
+                    "« ansible-vault encrypt », sinon git la garde pour "
+                    "toujours et le lab est gâché"
+                ),
+            ))
+    return report
+
+
+def check_doc_url(lab: LabDefinition, *, timeout: float = _TIMEOUT_HTTP) -> str | None:
+    """Vérifie que le `doc_url` du lab répond. Rend le motif d'échec, ou None.
+
+    Séparé des autres contrôles parce qu'il sort sur le réseau : il n'a rien à
+    faire dans une validation par défaut, qui doit rester rapide et jouable
+    hors ligne.
+    """
+    url = lab.doc_url
+    if not url:
+        return None
+    schema = urlparse(url).scheme
+    if schema not in ("http", "https"):
+        return f"schéma inattendu : {schema or '(aucun)'}"
+    requete = urllib.request.Request(  # noqa: S310 - schéma vérifié
+        url, method="HEAD", headers=_ENTETES
+    )
+    try:
+        with urllib.request.urlopen(requete, timeout=timeout) as reponse:  # noqa: S310
+            code = reponse.status
+    except urllib.error.HTTPError as exc:
+        # Certains sites refusent HEAD mais servent GET : on retente avant
+        # de déclarer une page morte.
+        if exc.code in (403, 405):
+            try:
+                repli = urllib.request.Request(url, headers=_ENTETES)  # noqa: S310
+                with urllib.request.urlopen(repli, timeout=timeout) as reponse:  # noqa: S310
+                    code = reponse.status
+            except (urllib.error.URLError, OSError) as exc2:
+                return f"injoignable : {exc2}"
+        else:
+            return f"HTTP {exc.code}"
+    except (urllib.error.URLError, OSError) as exc:
+        return f"injoignable : {exc}"
+    return None if 200 <= code < 400 else f"HTTP {code}"

--- a/src/dsoxlab/validators/content.py
+++ b/src/dsoxlab/validators/content.py
@@ -166,3 +166,135 @@ def check_doc_url(lab: LabDefinition, *, timeout: float = _TIMEOUT_HTTP) -> str 
     except (urllib.error.URLError, OSError) as exc:
         return f"injoignable : {exc}"
     return None if 200 <= code < 400 else f"HTTP {code}"
+
+
+#: `### Tâche 3 — … (20 pts)` : un titre de tâche qui annonce ses points.
+#: Les `##` (sections d'un examen blanc) totalisent leurs `###` : les compter
+#: doublerait la somme, ce qui a produit un faux positif à 200 points.
+_TACHE_NOTEE = re.compile(
+    r"^###\s.*?\((\d+)\s*(?:pts|points)\)", re.M
+)
+
+#: L'en-tête annonce le format : « 5 tâches, 100 points, 20 minutes ».
+_FORMAT_ANNONCE = re.compile(
+    r"(\d+)\s*(?:tâches|taches|tasks)[^.\n]*?(\d+)\s*(?:points|pts)",
+    re.IGNORECASE,
+)
+
+_TEST_PYTHON = re.compile(r"^def test_", re.M)
+
+
+def _lire(chemin: Path) -> str:
+    try:
+        return chemin.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def validate_scoring(lab: LabDefinition) -> ContentReport:
+    """Le barème annoncé doit correspondre à la note réellement calculée.
+
+    dsoxlab note **par test** : sur cinq tests, chacun vaut 20 points. Si
+    l'énoncé annonce cinq tâches à 20 points mais que le fichier de tests en
+    compte six, chaque tâche vaut en réalité 16,7 et le barème affiché ment.
+    L'apprenant ne peut pas le deviner, et l'auteur non plus : ajouter une
+    vérification à un lab suffit à décaler tout son barème.
+
+    Le contrôle ne s'applique **que** si l'énoncé annonce des points par
+    tâche. Un examen blanc qui vérifie plusieurs points par tâche sans
+    afficher de barème détaillé fait un autre choix, tout aussi valable.
+    """
+    report = ContentReport(lab_id=lab.id)
+    enonce = lab.path / "challenge" / "README.fr.md"
+    if not enonce.is_file():
+        enonce = lab.path / "challenge" / "README.md"
+    tests = lab.path / "challenge" / "tests" / "test_functional.py"
+    if not enonce.is_file() or not tests.is_file():
+        return report
+
+    texte = _lire(enonce)
+    points = [int(x) for x in _TACHE_NOTEE.findall(texte)]
+    if not points:
+        return report
+
+    nb_tests = len(_TEST_PYTHON.findall(_lire(tests)))
+    if nb_tests and nb_tests != len(points):
+        report.issues.append(ContentIssue(
+            path=enonce,
+            message=(
+                f"{len(points)} tâche(s) notée(s) pour {nb_tests} test(s) : "
+                "le score se calcule par test, donc le barème affiché ne "
+                "correspond pas à la note obtenue"
+            ),
+        ))
+
+    annonce = _FORMAT_ANNONCE.search(texte)
+    if annonce is not None:
+        nb_annonce, total_annonce = int(annonce.group(1)), int(annonce.group(2))
+        if sum(points) != total_annonce:
+            report.issues.append(ContentIssue(
+                path=enonce,
+                message=(
+                    f"les tâches totalisent {sum(points)} points, "
+                    f"l'en-tête en annonce {total_annonce}"
+                ),
+            ))
+        if len(points) != nb_annonce:
+            report.issues.append(ContentIssue(
+                path=enonce,
+                message=(
+                    f"{len(points)} tâche(s) notée(s), "
+                    f"l'en-tête en annonce {nb_annonce}"
+                ),
+            ))
+    return report
+
+
+def validate_language_parity(lab: LabDefinition) -> ContentReport:
+    """Un document traduit dans une seule langue se dégrade en silence.
+
+    Le contrat prévoit `<nom>.fr.md` à côté de `<nom>.md`. Quand seule une
+    langue existe, rien ne proteste : l'apprenant de l'autre langue tombe sur
+    un contenu absent, ou pire, sur une version périmée que personne ne
+    relit.
+    """
+    report = ContentReport(lab_id=lab.id)
+    for francais in sorted(lab.path.rglob("*.fr.md")):
+        anglais = francais.with_name(francais.name.replace(".fr.md", ".md"))
+        if not anglais.is_file():
+            report.issues.append(ContentIssue(
+                path=francais,
+                message=f"pas d'équivalent anglais ({anglais.name})",
+            ))
+    return report
+
+
+def validate_targets(lab: LabDefinition, host_names: set[str]) -> ContentReport:
+    """Les cibles d'un lab vm doivent exister dans `infra.hosts` du meta.yml.
+
+    Aujourd'hui, un FQDN inconnu ne se voit qu'au moment de jouer le lab :
+    l'inventaire lève, sur la machine de l'apprenant, après provisionnement.
+    Le défaut est pourtant lisible dans le contrat, donc détectable avant.
+    """
+    report = ContentReport(lab_id=lab.id)
+    if not host_names:
+        return report
+    for cible in lab.runtime.targets:
+        if cible.host and cible.host not in host_names:
+            report.issues.append(ContentIssue(
+                path=lab.path / "lab.yaml",
+                message=(
+                    f"target « {cible.name} » vise l'hôte « {cible.host} », "
+                    "absent de infra.hosts du meta.yml"
+                ),
+            ))
+        for role, hote in (cible.roles or {}).items():
+            if hote not in host_names:
+                report.issues.append(ContentIssue(
+                    path=lab.path / "lab.yaml",
+                    message=(
+                        f"le rôle « {role} » vise « {hote} », "
+                        "absent de infra.hosts du meta.yml"
+                    ),
+                ))
+    return report

--- a/tests/test_validators_content.py
+++ b/tests/test_validators_content.py
@@ -1,0 +1,160 @@
+"""Les contrôles de contenu doivent trouver ce qu'aucun test fonctionnel ne voit.
+
+Un lien mort, un guide disparu, une solution en clair : rien de tout cela
+n'empêche un lab de s'exécuter. C'est précisément pourquoi ces défauts
+survivaient. Ces tests vérifient donc surtout que le contrôle *échoue* quand il
+le doit, et qu'il reste muet là où il n'a rien à dire.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from dsoxlab.models.lab import LabDefinition, ValidationConfig
+from dsoxlab.models.runtime import RuntimeConfig, RuntimeType
+from dsoxlab.validators import content
+
+
+def _lab(chemin: Path, doc_url: str = "https://example.test/guide") -> LabDefinition:
+    return LabDefinition(
+        id="lab-test",
+        title="Lab de test",
+        level="l1",
+        path=chemin,
+        doc_url=doc_url,
+        runtime=RuntimeConfig(type=RuntimeType.SHELL, workdir="work"),
+        skills=["test"],
+        distros=["almalinux10"],
+        validation=ValidationConfig(),
+    )
+
+
+class TestLiensInternes:
+    def test_un_lien_mort_est_signale(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text(
+            "Voir [le lab](../autre/lab.md) pour la suite.", encoding="utf-8"
+        )
+        rapport = content.validate_internal_links(_lab(tmp_path))
+        assert not rapport.ok
+        assert "../autre/lab.md" in rapport.issues[0].message
+
+    def test_un_lien_valide_ne_dit_rien(self, tmp_path: Path) -> None:
+        (tmp_path / "cible.md").write_text("cible", encoding="utf-8")
+        (tmp_path / "README.md").write_text(
+            "Voir [la cible](./cible.md).", encoding="utf-8"
+        )
+        assert content.validate_internal_links(_lab(tmp_path)).ok
+
+    def test_l_ancre_est_ignoree(self, tmp_path: Path) -> None:
+        """`#section` est résolu par le lecteur Markdown, pas par le disque."""
+        (tmp_path / "cible.md").write_text("cible", encoding="utf-8")
+        (tmp_path / "README.md").write_text(
+            "Voir [la section](./cible.md#une-section).", encoding="utf-8"
+        )
+        assert content.validate_internal_links(_lab(tmp_path)).ok
+
+    def test_une_url_absolue_n_est_pas_de_son_ressort(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text(
+            "Voir [le guide](https://example.test/absent).", encoding="utf-8"
+        )
+        assert content.validate_internal_links(_lab(tmp_path)).ok
+
+    def test_lab_sans_markdown(self, tmp_path: Path) -> None:
+        assert content.validate_internal_links(_lab(tmp_path)).ok
+
+
+class TestSolutionsChiffrees:
+    def test_une_solution_en_clair_est_signalee(self, tmp_path: Path) -> None:
+        sol = tmp_path / "solution"
+        sol.mkdir()
+        (sol / "solution.yaml").write_text("- name: en clair\n", encoding="utf-8")
+        rapport = content.validate_solutions_encrypted(_lab(tmp_path), sol)
+        assert not rapport.ok
+        assert "en clair" in rapport.issues[0].message
+
+    def test_une_solution_chiffree_passe(self, tmp_path: Path) -> None:
+        sol = tmp_path / "solution"
+        sol.mkdir()
+        (sol / "solution.yaml").write_text(
+            "$ANSIBLE_VAULT;1.1;AES256\n3462383...\n", encoding="utf-8"
+        )
+        assert content.validate_solutions_encrypted(_lab(tmp_path), sol).ok
+
+    def test_repertoire_absent_n_est_pas_une_faute(self, tmp_path: Path) -> None:
+        """Un dépôt sans corrigés a fait un autre choix, pas une erreur."""
+        assert content.validate_solutions_encrypted(
+            _lab(tmp_path), tmp_path / "nexiste-pas"
+        ).ok
+
+    def test_un_readme_dans_solution_n_a_pas_a_etre_chiffre(
+        self, tmp_path: Path
+    ) -> None:
+        sol = tmp_path / "solution"
+        sol.mkdir()
+        (sol / "README.md").write_text("Comment lire ces corrigés.", encoding="utf-8")
+        assert content.validate_solutions_encrypted(_lab(tmp_path), sol).ok
+
+
+class TestDocUrl:
+    def test_url_qui_repond(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(content.urllib.request, "urlopen", _reponse(200))
+        assert content.check_doc_url(_lab(tmp_path)) is None
+
+    def test_page_disparue(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _404(*_a: object, **_k: object) -> None:
+            raise urllib.error.HTTPError("u", 404, "Not Found", {}, None)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(content.urllib.request, "urlopen", _404)
+        assert content.check_doc_url(_lab(tmp_path)) == "HTTP 404"
+
+    def test_head_refuse_mais_get_repond(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Des sites refusent HEAD et servent GET : ce n'est pas une page morte."""
+        appels: list[int] = []
+
+        def _selon_appel(*_a: object, **_k: object) -> object:
+            appels.append(1)
+            if len(appels) == 1:
+                raise urllib.error.HTTPError("u", 405, "Not Allowed", {}, None)  # type: ignore[arg-type]
+            return _Reponse(200)
+
+        monkeypatch.setattr(content.urllib.request, "urlopen", _selon_appel)
+        assert content.check_doc_url(_lab(tmp_path)) is None
+        assert len(appels) == 2
+
+    def test_hors_ligne(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boum(*_a: object, **_k: object) -> None:
+            raise urllib.error.URLError("network is unreachable")
+
+        monkeypatch.setattr(content.urllib.request, "urlopen", _boum)
+        motif = content.check_doc_url(_lab(tmp_path))
+        assert motif is not None and "injoignable" in motif
+
+    def test_schema_inattendu(self, tmp_path: Path) -> None:
+        motif = content.check_doc_url(_lab(tmp_path, doc_url="ftp://exemple/guide"))
+        assert motif is not None and "ftp" in motif
+
+    def test_sans_doc_url(self, tmp_path: Path) -> None:
+        assert content.check_doc_url(_lab(tmp_path, doc_url="")) is None
+
+
+class _Reponse:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    def __enter__(self) -> _Reponse:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+
+def _reponse(status: int):  # noqa: ANN202 - fabrique de doublure
+    def _ouvrir(*_a: object, **_k: object) -> _Reponse:
+        return _Reponse(status)
+
+    return _ouvrir

--- a/tests/test_validators_content.py
+++ b/tests/test_validators_content.py
@@ -158,3 +158,96 @@ def _reponse(status: int):  # noqa: ANN202 - fabrique de doublure
         return _Reponse(status)
 
     return _ouvrir
+
+
+class TestBareme:
+    """Le score se calcule par test : un test de plus décale tout le barème."""
+
+    def _lab_note(self, tmp_path: Path, taches: int, tests: int) -> LabDefinition:
+        ch = tmp_path / "challenge"
+        (ch / "tests").mkdir(parents=True)
+        points = 100 // taches
+        corps = f"**Format** : {taches} tâches, {points * taches} points.\n\n"
+        corps += "".join(
+            f"### Tâche {i} — quelque chose ({points} pts)\n\n" for i in range(1, taches + 1)
+        )
+        (ch / "README.fr.md").write_text(corps, encoding="utf-8")
+        (ch / "tests" / "test_functional.py").write_text(
+            "".join(f"def test_{i}(host):\n    assert True\n\n" for i in range(tests)),
+            encoding="utf-8",
+        )
+        return _lab(tmp_path)
+
+    def test_un_test_de_plus_est_signale(self, tmp_path: Path) -> None:
+        rapport = content.validate_scoring(self._lab_note(tmp_path, taches=5, tests=6))
+        assert not rapport.ok
+        assert "5 tâche(s) notée(s) pour 6 test(s)" in rapport.issues[0].message
+
+    def test_un_pour_un_passe(self, tmp_path: Path) -> None:
+        assert content.validate_scoring(self._lab_note(tmp_path, taches=5, tests=5)).ok
+
+    def test_sans_bareme_par_tache_le_controle_se_tait(self, tmp_path: Path) -> None:
+        """Un examen blanc peut vérifier plusieurs points par tâche."""
+        ch = tmp_path / "challenge"
+        (ch / "tests").mkdir(parents=True)
+        (ch / "README.fr.md").write_text(
+            "### Tâche 1 — sans points annoncés\n", encoding="utf-8"
+        )
+        (ch / "tests" / "test_functional.py").write_text(
+            "def test_a(h): ...\ndef test_b(h): ...\n", encoding="utf-8"
+        )
+        assert content.validate_scoring(_lab(tmp_path)).ok
+
+    def test_les_sections_ne_sont_pas_comptees_comme_taches(self, tmp_path: Path) -> None:
+        """`## Section A (20 pts)` totalise ses `###` : la compter doublerait."""
+        ch = tmp_path / "challenge"
+        (ch / "tests").mkdir(parents=True)
+        (ch / "README.fr.md").write_text(
+            "**Format** : 2 tâches, 20 points.\n\n"
+            "## Section A — bloc (20 pts)\n\n"
+            "### Tâche 1 — a (10 pts)\n\n### Tâche 2 — b (10 pts)\n",
+            encoding="utf-8",
+        )
+        (ch / "tests" / "test_functional.py").write_text(
+            "def test_a(h): ...\ndef test_b(h): ...\n", encoding="utf-8"
+        )
+        assert content.validate_scoring(_lab(tmp_path)).ok
+
+
+class TestPariteLangues:
+    def test_traduction_manquante(self, tmp_path: Path) -> None:
+        (tmp_path / "README.fr.md").write_text("cours", encoding="utf-8")
+        rapport = content.validate_language_parity(_lab(tmp_path))
+        assert not rapport.ok
+        assert "README.md" in rapport.issues[0].message
+
+    def test_les_deux_langues_presentes(self, tmp_path: Path) -> None:
+        (tmp_path / "README.fr.md").write_text("cours", encoding="utf-8")
+        (tmp_path / "README.md").write_text("course", encoding="utf-8")
+        assert content.validate_language_parity(_lab(tmp_path)).ok
+
+
+class TestCibles:
+    def _lab_vm(self, tmp_path: Path, host: str) -> LabDefinition:
+        from dsoxlab.models.runtime import Target
+
+        lab = _lab(tmp_path)
+        lab.runtime.type = RuntimeType.VM
+        lab.runtime.targets = [Target(name="rhel", host=host)]
+        return lab
+
+    def test_hote_inconnu(self, tmp_path: Path) -> None:
+        rapport = content.validate_targets(
+            self._lab_vm(tmp_path, "absent.lab"), {"present.lab"}
+        )
+        assert not rapport.ok
+        assert "absent.lab" in rapport.issues[0].message
+
+    def test_hote_connu(self, tmp_path: Path) -> None:
+        assert content.validate_targets(
+            self._lab_vm(tmp_path, "present.lab"), {"present.lab"}
+        ).ok
+
+    def test_sans_infra_declaree_le_controle_se_tait(self, tmp_path: Path) -> None:
+        """Un dépôt 100 % shell n'a pas d'`infra.hosts` : ce n'est pas une faute."""
+        assert content.validate_targets(self._lab_vm(tmp_path, "x.lab"), set()).ok

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.29"
+version = "0.1.30"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
## Pourquoi

Trois contrôles étaient **recopiés à la main dans chaque dépôt de labs**. Ils vivent maintenant dans l'outil, donc `linux-dsoxlab-training`, `ansible-training` et tout dépôt futur en bénéficient sans les dupliquer ni les maintenir en parallèle.

Ils attrapent des dérives qu'aucun test fonctionnel ne voit, parce qu'elles ne cassent pas l'exécution d'un lab, seulement l'expérience de l'apprenant :

- **un lien relatif mort** dans un Markdown. Le dépôt Ansible en comptait **150** le jour où le contrôle y a été écrit ;
- **une solution laissée en clair**, irrattrapable : git la garde pour toujours et le lab est gâché pour qui lit le dépôt ;
- **un `doc_url` qui ne répond plus**, alors que le contrat exige ce champ précisément pour renvoyer au guide.

## Ce qui est actif par défaut, et ce qui ne l'est pas

Les deux premiers sont locaux : rapides, déterministes, jouables hors ligne, donc intégrés à `validate-structure`. Le troisième sort sur le réseau et reste derrière `--check-urls`.

Le contrôle des solutions ne s'applique qu'aux dépôts qui tiennent un répertoire `solution/`. Son absence n'est pas une faute, c'est un autre choix : l'agnosticisme impose de ne pas imposer la convention.

## Un détail qui décidait de tout

La requête porte un **User-Agent**. Sans lui, le blog rend `403` et le contrôle déclarait morts **84 guides qui répondent parfaitement**. Le test local du dépôt le faisait déjà ; l'outil concorde maintenant avec lui.

## Vérifié sur les deux dépôts fournisseurs

| | Labs | `validate-structure` | `--check-urls` |
|---|---|---|---|
| `linux-dsoxlab-training` | 84 | vert | **84/84 répondent** |
| `ansible-training` | 113 | vert | 2 signalés |

Les deux `doc_url` signalés côté Ansible sont exactement ceux que le test local du dépôt signale, et leurs pages existent : elles ne sont simplement pas encore déployées.

**Détection prouvée** en cassant volontairement un lien relatif et une solution dans un clone : les deux sont remontés avec le fichier fautif et le motif, `RC=1`.

## Tests

15 tests, qui couvrent surtout les cas où le contrôle **doit se taire** : ancre Markdown, URL absolue, répertoire de solutions absent, `README` non chiffré dans `solution/`, site qui refuse `HEAD` mais sert `GET`, hors ligne, schéma non HTTP. 112 tests au total, `ruff` et `mypy --strict` verts.

## Release

CHANGELOG EN + FR, bump `0.1.30`, `uv.lock` inclus. **Non publiée** : à taguer quand vous le déciderez, via `scripts/check-release.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
