### PR TITLE
fix(discovery): dériver bloc_order du meta.yml, pas de chaque lab.yaml

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,22 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.31] - 2026-07-23
+
+### Corrigé
+
+- **`dsoxlab next` proposait les labs dans l'ordre alphabétique.** Le tri
+  pédagogique s'appuie sur `bloc_order`, que le scanner ne posait jamais : il
+  restait à 0 sauf mention explicite dans un `lab.yaml`, et le tri retombait
+  sur l'`id`. Un débutant se voyait proposer `ansible-vault` avant son premier
+  playbook, ou l'écriture d'un script Bash avant d'avoir ouvert un terminal.
+  Mesuré : **19 sections sur 22** dans le dépôt Ansible.
+  Le `meta.yml` est documenté comme pilotant cet ordre ; il le pilote
+  désormais vraiment. Le scanner dérive la position depuis
+  `sections[].labs[]`, donc aucun dépôt n'a à recopier l'information dans ses
+  `lab.yaml` : 197 fichiers n'ont plus besoin d'être touchés. Un `bloc_order`
+  explicite reste prioritaire.
+
 ## [0.1.30] - 2026-07-23
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31] - 2026-07-23
+
+### Fixed
+
+- **`dsoxlab next` suggested labs in alphabetical order.** The pedagogical
+  sort relies on `bloc_order`, which the scanner never set: it stayed at 0
+  unless a `lab.yaml` spelled it out, and the sort fell back to the `id`. A
+  beginner was pointed at `ansible-vault` before their first playbook, or at
+  writing a Bash script before ever opening a terminal. Measured: **19 of 22
+  sections** in the Ansible repository.
+  The `meta.yml` is documented as driving that order; it now actually does.
+  The scanner derives the position from `sections[].labs[]`, so no repository
+  has to copy it into its `lab.yaml` files: 197 files no longer need
+  touching. An explicit `bloc_order` still wins.
+
 ## [0.1.30] - 2026-07-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.30"
+version = "0.1.31"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/discovery/scanner.py
+++ b/src/dsoxlab/discovery/scanner.py
@@ -96,6 +96,15 @@ def _assign_section(
             if rel in section.labs:
                 lab.bloc = lab.bloc or idx
                 lab.bloc_name = section.title or section.id
+                # Position dans la section, d'où « dsoxlab next » tire l'ordre
+                # pédagogique. Sans elle, le tri retombait sur l'id, donc sur
+                # l'alphabet : « ansible-vault » était proposé avant
+                # « premier-playbook », et « bash-script » avant
+                # « discover-linux-map ». Le meta.yml est censé piloter cet
+                # ordre ; il le pilote désormais vraiment, sans qu'aucun
+                # lab.yaml n'ait à recopier l'information.
+                # Un bloc_order explicite dans le lab.yaml reste prioritaire.
+                lab.bloc_order = lab.bloc_order or (section.labs.index(rel) + 1)
                 break
         return
 

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.30"
+version = "0.1.31"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
## Le défaut

`dsoxlab next` proposait les labs **dans l'ordre alphabétique**. Le tri pédagogique s'appuie sur `bloc_order`, que le scanner ne posait jamais : il restait à `0` sauf mention explicite dans un `lab.yaml`, et le tri retombait sur l'`id`.

Pour un débutant :

| Section | `next` proposait | Le `meta.yml` dit |
|---|---|---|
| `premiers-pas` (Ansible) | `ansible-vault` | `premier-playbook` |
| `ecrire-code` (Ansible) | `any-errors-fatal` | `plays-et-tasks` |
| `l1` (Linux) | `l1-bash-script` | `l1-discover-linux-map` |

Chiffrer des secrets avant d'avoir écrit un playbook, ou écrire un script Bash avant d'avoir ouvert un terminal. Mesuré : **19 sections sur 22** dans le dépôt Ansible.

## Le correctif, au bon endroit

Le `meta.yml` est documenté comme pilotant cet ordre. Il le pilote maintenant vraiment : le scanner dérive la position depuis `sections[].labs[]`, **au même endroit où il rattache déjà `bloc` et `bloc_name`**.

Conséquence : aucun dépôt n'a à recopier l'information. J'avais commencé par poser `bloc_order` à la main dans les `lab.yaml` — **197 fichiers** (84 Linux + 113 Ansible) qu'il aurait fallu tenir à jour à chaque réordonnancement, et recommencer pour chaque nouveau dépôt. Une ligne dans l'outil remplace tout cela.

Un `bloc_order` explicite dans un `lab.yaml` reste prioritaire.

## Vérifié sur les deux dépôts, sans aucun `bloc_order` dans leurs `lab.yaml`

```
Linux     l1      → l1-discover-linux-map     drills → drill-essential-commands
          l2      → l2-swap-management        lfcs   → lfcs-package-apt

Ansible   premiers-pas     → premiers-pas-premier-playbook
          ecrire-code      → ecrire-code-plays-et-tasks
          modules-fichiers → modules-fichiers-copy
          decouvrir        → decouvrir-declaratif-vs-imperatif
```

121 tests, `ruff` et `mypy --strict` verts.

## Release

CHANGELOG EN + FR, bump `0.1.31`, `uv.lock` inclus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
