### PR TITLE
feat(kvm): Debian 12/13, Ubuntu 26.04 et provisioning KVM increvable

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,54 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.32] - 2026-07-23
+
+### Ajouté
+
+- **Support de Debian 12 (bookworm) sur les trois providers.** La distro
+  `debian12` était déjà associée à une image (URL qcow2 pour kvm, alias
+  `images:debian/12/cloud` pour incus) et à un template cloud-init `debian`,
+  mais ce template n'existait pas : tout host déclarant `distro: debian12`
+  échouait au provision. Ajout de `templates/cloud-init/debian.yaml.tmpl` (mêmes
+  comptes de service `student`/`ansible` et même durcissement que les autres
+  distros). Debian 12 se provisionne désormais sur kvm, incus et outscale.
+- **Distros récentes câblées sur tous les providers** : `debian13` (trixie) et
+  `ubuntu26` (26.04 LTS, Resolute Raccoon), en plus de `alma9` et `ubuntu22`.
+  Chaque provider expose désormais le même jeu de sept distros (URL d'images
+  kvm, alias `images:` incus, OMI pinées outscale), vérifié par
+  `test_cloud_init_templates.py`. URL d'images confirmées disponibles avant
+  câblage.
+- **Test de non-régression sur la cohérence distro/cloud-init**
+  (`tests/test_cloud_init_templates.py`) : toute distro mappée par un provider
+  doit avoir son template cloud-init, les trois providers doivent exposer le
+  même jeu de distros, et `debian12` doit être câblé partout. C'est le garde-fou
+  qui a manqué au `debian.yaml.tmpl` absent.
+
+### Corrigé
+
+- **Outscale ne mappait des OMI que pour `alma10` et `ubuntu24`** alors que
+  `distro_to_template` en promettait cinq. Un host déclarant `alma9`, `ubuntu22`
+  ou `debian12` sur outscale se résolvait en OMI vide et un échec Terraform
+  opaque. `image_ids` couvre désormais tout le jeu (chaque entrée gardant son
+  défaut `""`, un catalogue ne pin que les OMI qu'il utilise), avec les clés
+  correspondantes `image_id_alma9` / `image_id_ubuntu22` / `image_id_debian12`
+  documentées dans `variables.tf`.
+- **`element N has vanished` à l'ajout d'un host sur un réseau KVM existant.**
+  Le provider `dmacvicar/libvirt` ne sait pas mettre à jour un réseau en place :
+  modifier `ips[].dhcp.hosts` le pousse à recréer le réseau (issue #468), ce qui
+  échoue et couperait la connectivité de toutes les VM attachées. Le réseau est
+  désormais figé après création (`lifecycle { ignore_changes = [ips] }`) ; les
+  baux DHCP des hosts ajoutés ensuite sont posés à chaud via `virsh net-update`,
+  dans une nouvelle étape `_ensure_kvm_dhcp_leases` jouée avant l'apply des
+  domaines.
+- **Collision de MAC entre dépôts partageant un hôte (KVM).** Les MAC étaient
+  `52:54:00:cd:00:<idx>`, identiques d'un dépôt à l'autre : deux catalogues qui
+  tournent en parallèle donnaient la même MAC à leurs VM de même index, et l'une
+  devenait injoignable (`No route to host` silencieux). Les deux octets du
+  milieu sont maintenant dérivés d'un hash du `repo.id`, rendant les MAC uniques
+  par dépôt : le pendant en couche 2 de l'isolation par CIDR déjà en place. Les
+  VM KVM existantes doivent être re-provisionnées pour prendre les nouvelles MAC.
+
 ## [0.1.31] - 2026-07-23
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.32] - 2026-07-23
+
+### Added
+
+- **Debian 12 (bookworm) support across the three providers.** The `debian12`
+  distro was already mapped to an image (qcow2 URL for kvm, `images:debian/12/cloud`
+  alias for incus) and to a `debian` cloud-init template, but that template did
+  not exist: any host declaring `distro: debian12` failed at provision time.
+  Added `templates/cloud-init/debian.yaml.tmpl` (same `student`/`ansible`
+  service accounts and hardening as the other distros). Debian 12 now
+  provisions on kvm, incus and outscale.
+- **Recent distros wired across all providers**: `debian13` (trixie) and
+  `ubuntu26` (26.04 LTS, Resolute Raccoon), alongside `alma9` and `ubuntu22`.
+  Each provider now exposes the same seven-distro set (kvm image URLs, incus
+  `images:` aliases, outscale pinned OMIs), verified by
+  `test_cloud_init_templates.py`. Image URLs confirmed live before wiring.
+- **Regression test for distro/cloud-init consistency**
+  (`tests/test_cloud_init_templates.py`): every distro a provider maps must have
+  its cloud-init template, all providers must expose the same distro set, and
+  `debian12` must be wired everywhere. This is the guard that the missing
+  `debian.yaml.tmpl` slipped past.
+
+### Fixed
+
+- **Outscale only mapped OMIs for `alma10` and `ubuntu24`** while
+  `distro_to_template` promised five distros. A host declaring `alma9`,
+  `ubuntu22` or `debian12` on outscale resolved to an empty OMI and an opaque
+  Terraform failure. `image_ids` now covers the full set (each still defaulting
+  to `""`, so a catalog only pins the OMIs it actually uses), with the matching
+  `image_id_alma9` / `image_id_ubuntu22` / `image_id_debian12` documented in
+  `variables.tf`.
+- **`element N has vanished` when adding a host to an existing KVM network.**
+  The `dmacvicar/libvirt` provider cannot update a network in place: changing
+  `ips[].dhcp.hosts` makes it recreate the network (issue #468), which fails and
+  would drop connectivity for every attached VM. The network is now frozen after
+  creation (`lifecycle { ignore_changes = [ips] }`); DHCP leases for hosts added
+  later are applied live via `virsh net-update`, in a new
+  `_ensure_kvm_dhcp_leases` step run before the domain apply.
+- **MAC collision between repos sharing a host (KVM).** MACs were
+  `52:54:00:cd:00:<idx>`, identical across repos, so two catalogs running in
+  parallel gave the same MAC to their same-index VMs and one became unreachable
+  (silent `No route to host`). The two middle octets are now derived from a hash
+  of `repo.id`, making MACs unique per repo: the layer-2 counterpart of the
+  existing per-repo CIDR isolation. Existing KVM VMs must be re-provisioned to
+  pick up the new MACs.
+
 ## [0.1.31] - 2026-07-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.31"
+version = "0.1.32"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/infra/inventory.py
+++ b/src/dsoxlab/infra/inventory.py
@@ -351,6 +351,28 @@ class HostReadyTimeout(RuntimeError):
     """Levée quand un host ne devient pas joignable en SSH dans le délai imparti."""
 
 
+def _reset_kvm_domain(repo_meta: RepoMetadata, fqdn: str) -> bool:
+    """Envoie un ``virsh reset`` à un domaine KVM. Retourne True si tenté.
+
+    Débloque une VM coincée au premier boot. Cas connu : Debian cloud (generic
+    comme genericcloud) sous firmware OVMF/EFI avec resize du disque au premier
+    démarrage kernel-panique (« Attempted to kill init »), bug documenté côté
+    Proxmox et XCP-ng. Un simple reset passe le panic : la VM redémarre et boote
+    normalement. alma/ubuntu ne déclenchent pas ce cas, mais le reset répare
+    aussi n'importe quelle VM bloquée au boot. No-op hors provider kvm.
+    """
+    infra = repo_meta.infra
+    if infra is None or getattr(infra, "provider", None) != "kvm":
+        return False
+    res = subprocess.run(
+        ["sudo", "virsh", "reset", fqdn], capture_output=True, text=True
+    )
+    if res.returncode == 0:
+        logger.info("reset envoyé à %s (déblocage du premier boot)", fqdn)
+        return True
+    return False
+
+
 def wait_for_hosts_ready(
     repo_meta: RepoMetadata,
     hosts: list[str],
@@ -358,6 +380,7 @@ def wait_for_hosts_ready(
     timeout: float = 180.0,
     poll_interval: float = 3.0,
     connect_timeout: int = 8,
+    reset_after: float = 60.0,
     on_attempt: Callable[[str, int], None] | None = None,
 ) -> None:
     """Attend que chaque host soit réellement utilisable après ``terraform apply``.
@@ -405,7 +428,10 @@ def wait_for_hosts_ready(
     )
 
     for fqdn in hosts:
-        deadline = time.monotonic() + timeout
+        start = time.monotonic()
+        deadline = start + timeout
+        reset_deadline = start + reset_after
+        reset_done = False
         attempt = 0
         while True:
             attempt += 1
@@ -434,6 +460,14 @@ def wait_for_hosts_ready(
                     f"{fqdn} injoignable en SSH après {timeout:.0f}s "
                     "(cloud-init trop long, ou VM en échec de démarrage)."
                 )
+            # Un host dont sshd n'a JAMAIS répondu après `reset_after` est
+            # probablement coincé au boot (kernel panic Debian cloud + OVMF +
+            # resize, cf. _reset_kvm_domain). Un reset unique le débloque. Sans
+            # risque pour une VM saine : dès que sshd répond, la tentative se
+            # connecte et bloque sur `cloud-init status --wait`, donc ce seuil
+            # n'est plus évalué (le boot normal sshd est bien en deçà de 60 s).
+            if not reset_done and time.monotonic() >= reset_deadline:
+                reset_done = _reset_kvm_domain(repo_meta, fqdn) or True
             time.sleep(poll_interval)
 
 

--- a/src/dsoxlab/infra/terraform.py
+++ b/src/dsoxlab/infra/terraform.py
@@ -29,9 +29,12 @@ Contrat invariant des providers (templates/terraform/README.md) :
 
 from __future__ import annotations
 
+import hashlib
+import ipaddress
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 from collections.abc import Callable
@@ -318,6 +321,69 @@ def other_active_providers(repo_meta: RepoMetadata) -> list[str]:
     ]
 
 
+def _ensure_kvm_dhcp_leases(
+    repo_meta: RepoMetadata, target_hosts: list[str] | None = None
+) -> None:
+    """Pose à chaud les baux DHCP statiques manquants d'un réseau KVM existant.
+
+    Le provider ``dmacvicar/libvirt`` ne sait pas mettre à jour un réseau :
+    modifier ``ips[].dhcp.hosts`` (ajout/retrait d'un host) le pousse à recréer
+    le réseau (issue #468), ce qui échoue en « element N has vanished » et
+    couperait la connectivité des VMs déjà attachées. Le template pose donc
+    ``lifecycle { ignore_changes = [ips] }`` sur ``libvirt_network.lab`` :
+    Terraform crée le réseau une fois avec les baux de la liste initiale, puis
+    n'y touche plus. Cette fonction ajoute les baux des hosts déclarés ENSUITE,
+    à chaud, via ``virsh net-update … --live --config``, avant l'apply des
+    domaines.
+
+    No-op hors provider kvm, ou si le réseau n'existe pas encore (Terraform le
+    crée alors lui-même avec tous ses baux). Best-effort : une entrée déjà
+    présente ou un ``virsh`` qui échoue ne bloque pas le provision (Terraform
+    reste la source de vérité pour la création initiale).
+
+    Le calcul MAC/IP DOIT rester aligné sur le template kvm
+    (``main.tf`` : préfixe MAC ``52:54:<h0>:<h1>:00`` dérivé de
+    ``sha256(repo_id)``, dernier octet ``idx+16`` ; ``ip = cidrhost(cidr,
+    idx+11)``), idx étant la position dans ``infra.hosts``.
+    """
+    infra = repo_meta.infra
+    if infra is None or getattr(infra, "provider", None) != "kvm" or not infra.network:
+        return
+    dump = subprocess.run(
+        ["sudo", "virsh", "net-dumpxml", infra.network],
+        capture_output=True,
+        text=True,
+    )
+    if dump.returncode != 0:
+        return  # réseau pas encore créé : Terraform le posera avec ses baux
+    existing = {m.lower() for m in re.findall(r"mac='([^']+)'", dump.stdout)}
+    try:
+        network = ipaddress.ip_network(infra.cidr or "10.10.10.0/24", strict=False)
+    except ValueError:
+        return
+    # Même dérivation que le template kvm (locals.mac_prefix) : deux octets du
+    # hash du repo.id isolent les MAC entre dépôts. Doit rester synchronisé.
+    digest = hashlib.sha256(repo_meta.id.encode("utf-8")).hexdigest()
+    mac_prefix = f"52:54:{digest[0:2]}:{digest[2:4]}:00"
+    wanted = set(target_hosts) if target_hosts else None
+    for idx, host in enumerate(infra.hosts):
+        if wanted is not None and host.name not in wanted:
+            continue
+        mac = f"{mac_prefix}:{idx + 16:02x}"
+        if mac.lower() in existing:
+            continue
+        ip = str(network.network_address + idx + 11)
+        entry = f"<host mac='{mac}' name='{host.name}' ip='{ip}'/>"
+        res = subprocess.run(
+            ["sudo", "virsh", "net-update", infra.network,
+             "add-last", "ip-dhcp-host", entry, "--live", "--config"],
+            capture_output=True,
+            text=True,
+        )
+        if res.returncode == 0:
+            logger.info("bail DHCP ajouté à chaud: %s -> %s (%s)", host.name, ip, mac)
+
+
 def apply(
     repo_meta: RepoMetadata,
     *,
@@ -350,6 +416,12 @@ def apply(
 
     tf_dir = workdir(repo_meta)
     write_tfvars(repo_meta)
+
+    # Le réseau KVM est figé (lifecycle ignore_changes) : on pose ici les baux
+    # DHCP des hosts ajoutés après sa création, à chaud, sinon leur VM ne
+    # recevrait pas son IP statique. No-op au premier provision (réseau absent)
+    # et hors kvm. Voir _ensure_kvm_dhcp_leases.
+    _ensure_kvm_dhcp_leases(repo_meta, target_hosts)
 
     # Note : ``init`` n'est PAS appelé automatiquement ici. La CLI
     # ``dsoxlab provision`` l'appelle séparément (avec spinner) pour

--- a/src/dsoxlab/templates/cloud-init/debian.yaml.tmpl
+++ b/src/dsoxlab/templates/cloud-init/debian.yaml.tmpl
@@ -1,0 +1,83 @@
+#cloud-config
+# Cloud-init Debian 12 (bookworm) pour les VMs de lab dsoxlab.
+# Variables Terraform substituées via templatefile() : hostname, ssh_pubkey.
+
+hostname: ${hostname}
+fqdn: ${hostname}.lab
+manage_etc_hosts: true
+preserve_hostname: false
+
+users:
+  - name: student
+    groups: [sudo]
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    shell: /bin/bash
+    # lock_passwd: false + passwd: '*' : sshd 9+ (Debian 12 embarque
+    # OpenSSH 9.2) rejette les comptes « locked » (hash préfixé par « ! »)
+    # même en authentification par clé publique. Cloud-init applique
+    # lock_passwd: true par défaut, ce qui met ce « ! » : on force false.
+    lock_passwd: false
+    passwd: "*"
+    ssh_authorized_keys:
+      - ${ssh_pubkey}
+
+  # ansible : compte de SERVICE d'automatisation, distinct du compte humain
+  # student. C'est lui que dsoxlab et les playbooks des labs utilisent pour se
+  # connecter (ansible_user: ansible). Même durcissement : clé SSH uniquement,
+  # sans mot de passe. NOPASSWD:ALL volontaire (automatisation généraliste).
+  - name: ansible
+    groups: [sudo]
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    shell: /bin/bash
+    lock_passwd: false
+    passwd: "*"
+    ssh_authorized_keys:
+      - ${ssh_pubkey}
+
+disable_root: true
+ssh_pwauth: false
+
+# Outils minimum pour les labs LFCS Debian-like : diagnostic.
+package_update: true
+packages:
+  # openssh-server : NON préinstallé sur les images Incus cloud (Incus passe
+  # par incus exec via l'agent). On l'installe pour avoir un flow SSH unifié
+  # avec les autres providers (kvm, outscale). Sur les images cloud Debian
+  # pour KVM/Outscale il est déjà présent : cette ligne est idempotente.
+  - openssh-server
+  - vim
+  - tmux
+  - bash-completion
+  - tree
+  - lsof
+  - strace
+  - tcpdump
+  - dnsutils
+  - net-tools
+  - ufw
+  - apparmor
+  - apparmor-utils
+  # qemu-guest-agent : laisse libvirt récupérer l'IP via le canal virtio
+  # (« virsh domifaddr --source agent ») côté provider kvm.
+  - qemu-guest-agent
+
+runcmd:
+  # Garde-fou anti-locking : force le hash à '*' (cf. commentaire dans la
+  # section users). Idempotent.
+  - [ usermod, -p, "*", student ]
+  - [ usermod, -p, "*", ansible ]
+  - [ systemctl, enable, --now, ssh ]
+  # enable SANS --now : l'unité déclare
+  # BindsTo=dev-virtio\x2dports-org.qemu.guest_agent.0.device, or le provider
+  # KVM ne déclare aucun channel virtio (cf. la note dans
+  # templates/terraform/kvm/main.tf). Le device n'existe donc jamais, et --now
+  # attendait 90 s avant d'échouer : le script runcmd sortait en 1, cloud-init
+  # finissait en « status: error », et « dsoxlab provision » restait bloqué sur
+  # son attente alors que la VM était prête. L'activation est conservée : le
+  # jour où un channel est déclaré (ou sur un provider qui en fournit un), le
+  # service démarrera au boot.
+  - [ systemctl, enable, qemu-guest-agent ]
+
+# Sécurité par défaut : AppArmor reste activé. UFW est installé mais pas activé
+# par défaut : c'est aux labs LFCS de l'activer explicitement (pour ne pas
+# couper la SSH du provisioning).

--- a/src/dsoxlab/templates/terraform/incus/main.tf
+++ b/src/dsoxlab/templates/terraform/incus/main.tf
@@ -20,8 +20,10 @@ locals {
   default_images = {
     alma10   = "images:almalinux/10/cloud"
     alma9    = "images:almalinux/9/cloud"
+    ubuntu26 = "images:ubuntu/resolute/cloud"
     ubuntu24 = "images:ubuntu/noble/cloud"
     ubuntu22 = "images:ubuntu/jammy/cloud"
+    debian13 = "images:debian/13/cloud"
     debian12 = "images:debian/12/cloud"
   }
 
@@ -31,8 +33,10 @@ locals {
   distro_to_template = {
     alma10   = "almalinux"
     alma9    = "almalinux"
+    ubuntu26 = "ubuntu"
     ubuntu24 = "ubuntu"
     ubuntu22 = "ubuntu"
+    debian13 = "debian"
     debian12 = "debian"
   }
 

--- a/src/dsoxlab/templates/terraform/kvm/main.tf
+++ b/src/dsoxlab/templates/terraform/kvm/main.tf
@@ -7,12 +7,21 @@
 # - Pas de bastion (réseau homelab direct depuis le poste de l'apprenant).
 
 locals {
-  # Convention dsoxlab : MAC déterministe par index pour permettre les
-  # baux DHCP statiques (51:54:00:cd:00:<XX>).
+  # MAC déterministe, unique par DÉPÔT et par index. Les deux octets du milieu
+  # sont dérivés d'un hash du repo.id : sans ça, deux catalogues KVM tournant en
+  # parallèle sur le même hôte donnaient la même MAC (52:54:00:cd:00:<idx>) à
+  # leurs VM de même index. Leurs baux se disputaient alors la table FDB du
+  # bridge et une des deux VM restait injoignable (« No route to host », sans
+  # erreur). C'est le pendant, en couche 2, de l'isolation par CIDR déjà en
+  # place. L'index reste dans le dernier octet pour garder les baux lisibles.
+  mac_prefix = format("52:54:%s:%s:00",
+    substr(sha256(var.repo_id), 0, 2),
+    substr(sha256(var.repo_id), 2, 2),
+  )
   hosts_with_idx = [
     for idx, h in var.hosts : merge(h, {
       idx = idx
-      mac = format("52:54:00:cd:00:%02x", idx + 16)
+      mac = format("%s:%02x", local.mac_prefix, idx + 16)
       ip  = cidrhost(var.network_cidr, idx + 11)
     })
   ]
@@ -25,8 +34,10 @@ locals {
   distro_to_template = {
     alma10   = "almalinux"
     alma9    = "almalinux"
+    ubuntu26 = "ubuntu"
     ubuntu24 = "ubuntu"
     ubuntu22 = "ubuntu"
+    debian13 = "debian"
     debian12 = "debian"
   }
 
@@ -35,9 +46,18 @@ locals {
   default_image_urls = {
     alma10   = "https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/AlmaLinux-10-GenericCloud-latest.x86_64.qcow2"
     alma9    = "https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2"
+    ubuntu26 = "https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-amd64.img"
     ubuntu24 = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
     ubuntu22 = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
-    debian12 = "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
+    # Variante « generic », PAS « genericcloud ». « genericcloud » utilise le
+    # kernel CLOUD de Debian, aux drivers réduits (ciblé EC2/Azure). Combiné au
+    # firmware OVMF/EFI que dsoxlab force ET au resize du disque au premier boot,
+    # il kernel-panique (« Attempted to kill init » ; bug connu documenté côté
+    # Proxmox et XCP-ng). « generic » embarque le kernel standard Debian et boot
+    # partout, EFI compris, pour ~90 Mo de plus. alma et ubuntu ne sont pas
+    # concernés (leur kernel n'est pas ce build cloud réduit).
+    debian13 = "https://cloud.debian.org/images/cloud/trixie/latest/debian-13-generic-amd64.qcow2"
+    debian12 = "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generic-amd64.qcow2"
   }
 
   image_urls = {
@@ -107,6 +127,18 @@ resource "libvirt_network" "lab" {
       }
     }
   ]
+
+  # Le provider dmacvicar/libvirt ne sait PAS mettre à jour un réseau existant :
+  # modifier `ips[].dhcp.hosts` (ajout/retrait d'un host) le pousse à RECRÉER le
+  # réseau (issue #468), ce qui échoue en « element N has vanished /
+  # inconsistent result after apply » et couperait la connectivité de toutes les
+  # VMs attachées. On fige donc le réseau après création : Terraform le crée une
+  # fois avec les baux de la liste initiale, puis n'y touche plus. Les baux des
+  # hosts ajoutés ENSUITE sont posés à chaud par dsoxlab via `virsh net-update`
+  # (infra/terraform.py:_ensure_kvm_dhcp_leases), avant l'apply des domaines.
+  lifecycle {
+    ignore_changes = [ips]
+  }
 }
 
 # ── Images cloud (téléchargées une fois par distro) ────────────────────────

--- a/src/dsoxlab/templates/terraform/outscale/main.tf
+++ b/src/dsoxlab/templates/terraform/outscale/main.tf
@@ -32,10 +32,18 @@ locals {
   bastion_user    = lookup(var.provider_config, "bastion_user", "student")
   ssh_pubkey      = lookup(var.provider_config, "ssh_pubkey", "")
 
-  # OMI par distro — l'utilisateur PIN les références dans meta.yml
+  # OMI par distro : l'utilisateur PIN les références dans meta.yml. Une entrée
+  # par distro de distro_to_template : une distro déclarée dans un lab mais
+  # absente ici donnerait une OMI vide et un échec Terraform opaque. Le défaut
+  # "" reste : chaque catalogue ne pin QUE les distros qu'il utilise.
   image_ids = {
     alma10   = lookup(var.provider_config, "image_id_alma10", "")
+    alma9    = lookup(var.provider_config, "image_id_alma9", "")
+    ubuntu26 = lookup(var.provider_config, "image_id_ubuntu26", "")
     ubuntu24 = lookup(var.provider_config, "image_id_ubuntu24", "")
+    ubuntu22 = lookup(var.provider_config, "image_id_ubuntu22", "")
+    debian13 = lookup(var.provider_config, "image_id_debian13", "")
+    debian12 = lookup(var.provider_config, "image_id_debian12", "")
   }
   image_id_bastion = coalesce(
     lookup(var.provider_config, "image_id_bastion", ""),
@@ -47,8 +55,10 @@ locals {
   distro_to_template = {
     alma10   = "almalinux"
     alma9    = "almalinux"
+    ubuntu26 = "ubuntu"
     ubuntu24 = "ubuntu"
     ubuntu22 = "ubuntu"
+    debian13 = "debian"
     debian12 = "debian"
   }
 

--- a/src/dsoxlab/templates/terraform/outscale/variables.tf
+++ b/src/dsoxlab/templates/terraform/outscale/variables.tf
@@ -35,7 +35,12 @@ variable "provider_config" {
     - vm_type_default        : type VM des labs (défaut tinav5.c2r4p1)
     - vm_type_bastion        : type VM du bastion (défaut tinav5.c1r1p1)
     - image_id_alma10        : OMI AlmaLinux 10 PINÉE (omi-xxxxxxxx)
+    - image_id_alma9         : OMI AlmaLinux 9 PINÉE
+    - image_id_ubuntu26      : OMI Ubuntu 26.04 PINÉE
     - image_id_ubuntu24      : OMI Ubuntu 24.04 PINÉE
+    - image_id_ubuntu22      : OMI Ubuntu 22.04 PINÉE
+    - image_id_debian13      : OMI Debian 13 PINÉE
+    - image_id_debian12      : OMI Debian 12 PINÉE
     - image_id_bastion       : OMI du bastion (par défaut = image_id_ubuntu24)
     - bastion_user           : utilisateur SSH du bastion (défaut "outscale")
     - ssh_pubkey             : clé SSH publique (injectée par dsoxlab depuis

--- a/tests/test_cloud_init_templates.py
+++ b/tests/test_cloud_init_templates.py
@@ -1,0 +1,72 @@
+"""Cohérence entre le mapping distro des providers Terraform et les cloud-init.
+
+Chaque `main.tf` de provider déclare un bloc ``distro_to_template`` qui associe
+une distro pédagogique (``debian12``, ``ubuntu24``…) au *stem* d'un template
+cloud-init packagé sous ``templates/cloud-init/<stem>.yaml.tmpl``. Si une distro
+pointe vers un template absent, ``cloud_init_template()`` lève au moment du
+provision, sur un provider donné seulement, et jamais en test.
+
+Ce fichier ferme ce trou : il a été ajouté après qu'un mapping ``debian12 =
+"debian"`` a été déclaré dans les trois providers alors que ``debian.yaml.tmpl``
+n'existait pas encore. Il garde aussi les trois providers alignés entre eux.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from dsoxlab.templates import cloud_init_template, template_root
+
+PROVIDERS = ("kvm", "incus", "outscale")
+
+_BLOCK_RE = re.compile(r"distro_to_template\s*=\s*\{(.*?)\}", re.DOTALL)
+_ENTRY_RE = re.compile(r"(\w+)\s*=\s*\"([^\"]+)\"")
+
+
+def _distro_to_template(provider: str) -> dict[str, str]:
+    """Extrait le bloc ``distro_to_template`` du main.tf d'un provider."""
+    main_tf = template_root() / "terraform" / provider / "main.tf"
+    block = _BLOCK_RE.search(main_tf.read_text(encoding="utf-8"))
+    assert block, f"bloc distro_to_template introuvable dans {main_tf}"
+    return dict(_ENTRY_RE.findall(block.group(1)))
+
+
+@pytest.mark.parametrize("provider", PROVIDERS)
+def test_every_mapped_distro_has_a_cloud_init(provider: str) -> None:
+    mapping = _distro_to_template(provider)
+    assert mapping, f"{provider} : distro_to_template vide"
+    for distro, stem in mapping.items():
+        # cloud_init_template lève FileNotFoundError si le template manque :
+        # c'est exactement l'échec de provision qu'on veut attraper ici.
+        path = cloud_init_template(stem)
+        assert path.is_file(), f"{provider}: {distro} -> {stem}.yaml.tmpl absent"
+
+
+def test_debian12_supported_on_all_providers() -> None:
+    """debian12 doit être mappé partout, vers le cloud-init debian."""
+    for provider in PROVIDERS:
+        mapping = _distro_to_template(provider)
+        assert mapping.get("debian12") == "debian", (
+            f"{provider} : debian12 doit pointer vers le template 'debian'"
+        )
+    assert cloud_init_template("debian").is_file()
+
+
+def test_all_providers_share_the_same_distro_set() -> None:
+    """Les trois providers doivent proposer les mêmes distros (pas de trou)."""
+    sets = {p: frozenset(_distro_to_template(p)) for p in PROVIDERS}
+    reference = sets["kvm"]
+    for provider, distros in sets.items():
+        assert distros == reference, (
+            f"{provider} diverge de kvm : {distros ^ reference}"
+        )
+
+
+def test_no_orphan_cloud_init_used() -> None:
+    """Tout template cloud-init packagé est bien un fichier .yaml.tmpl lisible."""
+    cloud_init_dir = template_root() / "cloud-init"
+    for tmpl in cloud_init_dir.glob("*.yaml.tmpl"):
+        stem = tmpl.name[: -len(".yaml.tmpl")]
+        assert cloud_init_template(stem) == tmpl

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.31"
+version = "0.1.32"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
Distros : cloud-init debian ajouté (il manquait, tout debian12 échouait au provision), debian13/ubuntu26 câblés sur kvm/incus/outscale, outscale aligné sur le jeu complet (alma9, ubuntu22, debian). Image Debian « generic » (la « genericcloud » kernel-panique sous OVMF + resize du disque).

Provisioning KVM robuste :
- réseau figé (lifecycle ignore_changes) + baux DHCP posés à chaud via virsh net-update : plus de recréation du réseau à l'ajout d'un host (« element vanished », le provider ne sait pas mettre à jour un réseau) ;
- MAC dérivée d'un hash du repo.id : unique par dépôt, fin des collisions entre catalogues KVM tournant en parallèle sur le même hôte ;
- reset automatique du premier boot dans wait_for_hosts_ready : passe le kernel panic Debian (OVMF + resize) sans intervention.

Test de cohérence distro/cloud-init. CHANGELOG EN+FR, bump 0.1.32, uv.lock.

# Summary

<!-- What does this PR change, and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

Only the **Always** block applies to every PR. The other blocks are conditional:
if a block does not apply, say so (`N/A`) rather than leaving it blank — a blank
box reads as "forgotten", an explicit `N/A` reads as "considered".

### Always

- [ ] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit)
- [ ] `uv run mypy src/dsoxlab` passes (strict)
- [ ] `uv run pytest` passes
- [ ] The engine stays domain-agnostic — no domain-specific logic in
      `src/dsoxlab/` (no `if category == "linux"`)
- [ ] No hardcoded personal path or host; `pathlib.Path` throughout
- [ ] Manually tested against **two** lab repositories, to prove the agnostic
      design (e.g. `linux-dsoxlab-training` and `ansible-training`)

### When behavior changes — otherwise N/A

- [ ] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated (the project is
      bilingual; an EN-only entry is an incomplete entry)
- [ ] Version bumped in `pyproject.toml` and `uv.lock` refreshed (`uv lock`).
      `__version__` is derived from the package metadata — there is nothing to
      bump in `src/dsoxlab/__init__.py`.

### When a command or option is added, removed or changed — otherwise N/A

- [ ] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [ ] `help=_("…")` in `cli.py` and the `fullhelp_commands` section updated in
      EN **and** FR — `fullhelp` must never describe a command that no longer
      exists
- [ ] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched — otherwise N/A

These are CI gates: they fail the build, so run them before pushing.

- [ ] `actionlint` clean
- [ ] `zizmor --offline .github/workflows/` reports no findings
- [ ] `poutine analyze_local . --fail-on-violation` clean
- [ ] Every action pinned to a **full 40-character commit SHA** with a
      `# vX.Y.Z` comment — never `@v4`, never `@main`
- [ ] `step-security/harden-runner` is the job's first step
- [ ] No job renamed, or the required status checks updated accordingly — they
      match job names **exactly**, and a renamed job silently stops being
      required
- [ ] A new third-party action is added to `trustedGithubActions` in
      `.plumber.yaml` (and acknowledged per purl in `.poutine.yml` if its
      creator is not Marketplace-verified)

### When the declarative contract (`meta.yml` / `lab.yaml`) changes — otherwise N/A

- [ ] The contract section of `README.md` reflects the change
- [ ] `fuzz/corpus/` seeds and `fuzz/dict/yaml_contract.dict` cover any new field
- [ ] A malformed value of the new field still raises inside the parser contract
      — `(KeyError, ValueError, yaml.YAMLError)` — so a bad lab is skipped with a
      warning instead of crashing the CLI

## Related issues

<!-- e.g. Closes #123 -->
