### PR TITLE
fix(i18n): extraire les 21 textes affichés restés en dur dans cli.py

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,35 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.34] - 2026-07-27
+
+### Corrigé
+
+- **21 textes affichés ignoraient `DSOXLAB_LANG`.** La règle i18n (« tout
+  texte affiché passe par `_()` ») n'existait qu'en prose, et la prose ne
+  tient pas : des libellés étaient revenus en dur. Les uns en français, donc
+  affichés en français sous `DSOXLAB_LANG=en` (aides de
+  `dsoxlab use --provider`, `provision --host`, `destroy --host`,
+  `Host inconnu`, `Cible Terraform`, tout le pré-vol sudo de `doctor --fix`) ;
+  les autres en anglais, donc affichés en anglais sous `DSOXLAB_LANG=fr`
+  (tous les libellés de barres de progression : tâches Ansible,
+  `Terraform init complete`, `Nothing to do`, progression des tests). Ils
+  vivent désormais dans les catalogues EN et FR, qui atteignent 315 clés
+  appariées.
+- **`destroy --host` avait perdu son avertissement le plus utile** pendant
+  l'extraction, il est rétabli : Terraform détruit aussi tout ce qui dépend de
+  la cible, donc l'option n'isole **pas** une VM des autres.
+
+### Ajouté
+
+- **Un garde-fou qui maintient la règle vraie**
+  (`tests/test_i18n_coverage.py`) : il analyse `cli.py` et rejette tout
+  `help=`/`description=` qui n'est pas un appel `_()`, ainsi que toute phrase
+  en dur passée à `error/info/warn/success`. La mise en forme pure autour de
+  valeurs déjà traduites (`f"  ✔ {fqdn} ({ip})"`) reste acceptée. Le garde-fou
+  a été passé sur le commit précédent, où il signale les 21 violations : on
+  sait donc qu'il échoue quand il le doit.
+
 ## [0.1.33] - 2026-07-27
 
 Les deux changements viennent du retour d'un apprenant sur sa première

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.34] - 2026-07-27
+
+### Fixed
+
+- **21 user-facing strings ignored `DSOXLAB_LANG`.** The i18n rule ("every
+  displayed text goes through `_()`") was stated in prose only, and prose does
+  not hold: option helps and messages had drifted back into literals. Some were
+  French, so an English run printed French (`dsoxlab use --provider`,
+  `provision --host` and `destroy --host` helps, `Host inconnu`,
+  `Cible Terraform`, the whole `doctor --fix` sudo pre-flight); others were
+  English, so a French run printed English (every progress-bar label: Ansible
+  task names, `Terraform init complete`, `Nothing to do`, test progress). All
+  of them now live in the EN and FR catalogs, which reach 315 paired keys.
+- **`destroy --host` lost its sharpest warning** while being extracted, and it
+  is restored: Terraform destroys everything depending on the target, so the
+  option does **not** isolate one VM from the others.
+
+### Added
+
+- **A guard that keeps the rule true** (`tests/test_i18n_coverage.py`): it
+  parses `cli.py` and rejects any `help=`/`description=` that is not an `_()`
+  call, and any literal sentence handed to `error/info/warn/success`. Pure
+  layout around translated values (`f"  ✔ {fqdn} ({ip})"`) still passes. The
+  guard was run against the previous commit, where it reports all 21
+  violations, so it is known to fail when it should.
+
 ## [0.1.33] - 2026-07-27
 
 Both changes come from a learner's report on their first session with the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.33"
+version = "0.1.34"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -348,8 +348,7 @@ def use(
     target: Annotated[Optional[str], typer.Option("--target", "-t",
         help=_("opt_target"))] = None,
     provider: Annotated[Optional[str], typer.Option("--provider", "-p",
-        help="Provider d'infra à activer (ex. kvm, outscale, incus). "
-             "Override par DSOXLAB_PROVIDER. Persisté entre commandes.")] = None,
+        help=_("opt_use_provider"))] = None,
     reset: Annotated[bool, typer.Option("--reset", "-r", help=_("opt_use_reset"))] = False,
 ) -> None:
     root = _root(lab_home)
@@ -377,7 +376,7 @@ def use(
         try:
             raw = _yaml.safe_load(meta_path.read_text(encoding="utf-8")) or {}
         except _yaml.YAMLError as exc:
-            error(f"Lecture meta.yml impossible : {exc}")
+            error(_("meta_read_failed", error=exc))
             raise typer.Exit(1)
         declared = (raw.get("infra") or {}).get("provider")
         if isinstance(declared, list):
@@ -422,7 +421,7 @@ def use(
                     candidates=", ".join(declared_providers)))
             raise typer.Exit(1)
         set_active_provider(root, provider)
-        success(f"Provider actif : [bold]{provider}[/bold]")
+        success(_("context_provider_set", provider=provider))
 
     section: str | None = None
     level: str | None = None
@@ -819,7 +818,7 @@ def _run_check_with_progress(
                 total = event.get("total", 0) or None
                 progress.update(
                     task,
-                    description=f"Tests : {lab.id}",
+                    description=_("progress_tests_running", lab_id=lab.id),
                     total=total,
                 )
             elif etype == "verdict":
@@ -841,7 +840,7 @@ def _run_check_with_progress(
             # result.output et imprimées seulement si le check échoue.
 
         result = check_lab(lab, target=target, on_event=on_event)
-        progress.update(task, description=f"Tests {lab.id} terminés")
+        progress.update(task, description=_("progress_tests_done", lab_id=lab.id))
 
     return result
 
@@ -1298,28 +1297,20 @@ def doctor(
         sudo_fixes = [c for _, c in failing if c.strip().startswith("sudo ")]
         if sudo_fixes:
             if not sys.stdin.isatty():
-                error(
-                    "Au moins un fix exige sudo, mais ce shell n'est pas "
-                    "interactif (pas de TTY). Lance dsoxlab depuis un "
-                    "terminal ou applique les commandes manuellement."
-                )
+                error(_("fix_needs_tty"))
                 raise typer.Exit(1)
             if shutil.which("sudo") is None:
-                error("sudo introuvable dans le PATH \u2014 fix impossible.")
+                error(_("fix_no_sudo"))
                 raise typer.Exit(1)
 
             # Pr\u00e9-cache les credentials sudo : un seul prompt password
             # pour toute la cascade. Sans ce sudo -v, l'apprenant
             # pourrait avoir \u00e0 retaper son password \u00e0 chaque commande
             # (si sudo timestamp_timeout=0 ou si la cascade d\u00e9passe 5min).
-            info(
-                f"[bold]{len(sudo_fixes)}[/bold] commande(s) n\u00e9cessitent "
-                "sudo. Pr\u00e9-authentification ci-dessous (un seul prompt "
-                "pour toute la cascade) :"
-            )
+            info(_("fix_sudo_preauth", count=len(sudo_fixes)))
             preauth = subprocess.run(["sudo", "-v"])  # noqa: S603,S607
             if preauth.returncode != 0:
-                error("Pr\u00e9-authentification sudo \u00e9chou\u00e9e \u2014 abandon des fixes.")
+                error(_("fix_sudo_failed"))
                 raise typer.Exit(1)
 
         info(_("fix_count", count=len(failing)))
@@ -1340,9 +1331,7 @@ def doctor(
 def provision(
     host: Annotated[Optional[list[str]], typer.Option(
         "--host",
-        help="Cible une seule VM (fqdn meta.yml). Répétable. Si absent, "
-             "applique tout le plan. Les ressources partagées (réseau, "
-             "images de base) sont gérées par Terraform en cascade.",
+        help=_("opt_provision_host"),
     )] = None,
     lab_home: LabHomeOption = None,
 ) -> None:
@@ -1389,14 +1378,14 @@ def provision(
         known = {h.name for h in repo_meta.infra.hosts}
         for fqdn in host:
             if fqdn not in known:
-                error(f"Host inconnu : '{fqdn}'. Connus : {sorted(known)}")
+                error(_("host_unknown", fqdn=fqdn, known=", ".join(sorted(known))))
                 raise typer.Exit(1)
             try:
                 targets.extend(host_targets(provider, fqdn))
             except NotImplementedError as exc:
                 error(str(exc))
                 raise typer.Exit(2)
-        info(f"Cible Terraform : {', '.join(host)} ({len(targets)} ressources)")
+        info(_("terraform_target", hosts=", ".join(host), count=len(targets)))
 
     try:
         # Étape 1 : terraform init (peut télécharger ~50 MB de provider
@@ -1502,14 +1491,11 @@ def provision(
 def destroy(
     host: Annotated[Optional[list[str]], typer.Option(
         "--host",
-        help="Restreint la cible Terraform à un fqdn du meta.yml. Répétable. "
-             "ATTENTION : Terraform détruit aussi tout ce qui dépend de la "
-             "cible, donc cette option n'isole PAS une VM des autres. Pour "
-             "récupérer une machine, préférer destroy complet + provision.",
+        help=_("opt_destroy_host"),
     )] = None,
     yes: Annotated[bool, typer.Option(
         "--yes", "-y",
-        help="Ne pas demander confirmation (usage non interactif).",
+        help=_("opt_yes"),
     )] = False,
     lab_home: LabHomeOption = None,
 ) -> None:
@@ -1530,14 +1516,14 @@ def destroy(
         known = {h.name for h in repo_meta.infra.hosts}
         for fqdn in host:
             if fqdn not in known:
-                error(f"Host inconnu : '{fqdn}'. Connus : {sorted(known)}")
+                error(_("host_unknown", fqdn=fqdn, known=", ".join(sorted(known))))
                 raise typer.Exit(1)
             try:
                 targets.extend(host_targets(provider, fqdn))
             except NotImplementedError as exc:
                 error(str(exc))
                 raise typer.Exit(2)
-        info(f"Cible Terraform : {', '.join(host)} ({len(targets)} ressources)")
+        info(_("terraform_target", hosts=", ".join(host), count=len(targets)))
         # Mesuré le 2026-07-23 : terraform détruit la cible ET tout ce qui en
         # dépend. Les volumes et disques cloud-init étant chaînés aux domaines,
         # cibler un seul hôte emporte les autres (7 ressources détruites pour
@@ -1630,7 +1616,7 @@ def _run_ansible_with_progress(
             if etype == "playbook_on_task_start":
                 task_name = data.get("name") or data.get("task", "")
                 state["current_task"] = task_name
-                progress.update(task, description=f"Task: {task_name}")
+                progress.update(task, description=_("progress_ansible_task", task=task_name))
             elif etype == "runner_on_ok":
                 host = data.get("host", "?")
                 task_name = data.get("task", state["current_task"])
@@ -1667,7 +1653,10 @@ def _run_ansible_with_progress(
                 )
 
         runner(on_event)
-        progress.update(task, description=f"{playbook_path.name} complete")
+        progress.update(
+            task,
+            description=_("progress_playbook_done", playbook=playbook_path.name),
+        )
 
 
 def _run_terraform_init_with_spinner(runner: Callable[[EventCallback], Any]) -> None:
@@ -1699,7 +1688,7 @@ def _run_terraform_init_with_spinner(runner: Callable[[EventCallback], Any]) -> 
                     progress.update(task, description=msg.strip())
 
         runner(on_event)
-        progress.update(task, description="Terraform init complete")
+        progress.update(task, description=_("progress_tf_init_done"))
 
 
 def _run_terraform_with_progress(
@@ -1817,11 +1806,16 @@ def _run_terraform_with_progress(
         if state["total"] > 0:
             progress.update(
                 task,
-                description=f"{label_action} complete",
+                description=_("progress_action_done", action=label_action),
                 completed=state["total"],
             )
         else:
-            progress.update(task, description="Nothing to do", total=1, completed=1)
+            progress.update(
+                task,
+                description=_("progress_nothing_to_do"),
+                total=1,
+                completed=1,
+            )
 
     return state["result"]
 

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -15,6 +15,18 @@ STRINGS: dict[str, str] = {
     "opt_top":      "Number of displayed results",
     "opt_fix":      "Attempt automatic remediation of missing components.",
     "opt_no_pager": "Print everything at once instead of paging output longer than the screen.",
+    "opt_use_provider":
+        "Infra provider to activate (e.g. kvm, outscale, incus). "
+        "Overridden by DSOXLAB_PROVIDER. Persisted across commands.",
+    "opt_provision_host":
+        "Target a single VM (fqdn from meta.yml). Repeatable. When omitted, "
+        "applies the whole plan. Shared resources (network, base images) are "
+        "handled by Terraform in cascade.",
+    "opt_destroy_host":
+        "Restrict the Terraform target to one fqdn from meta.yml. Repeatable. "
+        "WARNING: Terraform also destroys everything that depends on the target, "
+        "so this option does NOT isolate one VM from the others. To recover a "
+        "single machine, prefer a full destroy + provision.",
     "opt_yes":      "Confirm without asking",
     "opt_filter_lab": "Filter by lab",
 
@@ -95,6 +107,17 @@ STRINGS: dict[str, str] = {
 
     # ── provision / destroy / status / ssh ────────────────────────────────────
     "provision_no_meta":   "No meta.yml found in {root}. Are you in a dsoxlab repository?",
+    "host_unknown":        "Unknown host: '{fqdn}'. Known hosts: {known}.",
+    "terraform_target":    "Terraform target: {hosts} ({count} resources)",
+
+    # ── progress bars ────────────────────────────────────────────────────────
+    "progress_tests_running":  "Tests: {lab_id}",
+    "progress_tests_done":     "Tests {lab_id} finished",
+    "progress_ansible_task":   "Task: {task}",
+    "progress_playbook_done":  "{playbook} complete",
+    "progress_tf_init_done":   "Terraform init complete",
+    "progress_action_done":    "{action} complete",
+    "progress_nothing_to_do":  "Nothing to do",
     "provision_starting":  "Provisioning infrastructure (provider: {provider})…",
     "provision_no_ssh_key": "Lab SSH key missing: {path}\nWithout it, cloud keypair would be empty and VMs unreachable.\nRun first: dsoxlab instructor bootstrap",
     "provision_done":      "Provisioning complete — {count} host(s) ready.",
@@ -306,6 +329,8 @@ silent.
     "context_set_info": "Commands list-labs and validate-structure now use this filter by default.",
     "context_lang_set": "Language set to [bold]{lang}[/bold] — lab titles and descriptions will be shown in this language.",
     "context_target_set": "Default target set to [bold]{target}[/bold] — 'dsoxlab run' will use it unless --target is given.",
+    "context_provider_set": "Active provider: [bold]{provider}[/bold]",
+    "meta_read_failed": "Cannot read meta.yml: {error}",
     "context_cleared":  "Context reset — all labs are now visible.",
     "context_active":   "Active context: [bold]{label}[/bold] — use [bold]dsoxlab use --reset[/bold] to see all.",
 
@@ -419,6 +444,15 @@ silent.
     # ── doctor — fix ──────────────────────────────────────────────────────────
     "fix_nothing": "No remediation needed.",
     "fix_count":   "{count} component(s) to fix…",
+    "fix_needs_tty":
+        "At least one remediation requires sudo, but this shell is not "
+        "interactive (no TTY). Run dsoxlab from a terminal, or apply the "
+        "commands by hand.",
+    "fix_no_sudo": "sudo not found in PATH: remediation is impossible.",
+    "fix_sudo_preauth":
+        "[bold]{count}[/bold] command(s) require sudo. Pre-authentication "
+        "below (a single prompt for the whole run):",
+    "fix_sudo_failed": "sudo pre-authentication failed: remediations aborted.",
     "fix_success": "{label}: remediation successful.",
     "fix_failure": "{label}: remediation failed (code {code}).",
     "fix_rerun":   "Run [bold]dsoxlab doctor[/bold] again to verify.",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -15,6 +15,18 @@ STRINGS: dict[str, str] = {
     "opt_top":        "Nombre de résultats affichés",
     "opt_fix":        "Tenter la remédiation automatique des composants manquants.",
     "opt_no_pager":   "Tout afficher d'un bloc au lieu de paginer ce qui dépasse l'écran.",
+    "opt_use_provider":
+        "Provider d'infra à activer (ex. kvm, outscale, incus). "
+        "Surchargé par DSOXLAB_PROVIDER. Persisté entre commandes.",
+    "opt_provision_host":
+        "Cible une seule VM (fqdn du meta.yml). Répétable. Si absent, applique "
+        "tout le plan. Les ressources partagées (réseau, images de base) sont "
+        "gérées par Terraform en cascade.",
+    "opt_destroy_host":
+        "Restreint la cible Terraform à un fqdn du meta.yml. Répétable. "
+        "ATTENTION : Terraform détruit aussi tout ce qui dépend de la cible, "
+        "donc cette option n'isole PAS une VM des autres. Pour récupérer une "
+        "machine, préférer destroy complet + provision.",
     "opt_yes":        "Confirme sans demander",
     "opt_filter_lab": "Filtre par lab",
 
@@ -95,6 +107,17 @@ STRINGS: dict[str, str] = {
     "provider_unknown":       "Provider '{name}' inconnu pour ce dépôt. Candidats : {candidates}",
 
     "provision_no_meta":   "Pas de meta.yml trouvé dans {root}. Es-tu dans un dépôt dsoxlab ?",
+    "host_unknown":        "Host inconnu : '{fqdn}'. Connus : {known}.",
+    "terraform_target":    "Cible Terraform : {hosts} ({count} ressources)",
+
+    # ── barres de progression ────────────────────────────────────────────────
+    "progress_tests_running":  "Tests : {lab_id}",
+    "progress_tests_done":     "Tests {lab_id} terminés",
+    "progress_ansible_task":   "Tâche : {task}",
+    "progress_playbook_done":  "{playbook} terminé",
+    "progress_tf_init_done":   "terraform init terminé",
+    "progress_action_done":    "{action} terminé",
+    "progress_nothing_to_do":  "Rien à faire",
     "provision_starting":  "Provisionnement de l'infrastructure (provider : {provider})…",
     "provision_no_ssh_key": "Clé SSH du lab manquante : {path}\nSans elle, le keypair cloud serait vide et les VMs inaccessibles.\nLance d'abord : dsoxlab instructor bootstrap",
     "provision_done":      "Provisionnement terminé — {count} hôte(s) prêt(s).",
@@ -304,6 +327,8 @@ hors ligne, elle se tait.
     "context_set_info": "Les commandes list-labs et validate-structure utilisent maintenant ce filtre par défaut.",
     "context_lang_set": "Langue définie : [bold]{lang}[/bold] — les titres et descriptions des labs seront affichés dans cette langue.",
     "context_target_set": "Cible par défaut : [bold]{target}[/bold] — 'dsoxlab run' l'utilisera sauf si --target est spécifié.",
+    "context_provider_set": "Provider actif : [bold]{provider}[/bold]",
+    "meta_read_failed": "Lecture du meta.yml impossible : {error}",
     "context_cleared":  "Contexte réinitialisé — tous les labs sont maintenant visibles.",
     "context_active":   "Contexte actif : [bold]{label}[/bold] — utilisez [bold]dsoxlab use --reset[/bold] pour tout voir.",
 
@@ -419,6 +444,15 @@ hors ligne, elle se tait.
     # ── doctor — remédiation ──────────────────────────────────────────────────
     "fix_nothing": "Aucune remédiation nécessaire.",
     "fix_count":   "{count} composant(s) à corriger…",
+    "fix_needs_tty":
+        "Au moins une remédiation exige sudo, mais ce shell n'est pas "
+        "interactif (pas de TTY). Lancez dsoxlab depuis un terminal, ou "
+        "appliquez les commandes à la main.",
+    "fix_no_sudo": "sudo introuvable dans le PATH : remédiation impossible.",
+    "fix_sudo_preauth":
+        "[bold]{count}[/bold] commande(s) nécessitent sudo. "
+        "Pré-authentification ci-dessous (un seul prompt pour toute la cascade) :",
+    "fix_sudo_failed": "Pré-authentification sudo échouée : remédiations abandonnées.",
     "fix_success": "{label} : remédiation réussie.",
     "fix_failure": "{label} : échec de la remédiation (code {code}).",
     "fix_rerun":   "Relancez [bold]dsoxlab doctor[/bold] pour vérifier.",

--- a/tests/test_i18n_coverage.py
+++ b/tests/test_i18n_coverage.py
@@ -1,0 +1,137 @@
+"""Guard: no user-facing string may be hardcoded in `cli.py`.
+
+The rule already existed in prose ("every displayed text goes through
+`_()`"), and prose did not hold: option helps, progress-bar labels and a
+handful of error messages had drifted back into literals. Some were French,
+so an English run showed French; others were English, so a French run showed
+English. Both are the same defect.
+
+Rather than re-audit by hand, this module parses `cli.py` and asserts the
+invariant. It deliberately checks only what can be decided without judgement:
+
+* `help=` and `description=` keywords must be `_()` calls, no exception;
+* a bare string literal handed to `error/info/warn/success` is forbidden;
+* an f-string handed to those is allowed **only** if its literal parts carry
+  no word, i.e. it is pure layout around already-translated values
+  (`f"  ✔ {fqdn} ({ip})"` passes, `f"Host inconnu : {fqdn}"` does not).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+import dsoxlab
+
+CLI = Path(dsoxlab.__file__).parent / "cli.py"
+
+#: Les helpers d'affichage de `reporting.console`. Leur premier argument est
+#: le message vu par l'apprenant.
+MESSAGE_FUNCS = {"error", "info", "warn", "success"}
+
+#: Balises Rich (`[bold]`, `[/green]`…) : de la mise en forme, pas du texte.
+_RICH_TAG = re.compile(r"\[/?[a-z0-9 #]+\]", re.I)
+
+#: « Mot » au sens de ce test : trois lettres consécutives ou plus. En dessous,
+#: on est dans les symboles, la ponctuation ou les unités, pas dans la phrase.
+_WORD = re.compile(r"[^\W\d_]{3,}", re.UNICODE)
+
+
+@pytest.fixture(scope="module")
+def tree() -> ast.Module:
+    return ast.parse(CLI.read_text(encoding="utf-8"), filename=str(CLI))
+
+
+def _is_i18n_call(node: ast.AST) -> bool:
+    """Le nœud est-il un appel `_("clé", …)` ?"""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_"
+    )
+
+
+def _literal_words(node: ast.JoinedStr) -> list[str]:
+    """Les mots portés par les parties littérales d'une f-string."""
+    mots: list[str] = []
+    for part in node.values:
+        if isinstance(part, ast.Constant) and isinstance(part.value, str):
+            mots += _WORD.findall(_RICH_TAG.sub("", part.value))
+    return mots
+
+
+def test_option_help_and_progress_labels_go_through_i18n(tree: ast.Module) -> None:
+    """`help=` et `description=` sont affichés tels quels : jamais de littéral."""
+    coupables: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg not in {"help", "description"}:
+                continue
+            if isinstance(kw.value, (ast.Constant, ast.JoinedStr)) and not _is_i18n_call(
+                kw.value
+            ):
+                coupables.append(f"cli.py:{kw.value.lineno} — {kw.arg}=")
+
+    assert not coupables, (
+        "Ces libellés s'afficheraient dans une seule langue :\n  "
+        + "\n  ".join(coupables)
+    )
+
+
+def test_messages_are_translated_or_pure_layout(tree: ast.Module) -> None:
+    """Aucun `error/info/warn/success` ne porte de phrase en dur."""
+    coupables: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id not in MESSAGE_FUNCS or not node.args:
+            continue
+
+        premier = node.args[0]
+        if _is_i18n_call(premier):
+            continue
+        if isinstance(premier, ast.Constant) and isinstance(premier.value, str):
+            coupables.append(f"cli.py:{premier.lineno} — {premier.value[:50]!r}")
+        elif isinstance(premier, ast.JoinedStr):
+            mots = _literal_words(premier)
+            if mots:
+                coupables.append(f"cli.py:{premier.lineno} — mots en dur : {mots}")
+
+    assert not coupables, (
+        "Ces messages ne suivraient pas DSOXLAB_LANG :\n  " + "\n  ".join(coupables)
+    )
+
+
+def test_the_guard_would_actually_catch_a_regression() -> None:
+    """Un test qui ne peut pas échouer ne prouve rien : on le fait échouer.
+
+    Sans ce contrôle, une heuristique trop laxiste (ou un `_WORD` mal réglé)
+    laisserait les deux tests ci-dessus passer sur n'importe quel code.
+    """
+    fautif = ast.parse('error("Host inconnu")\ninfo(f"Cible : {x}")\n')
+    trouves = 0
+    for node in ast.walk(fautif):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id not in MESSAGE_FUNCS or not node.args:
+            continue
+        premier = node.args[0]
+        if isinstance(premier, ast.Constant):
+            trouves += 1
+        elif isinstance(premier, ast.JoinedStr) and _literal_words(premier):
+            trouves += 1
+
+    assert trouves == 2, "le garde-fou ne détecte plus les chaînes en dur"
+
+
+def test_pure_layout_is_not_flagged() -> None:
+    """Et il ne doit pas crier sur de la mise en forme sans texte."""
+    layout = ast.parse('success(f"  ✔ {fqdn} ({ip})")\ninfo(f"[bold]{a}[/bold] → {b}")\n')
+    for node in ast.walk(layout):
+        if isinstance(node, ast.JoinedStr):
+            assert not _literal_words(node)

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.33"
+version = "0.1.34"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
# Summary

The i18n rule ("every displayed text goes through `_()`") was stated in prose only, and prose did not hold: **21 user-facing strings** in `cli.py` ignored `DSOXLAB_LANG`. The defect ran **both ways**, which is why half of it had gone unnoticed:

| Direction | Strings | Symptom |
| --- | --- | --- |
| French literals | `use --provider`, `provision --host` and `destroy --host` helps; `Host inconnu` and `Cible Terraform` (×2 each); the whole `doctor --fix` sudo pre-flight | French text under `DSOXLAB_LANG=en` |
| English literals | every progress-bar label: Ansible task name, `Terraform init complete`, `Nothing to do`, test progress | English text under `DSOXLAB_LANG=fr` |

Writing a label in English is no more neutral than writing it in French. Both families now live in the EN and FR catalogs, which reach **315 paired keys** (`set(en) ^ set(fr)` is empty).

**One regression fixed on the way**: extracting the `destroy --host` help had dropped its sharpest warning, that the option does **not** isolate one VM from the others (Terraform destroys everything depending on the target). Restored in both languages.

## The guard, verified by making it fail

`tests/test_i18n_coverage.py` parses `cli.py` and rejects:

- any `help=` / `description=` that is not an `_()` call;
- any literal sentence handed to `error` / `info` / `warn` / `success`.

Pure layout around already-translated values (`f"  ✔ {fqdn} ({ip})"`) still passes, so the guard does not punish formatting.

A guard that passes proves nothing, so it was run against the **previous commit**: it reports all **21** violations there, and **0** on this branch. It therefore fails when it should.

## How this was verified

Every path was replayed in EN **and** FR, not re-read:

- on a throwaway repo (so no user context was touched): `use --provider` confirmation, the three option helps, `Host inconnu` (forcing the SSH key, since `provision` exits earlier otherwise), and an unreadable `meta.yml`;
- on two real lab repositories: `list-labs` and `doctor` on `linux-dsoxlab-training` and `terraform-training`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit)
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes — 149 tests, 4 of them new
- [x] The engine stays domain-agnostic — no domain-specific logic added; the extracted strings are generic CLI messages
- [x] No hardcoded personal path or host; `pathlib.Path` throughout
- [x] Manually tested against **two** lab repositories (`linux-dsoxlab-training` and `terraform-training`, the latter having no `infra:` block and only `shell` labs)

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped to `0.1.34` in `pyproject.toml`, `uv.lock` refreshed

### When a command or option is added, removed or changed

- [x] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [x] `help=_("…")` in `cli.py`. `fullhelp_commands` needs no change here: no command or option is added, removed or renamed — only the language of existing labels is fixed
- [x] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched

N/A — no workflow file is touched.

### When the declarative contract (`meta.yml` / `lab.yaml`) changes

N/A — the contract is unchanged; this PR only moves display strings into the i18n catalogs.

## Related issues

Follow-up to #45, which introduced the two-table `doctor` and the pager: this PR pays the i18n debt that reviewing that work brought to light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)