### PR TITLE
fix(instructor): refuser de créer une clé SSH hors d'un dépôt de labs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,13 @@ src/dsoxlab/templates/terraform/*/.terraform.lock.hcl
 crash-*
 leak-*
 timeout-*
+
+# Clés SSH : ce dépôt est celui de l'outil, il n'a aucune raison d'en porter.
+# `dsoxlab instructor bootstrap` refuse désormais d'en générer hors d'un dépôt
+# de labs, et le hook `detect-private-key` refuse de les committer. Cette
+# troisième ligne couvre ce que les deux autres laissent passer : un fichier
+# déposé par un autre chemin, ou un commit forcé en `--no-verify`.
+ssh/
+*.pem
+id_ed25519
+id_rsa

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,32 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.35] - 2026-07-27
+
+Les deux corrections viennent d'une campagne de validation complète sur un
+catalogue de 84 labs : un incident, et une fuite que la campagne a rendue
+visible.
+
+### Corrigé
+
+- **`instructor bootstrap` pouvait écrire une clé SSH hors de tout dépôt de
+  labs.** Elle créait `<root>/ssh/id_ed25519` d'après ce que rendait
+  `get_lab_home()`, or cette fonction retombe sur le **répertoire courant**
+  quand elle ne trouve aucun `meta.yml`. Lancée depuis le dépôt de l'outil, la
+  commande y a donc déposé une clé privée sans passphrase, dans un dépôt public
+  qu'aucun `.gitignore` ne couvrait. Le hook `detect-private-key` aurait refusé
+  le commit (vérifié : il sort en 1 avec « Private key found »), donc rien n'a
+  fui, mais un hook se contourne avec `--no-verify` et une clé de lab n'a rien
+  à faire là. La commande refuse désormais quand la cible n'a pas de `meta.yml`,
+  et nomme la solution (`--lab-home`). Défense en profondeur : `ssh/`, `*.pem`,
+  `id_ed25519` et `id_rsa` sont maintenant gitignorés ici.
+- **Un descripteur de fichier fuyait à chaque playbook joué.** `_read_stdout()`
+  lisait le fichier d'artefact d'`ansible-runner` sans jamais le refermer.
+  Anodin sur un lab, mesurable sur une campagne qui en enchaîne 84. Le
+  `ResourceWarning` qui le signalait se noyait dans le bruit des
+  `DeprecationWarning` de la bibliothèque elle-même : une fois ce bruit filtré,
+  un lab `vm` est passé de 26 warnings à zéro.
+
 ## [0.1.34] - 2026-07-27
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.35] - 2026-07-27
+
+Both fixes come from running a full validation campaign over an 84-lab
+catalog: one incident, one leak that the campaign made visible.
+
+### Fixed
+
+- **`instructor bootstrap` could write an SSH key outside any lab repository.**
+  It created `<root>/ssh/id_ed25519` from whatever `get_lab_home()` returned,
+  and that function falls back to the **current directory** when it finds no
+  `meta.yml`. Run from the tool's own repository, the command therefore dropped
+  a passphrase-less private key into a public repo, where no `.gitignore`
+  covered it. The `detect-private-key` hook would have refused the commit
+  (verified: it exits 1 with "Private key found"), so nothing leaked, but a
+  hook is bypassable with `--no-verify` and a lab key has no business being
+  there. The command now refuses when the target has no `meta.yml`, and names
+  the fix (`--lab-home`). Defence in depth: `ssh/`, `*.pem`, `id_ed25519` and
+  `id_rsa` are now gitignored here.
+- **A file descriptor leaked on every playbook run.** `_read_stdout()` read
+  `ansible-runner`'s artifact file and never closed it. Harmless on one lab,
+  measurable across a campaign that chains 84. The `ResourceWarning` that
+  reported it was drowned in the library's own `DeprecationWarning` noise:
+  once that noise was filtered, a `vm` lab went from 26 warnings to zero.
+
 ## [0.1.34] - 2026-07-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.34"
+version = "0.1.35"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -2035,6 +2035,18 @@ def instructor_bootstrap(
     Vérifie la présence de ``terraform`` et ``ansible-runner``.
     """
     root = _root(lab_home)
+
+    # Une clé privée ne se crée pas n'importe où. Sans `meta.yml`, `root` n'est
+    # pas un dépôt de labs : `get_lab_home()` a simplement retenu le répertoire
+    # courant en dernier recours. Le cas est vécu : lancée depuis le dépôt de
+    # l'outil, la commande y a déposé une paire de clés hors de tout .gitignore.
+    # Le hook `detect-private-key` l'aurait arrêtée au commit, mais un hook se
+    # contourne (`--no-verify`) et ne protège que ce dépôt-ci. La clé n'avait
+    # de toute façon rien à faire là : on refuse plutôt que de deviner.
+    if not (root / "meta.yml").is_file():
+        error(_("bootstrap_not_a_lab_repo", root=root))
+        raise typer.Exit(1)
+
     ssh_dir = root / "ssh"
     private_key = ssh_dir / "id_ed25519"
     public_key = ssh_dir / "id_ed25519.pub"

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -162,6 +162,12 @@ STRINGS: dict[str, str] = {
     "cmd_instructor_help":            "Instructor commands (lab key generation, vault, hosts, ssh-config). Not for learners.",
     "cmd_instructor_bootstrap_help":  "Generate the lab SSH key (if missing) and check that terraform/ansible-runner are installed.",
     "bootstrap_key_exists":           "SSH key already present: {path}",
+    "bootstrap_not_a_lab_repo":
+        "{root} is not a lab repository: no meta.yml at its root.\n"
+        "No key was generated: it would land in an arbitrary directory, "
+        "outside of any .gitignore.\n"
+        "Move into the lab repository, or point at it:\n"
+        "  dsoxlab instructor bootstrap --lab-home /path/to/the-repo",
     "bootstrap_generating_key":       "Generating SSH ed25519 key: {path} (no passphrase)…",
     "bootstrap_key_created":          "SSH key created: {path}",
     "bootstrap_keygen_failed":        "ssh-keygen failed: {stderr}",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -162,6 +162,12 @@ STRINGS: dict[str, str] = {
     "cmd_instructor_help":            "Commandes formateur (clé SSH, vault, hosts, ssh-config). Pas pour les apprenants.",
     "cmd_instructor_bootstrap_help":  "Génère la clé SSH du lab (si absente) et vérifie que terraform/ansible-runner sont installés.",
     "bootstrap_key_exists":           "Clé SSH déjà présente : {path}",
+    "bootstrap_not_a_lab_repo":
+        "{root} n'est pas un dépôt de labs : aucun meta.yml à sa racine.\n"
+        "Aucune clé n'a été générée : elle atterrirait dans un répertoire "
+        "quelconque, hors de tout .gitignore.\n"
+        "Place-toi dans le dépôt de labs, ou indique-le :\n"
+        "  dsoxlab instructor bootstrap --lab-home /chemin/vers/le-depot",
     "bootstrap_generating_key":       "Génération clé SSH ed25519 : {path} (sans passphrase)…",
     "bootstrap_key_created":          "Clé SSH créée : {path}",
     "bootstrap_keygen_failed":        "ssh-keygen a échoué : {stderr}",

--- a/src/dsoxlab/infra/ansible.py
+++ b/src/dsoxlab/infra/ansible.py
@@ -20,6 +20,7 @@ import logging
 import os
 import tempfile
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -213,4 +214,14 @@ def _read_stdout(runner: Any) -> str:
             return str(stdout_attr.read())
         except Exception:  # noqa: BLE001 — best-effort logging
             return ""
+        finally:
+            # ansible-runner ouvre ce fichier d'artefact et ne le referme pas.
+            # Sans ce close, chaque playbook joué fuit un descripteur : anodin
+            # sur un lab, visible sur une campagne qui en enchaîne 84, et le
+            # ResourceWarning se noyait dans le bruit des DeprecationWarning
+            # de la bibliothèque elle-même.
+            close = getattr(stdout_attr, "close", None)
+            if callable(close):
+                with suppress(Exception):
+                    close()
     return str(stdout_attr)

--- a/tests/test_instructor_bootstrap.py
+++ b/tests/test_instructor_bootstrap.py
@@ -1,0 +1,63 @@
+"""Garde-fou : une clé SSH ne se génère que dans un dépôt de labs.
+
+Incident à l'origine de ce module. `dsoxlab instructor bootstrap` a été lancé
+depuis le dépôt de l'outil (pas un dépôt de labs). `get_lab_home()` retombe sur
+le répertoire courant en dernier recours, faute de `meta.yml` : la commande y a
+donc créé `ssh/id_ed25519`, une clé privée sans passphrase, dans un dépôt
+**public** où aucun `.gitignore` ne la couvrait.
+
+Le hook `detect-private-key` l'aurait refusée au commit (vérifié : il sort en 1
+avec « Private key found »), donc la fuite n'était pas imminente. Mais un hook
+se contourne avec `--no-verify`, et surtout une clé de lab n'a rien à faire
+dans le dépôt du moteur : le défaut est de l'avoir écrite là.
+
+Trois protections se superposent désormais, et ce module tient la première :
+refuser de générer hors d'un dépôt de labs, puis `ssh/` dans le `.gitignore`,
+puis les hooks de détection de secrets.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from dsoxlab.cli import app
+
+runner = CliRunner()
+
+META_MINIMAL = "repo:\n  id: demo\n  category: demo\n"
+
+
+def test_refuse_de_generer_hors_dun_depot_de_labs(tmp_path: Path) -> None:
+    """Sans `meta.yml`, aucune clé, et un message qui dit quoi faire."""
+    resultat = runner.invoke(
+        app, ["instructor", "bootstrap", "--lab-home", str(tmp_path)]
+    )
+
+    assert resultat.exit_code == 1
+    assert not (tmp_path / "ssh").exists(), (
+        "le répertoire ssh/ ne doit même pas être créé"
+    )
+
+
+def test_un_vrai_depot_de_labs_passe_le_garde_fou(tmp_path: Path) -> None:
+    """Avec `meta.yml`, la commande travaille normalement.
+
+    On lui présente une clé déjà en place : le chemin nominal est donc couvert
+    sans dépendre de `ssh-keygen`, et surtout sans écrire de clé privée depuis
+    une suite de tests.
+    """
+    (tmp_path / "meta.yml").write_text(META_MINIMAL, encoding="utf-8")
+    ssh_dir = tmp_path / "ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "id_ed25519").write_text("clé factice", encoding="utf-8")
+    (ssh_dir / "id_ed25519.pub").write_text("clé publique factice", encoding="utf-8")
+
+    resultat = runner.invoke(
+        app, ["instructor", "bootstrap", "--lab-home", str(tmp_path)]
+    )
+
+    assert resultat.exit_code == 0
+    # La clé en place n'est pas écrasée : c'est celle des VM déjà provisionnées.
+    assert (ssh_dir / "id_ed25519").read_text(encoding="utf-8") == "clé factice"

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.34"
+version = "0.1.35"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
# Summary

Two fixes, both surfaced by running a full validation campaign over an 84-lab catalog: one incident, one leak the campaign made visible.

**1. `instructor bootstrap` could write an SSH key outside any lab repository.**

It created `<root>/ssh/id_ed25519` from whatever `get_lab_home()` returned, and that function falls back to the **current directory** when it finds no `meta.yml`. Run from the tool's own repository, the command dropped a passphrase-less private key into a public repo, where no `.gitignore` covered it.

The `detect-private-key` hook would have refused the commit — verified, it exits 1 with `Private key found` — so nothing leaked. But a hook is bypassable with `--no-verify`, it only protects this repository, and a lab key has no business being there anyway. The command now requires a `meta.yml` at the root and names the escape hatch (`--lab-home`).

Three layers now stack: this refusal, `ssh/` in `.gitignore`, then the secret-detection hooks.

**2. A file descriptor leaked on every playbook run.**

`_read_stdout()` read `ansible-runner`'s artifact file and never closed it. Harmless on one lab, measurable across a campaign chaining 84. The `ResourceWarning` reporting it was drowned in the library's own `DeprecationWarning` noise: once that noise was filtered on the labs-repo side, a `vm` lab went from 26 warnings to zero.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [x] Security / supply chain

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit)
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes — 151 tests, 2 of them new
- [x] The engine stays domain-agnostic — the guard keys off `meta.yml`, nothing domain-specific
- [x] No hardcoded personal path or host; `pathlib.Path` throughout
- [x] Manually tested against **two** lab repositories: the refusal was checked on a non-lab directory, and the whole 84-lab campaign ran against `linux-dsoxlab-training` with the descriptor fix in place

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped to `0.1.35` in `pyproject.toml`, `uv.lock` refreshed

### When a command or option is added, removed or changed

- [x] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py` (`bootstrap_not_a_lab_repo`)
- [x] No CLI option added or renamed, so `fullhelp` needs no change; the new message was checked under `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched

N/A — no workflow file is touched.

### When the declarative contract (`meta.yml` / `lab.yaml`) changes

N/A — the contract is unchanged. `meta.yml` is only *read* here, as the marker of a lab repository.

## Related issues

Follow-up to #45 and #46. The companion content fixes live in `linux-dsoxlab-training`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)