### PR TITLE
fix(runtimes/shell): préserver l'arborescence des fixtures (0.1.37)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,25 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.37] - 2026-07-28
+
+### Corrigé
+
+- **Un lab `shell` peut enfin livrer un module local.** `ShellRuntime` copiait
+  chaque fixture sur son **nom de base** : `modules/stockage/main.tf` atterrissait
+  donc en `main.tf` et **écrasait silencieusement** le `main.tf` de la racine.
+  Tout lab qui enseigne les modules Terraform était de ce fait impossible à
+  construire, et la panne était invisible : le workdir avait l'air correct, seul
+  son contenu était faux. Le docstring du module promettait déjà
+  `<lab>/fixtures/<fichier>` → `<lab>/<workdir>/<fichier>`, exemples en
+  sous-répertoire compris : le code contredisait son propre contrat. Le chemin
+  déclaré est désormais **préservé**, et les répertoires intermédiaires sont
+  créés. Un chemin absolu ou contenant `..` est refusé avec un avertissement au
+  lieu d'être suivi, de sorte qu'une fixture n'écrit jamais hors du workdir.
+  Strictement additif : aucune des **136** fixtures déclarées dans les trois
+  dépôts de labs ne comporte de `/`, donc aucun lab existant ne change de
+  comportement.
+
 ## [0.1.36] - 2026-07-27
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.37] - 2026-07-28
+
+### Fixed
+
+- **A `shell` lab can finally ship a local module.** `ShellRuntime` copied every
+  fixture on its **base name**, so `modules/stockage/main.tf` landed on
+  `main.tf` and **silently overwrote** the root `main.tf`. Any lab teaching
+  Terraform modules was therefore impossible to build, and the failure was
+  invisible: the workdir looked plausible, only its content was wrong. The
+  module docstring already promised `<lab>/fixtures/<file>` →
+  `<lab>/<workdir>/<file>` with nested examples, so the code contradicted its
+  own contract. The declared path is now **preserved** and intermediate
+  directories are created. A path that is absolute or contains `..` is refused
+  with a warning instead of being followed, so a fixture never writes outside
+  the workdir. Strictly additive: none of the **136** fixtures declared across
+  the three lab repositories uses a `/`, so no existing lab changes behaviour.
+
 ## [0.1.36] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -182,6 +182,28 @@ validation:
 An optional `lab.fr.yaml` may override `title` and `description` for French
 only.
 
+#### Optional `runtime.fixtures`: the starting files of a `shell` lab
+
+A `shell` lab lists the files it hands to the learner. Each entry is a path
+**relative to `<lab>/fixtures/`**, and that path is **preserved** under the
+workdir: intermediate directories are created for you, so a lab can ship a local
+Terraform module without its `main.tf` colliding with the root one.
+
+```yaml
+runtime:
+  type: shell
+  workdir: challenge/work
+  fixtures:
+    - versions.tf
+    - main.tf
+    - modules/stockage/main.tf   # lands in <workdir>/modules/stockage/main.tf
+```
+
+Two things to know. A file **not listed here is not copied**, even if it sits in
+`fixtures/` — the runtime iterates over this list, not over the directory. And a
+path that is absolute or contains `..` is refused with a warning, so a fixture
+never writes outside the workdir.
+
 #### Optional `runtime.services`: containerized sidecars
 
 A lab can declare containers that must be up while it runs. dsoxlab starts them

--- a/fuzz/corpus/lab_yaml/shell-fixtures-nested.yaml
+++ b/fuzz/corpus/lab_yaml/shell-fixtures-nested.yaml
@@ -1,0 +1,14 @@
+id: l2-module-local
+title: Ship a local module as a fixture
+level: intermediate
+skills: [terraform, modules]
+distros: [any]
+doc_url: https://blog.stephane-robert.info/docs/infra-as-code/provisionnement/terraform/
+runtime:
+  type: shell
+  workdir: challenge/work
+  fixtures:
+    - versions.tf
+    - main.tf
+    - modules/stockage/main.tf
+    - reference/etat-initial.tfstate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.36"
+version = "0.1.37"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/runtimes/shell.py
+++ b/src/dsoxlab/runtimes/shell.py
@@ -14,7 +14,12 @@ le poste de l'apprenant), la préparation se déclare directement dans
 `dsoxlab run` :
 
 1. crée ``<lab>/<workdir>/`` (idempotent)
-2. copie chaque ``<lab>/fixtures/<file>`` vers ``<lab>/<workdir>/<file>``
+2. copie chaque ``<lab>/fixtures/<file>`` vers ``<lab>/<workdir>/<file>``, en
+   **préservant le chemin déclaré** : ``modules/stockage/main.tf`` arrive en
+   ``<workdir>/modules/stockage/main.tf``, et les répertoires intermédiaires
+   sont créés. Un lab Terraform peut donc livrer un module local sans que son
+   ``main.tf`` écrase celui de la racine. Un chemin absolu ou contenant ``..``
+   est refusé : une fixture ne sort jamais du workdir.
 
 `dsoxlab clean` supprime ``<workdir>/``. Aucun script bash n'est invoqué
 (décision 11.3 du REFACTORING-PLAN — zéro exception au déclaratif).
@@ -64,7 +69,15 @@ class ShellRuntime(BaseRuntime):
 
         fixtures_root = lab.path / "fixtures"
         for rel in lab.runtime.fixtures:
-            src = fixtures_root / rel
+            chemin = Path(rel)
+            if chemin.is_absolute() or ".." in chemin.parts:
+                logger.warning(
+                    "Fixture ignorée : %s sort du workdir. Un chemin de fixture "
+                    "est toujours relatif à fixtures/, sans « .. ».",
+                    rel,
+                )
+                continue
+            src = fixtures_root / chemin
             if not src.is_file():
                 logger.warning(
                     "Fixture déclarée mais introuvable : %s "
@@ -72,7 +85,11 @@ class ShellRuntime(BaseRuntime):
                     src,
                 )
                 continue
-            dst = workdir / Path(rel).name
+            # Le chemin déclaré est PRÉSERVÉ : `modules/stockage/main.tf` arrive
+            # en `<workdir>/modules/stockage/main.tf`. Aplatir sur le nom de
+            # base rendait impossible tout lab à modules (deux `main.tf` dans
+            # l'arborescence s'écrasaient l'un l'autre).
+            dst = workdir / chemin
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dst)
             logger.info("fixture %s → %s", rel, dst)

--- a/tests/test_shell_fixtures.py
+++ b/tests/test_shell_fixtures.py
@@ -1,0 +1,107 @@
+"""Tests for fixture copying in ShellRuntime.
+
+The runtime used to copy every fixture on its **base name**
+(``workdir / Path(rel).name``), while the module docstring promised
+``<lab>/fixtures/<file>`` → ``<lab>/<workdir>/<file>``. Any lab shipping a
+local module was therefore impossible: ``modules/stockage/main.tf`` landed on
+``main.tf`` and silently overwrote the root ``main.tf``. A Terraform lab needs
+modules, so the declared path is now preserved.
+
+These tests pin both directions: the tree is kept, and a path escaping the
+workdir is refused rather than followed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dsoxlab.models.lab import LabDefinition, ValidationConfig
+from dsoxlab.models.runtime import RuntimeConfig, RuntimeType
+from dsoxlab.runtimes.shell import ShellRuntime
+
+
+def _lab(tmp_path: Path, fixtures: list[str]) -> LabDefinition:
+    return LabDefinition(
+        id="demo-lab",
+        title="Demo",
+        level="l1",
+        skills=["s"],
+        runtime=RuntimeConfig(
+            type=RuntimeType.SHELL, workdir="challenge/work", fixtures=fixtures
+        ),
+        distros=["alma10"],
+        doc_url="https://example.test/doc",
+        validation=ValidationConfig(),
+        path=tmp_path,
+    )
+
+
+def _ecrire(racine: Path, rel: str, contenu: str) -> None:
+    cible = racine / rel
+    cible.parent.mkdir(parents=True, exist_ok=True)
+    cible.write_text(contenu, encoding="utf-8")
+
+
+def test_a_nested_fixture_keeps_its_path(tmp_path: Path) -> None:
+    """`modules/stockage/main.tf` must not land on `main.tf`."""
+    _ecrire(tmp_path / "fixtures", "main.tf", "racine\n")
+    _ecrire(tmp_path / "fixtures", "modules/stockage/main.tf", "module\n")
+    lab = _lab(tmp_path, ["main.tf", "modules/stockage/main.tf"])
+
+    ShellRuntime().start(lab)
+
+    work = tmp_path / "challenge" / "work"
+    assert (work / "main.tf").read_text(encoding="utf-8") == "racine\n"
+    assert (work / "modules" / "stockage" / "main.tf").read_text(
+        encoding="utf-8"
+    ) == "module\n", "the nested fixture must keep its directory"
+
+
+def test_intermediate_directories_are_created(tmp_path: Path) -> None:
+    """The learner never runs mkdir: the runtime creates the tree."""
+    _ecrire(tmp_path / "fixtures", "a/b/c/note.txt", "profond\n")
+    lab = _lab(tmp_path, ["a/b/c/note.txt"])
+
+    ShellRuntime().start(lab)
+
+    assert (tmp_path / "challenge" / "work" / "a" / "b" / "c" / "note.txt").is_file()
+
+
+def test_a_flat_fixture_still_lands_at_the_root(tmp_path: Path) -> None:
+    """Regression guard: the 136 fixtures declared across the lab repos are flat."""
+    _ecrire(tmp_path / "fixtures", "versions.tf", "tf\n")
+    lab = _lab(tmp_path, ["versions.tf"])
+
+    ShellRuntime().start(lab)
+
+    assert (tmp_path / "challenge" / "work" / "versions.tf").is_file()
+
+
+def test_a_fixture_escaping_the_workdir_is_refused(tmp_path: Path) -> None:
+    """`../` in a declared path must not write outside the workdir."""
+    _ecrire(tmp_path, "dehors.txt", "vole\n")
+    lab = _lab(tmp_path, ["../dehors.txt"])
+
+    ShellRuntime().start(lab)
+
+    work = tmp_path / "challenge" / "work"
+    assert work.is_dir(), "the workdir is still created"
+    assert list(work.iterdir()) == [], "nothing may be copied from outside fixtures/"
+
+
+def test_an_absolute_fixture_path_is_refused(tmp_path: Path) -> None:
+    lab = _lab(tmp_path, ["/etc/hostname"])
+
+    ShellRuntime().start(lab)
+
+    assert list((tmp_path / "challenge" / "work").iterdir()) == []
+
+
+def test_a_missing_fixture_does_not_stop_the_others(tmp_path: Path) -> None:
+    """A typo in one entry must not deprive the learner of the whole workdir."""
+    _ecrire(tmp_path / "fixtures", "present.tf", "ok\n")
+    lab = _lab(tmp_path, ["absent.tf", "present.tf"])
+
+    ShellRuntime().start(lab)
+
+    assert (tmp_path / "challenge" / "work" / "present.tf").is_file()

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.36"
+version = "0.1.37"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
# Summary

`ShellRuntime` copiait chaque fixture sur son **nom de base**
(`workdir / Path(rel).name`). Une fixture `modules/stockage/main.tf` atterrissait
donc en `main.tf` et **écrasait silencieusement** le `main.tf` de la racine.
Conséquence : tout lab enseignant les modules Terraform était impossible à
construire, et la panne était invisible — le workdir avait l'air correct, seul
son contenu était faux.

Le docstring du module promettait déjà `<lab>/fixtures/<fichier>` →
`<lab>/<workdir>/<fichier>`, avec des exemples en sous-répertoire : **le code
contredisait son propre contrat**.

Le chemin déclaré est désormais **préservé**, et les répertoires intermédiaires
sont créés. Un chemin **absolu** ou contenant **`..`** est refusé avec un
avertissement au lieu d'être suivi, de sorte qu'une fixture n'écrit jamais hors
du workdir.

**Strictement additif** : aucune des **136** fixtures déclarées dans les trois
dépôts de labs ne comporte de `/`, donc aucun lab existant ne change de
comportement.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

La case Documentation est cochée pour le second commit : le README ne documentait
pas `runtime.fixtures` du tout, alors que le contrat change ici.

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit)
- [x] `uv run mypy src/dsoxlab` passes (strict) — `Success: no issues found in 48 source files`
- [x] `uv run pytest` passes — **166 passed, 1 skipped** (le skip est `test_services.py`, Docker injoignable au moment du run)
- [x] The engine stays domain-agnostic — la correction ne touche qu'un calcul de chemin, aucun nom de domaine ni de produit ajouté
- [x] No hardcoded personal path or host; `pathlib.Path` throughout — le chemin déclaré passe par `Path(rel)`, et c'est ce qui permet le contrôle `is_absolute()` / `".." in parts`
- [x] Manually tested against **two** lab repositories — testé contre les **trois** : `ansible-training`, `linux-dsoxlab-training` et `terraform-training`

Détail du contrôle manuel, puisque c'est le point sensible d'un changement de
copie de fixtures :

| Contrôle | Résultat |
|---|---|
| Fixtures posées à l'identique sur les 3 dépôts | **0 écart** sur les labs vérifiables (les workdir déjà présents ne sont pas touchés) |
| Labs découverts par `dsoxlab doctor` | **113 / 84 / 87**, identiques aux fichiers sur disque |
| `dsoxlab validate-structure` | vert sur les 3 dépôts |
| Suite d'un dépôt VM, avant / après la correction | identique (`97 passed, 274 errors` dans les deux cas, erreurs préexistantes et sans lien) |
| Lab neuf à module local, `dsoxlab run` puis `check` | `modules/stockage/main.tf` bien posé, **14/14 et 100/100** |

Les six tests nouveaux de `tests/test_shell_fixtures.py` couvrent les deux sens :
l'arborescence préservée, la création des répertoires intermédiaires, la fixture
à plat inchangée, le refus d'un `..` et d'un chemin absolu, et une fixture
manquante qui ne prive pas l'apprenant des autres. **Deux d'entre eux échouent
bien sur l'ancien code** — contrôle joué en remettant l'ancienne ligne le temps
d'un run, pour vérifier que les tests discriminent au lieu de passer par hasard.

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.36 → **0.1.37**) and `uv.lock` refreshed (`uv lock` → `Updated dsoxlab v0.1.36 -> v0.1.37`)

### When a command or option is added, removed or changed

`N/A` — aucune commande ni option CLI n'est touchée. Le changement porte sur la
copie interne des fixtures, invisible dans l'interface : aucune clé i18n, aucun
`help=`, aucune entrée `fullhelp` à modifier.

### When `.github/workflows/` is touched

`N/A` — aucun fichier de `.github/workflows/` n'est modifié par cette PR.

### When the declarative contract (`meta.yml` / `lab.yaml`) changes

Ce bloc **s'applique** : la sémantique de `runtime.fixtures` s'élargit, un chemin
pouvant désormais comporter des `/`.

- [x] The contract section of `README.md` reflects the change — nouvelle section
      `Optional runtime.fixtures`, qui documente le champ (jamais documenté
      jusqu'ici), la préservation du chemin, le refus des chemins échappant au
      workdir, et le piège « un fichier non déclaré n'est pas copié »
- [x] `fuzz/corpus/` seeds cover the new field — nouveau seed
      `shell-fixtures-nested.yaml` avec des chemins en sous-répertoire, à côté du
      seed à plat existant. Le dictionnaire `yaml_contract.dict` portait déjà
      `fixtures="fixtures:"`, et aucun **nouveau champ** n'est introduit : c'est
      la valeur du champ existant qui s'enrichit
- [x] A malformed value still raises inside the parser contract — inchangé : le
      parsing de `fixtures` reste une liste de chaînes, et les chemins invalides
      (absolu, `..`) sont traités à la **copie**, par un `logger.warning` puis
      `continue`, exactement comme une fixture introuvable l'était déjà. Un lab
      douteux est donc ignoré avec un avertissement au lieu de faire tomber la
      CLI

## Related issues

Aucune issue ouverte sur le sujet. Le défaut a été trouvé en construisant un lab
Terraform à module local, qui était irréalisable sans cette correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)