### PR TITLE
feat(runtimes/services): initialiser un service, et savoir qu'il est …

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,50 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.38] - 2026-07-28
+
+### Ajouté
+
+- **`runtime.services[].post_start` : un service peut être initialisé, pas
+  seulement démarré.** Un conteneur qui boote est rarement un service
+  utilisable : une base veut son schéma, un coffre ses secrets, un registre son
+  dépôt. Jusqu'ici cette étape retombait sur un script bash à la racine du lab,
+  que l'apprenant devait penser à lancer — d'où des labs qui se skippent quand
+  le service manque, ou qui échouent quand il est là mais vide. Les commandes
+  déclarées sont jouées dans le conteneur une fois le service prêt, par
+  `docker exec` et **sans shell** (ni expansion, ni pipe, ni redirection).
+  Chaque entrée s'écrit au choix en chaîne lisible
+  (`vault kv put secret/lab k=v`, découpée à la manière du shell, guillemets
+  respectés) ou en argv explicite (`["vault", "kv", "put", …]`).
+
+  Elles sont **rejouées à chaque démarrage**, y compris sur un conteneur déjà
+  debout : c'est ce qui rend l'état de départ identique d'un lab à l'autre,
+  quoi qu'ait laissé l'exercice précédent — elles doivent donc être
+  idempotentes, au même titre qu'un `setup.yaml`. Une commande en échec lève
+  `ServiceError` et arrête le lab en nommant la commande fautive et la sortie du
+  service, plutôt que de laisser les tests enregistrer un 0 silencieux.
+
+  dsoxlab reste agnostique du domaine : il exécute ce que le lab déclare, et ne
+  sait ni ce qu'est un secret ni ce qu'est un schéma.
+
+- **`runtime.services[].ready_exec` : le seul signal fiable de disponibilité.**
+  `ready_tcp` seul est un **faux positif dès que le port est publié** : Docker
+  installe son proxy sur le port de l'hôte **au moment du `run`**, et ce proxy
+  accepte les connexions avant que le service écoute. Mesuré, pas supposé — une
+  connexion réussit sur un `-p 8299:1234` dont le conteneur n'écoute nulle part.
+  La sonde déclarée ici s'exécute **dans** le conteneur (`vault status`,
+  `pg_isready`, `redis-cli ping`…) et est réessayée jusqu'à son succès ou
+  l'expiration de `ready_timeout`. Elle doit être sans effet : l'initialisation,
+  c'est `post_start`, qui attend désormais que la sonde soit satisfaite.
+
+### Corrigé
+
+- **`ready_tcp` documenté pour ce qu'il est : un port de l'HÔTE.** La docstring
+  disait « dans le conteneur, côté hôte », ce qui se lit dans les deux sens. La
+  nuance devient un piège dès qu'un lab remappe pour cohabiter : avec
+  `ports: ["8201:8200"]`, un `ready_tcp: 8200` sonde le 8200 de l'hôte, donc le
+  service de quelqu'un d'autre, et le déclare prêt.
+
 ## [0.1.37] - 2026-07-28
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.38] - 2026-07-28
+
+### Added
+
+- **`runtime.services[].post_start`: a service can be initialised, not just
+  started.** A container that boots is rarely a usable service — a database
+  wants its schema, a vault its secrets, a registry its repository. Until now
+  that step fell back to a bash script at the lab root, which the learner had to
+  remember to run: labs that skipped when the service was missing, or failed
+  when it was there but empty. The declared commands run inside the container
+  once it is ready, through `docker exec` with **no shell** (no expansion, no
+  pipe, no redirection). Each entry may be written as a readable string
+  (`vault kv put secret/lab k=v`, split the way a shell would, quotes honoured)
+  or as an explicit argv (`["vault", "kv", "put", …]`).
+
+  They are **replayed on every start**, including on a container that was
+  already up: that is what makes the starting state identical from one lab to
+  the next, whatever the previous exercise left behind — so they must be
+  idempotent, exactly like a `setup.yaml`. A failing command raises
+  `ServiceError` and stops the lab, naming the offending command and the
+  service output, rather than letting the tests record a silent zero.
+
+  dsoxlab stays domain-agnostic: it runs what the lab declares and knows nothing
+  of secrets or schemas.
+
+- **`runtime.services[].ready_exec`: the only trustworthy readiness signal.**
+  `ready_tcp` alone is a **false positive whenever the port is published**:
+  Docker installs its proxy on the host port at `run` time, and that proxy
+  accepts connections before the service listens. Measured, not assumed — a
+  connection succeeds on a `-p 8299:1234` whose container listens nowhere. The
+  probe declared here runs *inside* the container (`vault status`,
+  `pg_isready`, `redis-cli ping`…) and is retried until it succeeds or
+  `ready_timeout` expires. It must be side-effect free; initialisation belongs
+  in `post_start`, which now waits for the probe.
+
+### Fixed
+
+- **`ready_tcp` documented as what it is: a HOST port.** The docstring said
+  "in the container, host side", which reads either way. It matters as soon as
+  a lab remaps to cohabit: with `ports: ["8201:8200"]`, a `ready_tcp: 8200`
+  probes the host's 8200 — somebody else's service — and declares it ready.
+
 ## [0.1.37] - 2026-07-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.37"
+version = "0.1.38"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/models/_contract.py
+++ b/src/dsoxlab/models/_contract.py
@@ -17,6 +17,7 @@ harnais de ``fuzz/``.
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -81,6 +82,65 @@ def as_mapping(value: object, field_name: str, source: Path, *, default_empty: b
             f"(reçu : {type(value).__name__})."
         )
     return value
+
+
+def as_argv(value: object, field_name: str, source: Path) -> list[str]:
+    """Valide UNE commande et la normalise en ``argv``.
+
+    Mêmes écritures que :func:`as_argv_list`, au singulier : une chaîne
+    découpée façon shell, ou une liste d'arguments.
+    """
+    if value is None:
+        return []
+    commandes = as_argv_list([value], field_name, source)
+    return commandes[0] if commandes else []
+
+
+def as_argv_list(value: object, field_name: str, source: Path) -> list[list[str]]:
+    """Valide une liste de commandes et la normalise en liste d'``argv``.
+
+    Deux écritures sont acceptées pour la même commande, parce que les deux se
+    défendent dans un ``lab.yaml`` :
+
+    - ``- vault kv put secret/x k=v`` — lisible, découpée à la manière du shell
+      (``shlex``), donc les guillemets d'un argument à espaces sont respectés ;
+    - ``- ["vault", "kv", "put", "secret/x", "k=v"]`` — explicite, sans découpage.
+
+    Le résultat est toujours un ``argv``, exécuté sans shell : ni pipe, ni
+    redirection, ni expansion. Une chaîne vide (ou qui ne contient que des
+    espaces) est refusée plutôt qu'ignorée : ``docker exec`` sans commande
+    échouerait plus loin, avec un message qui ne désignerait pas le lab fautif.
+    """
+    if value is None:
+        return []
+    if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
+        raise ValueError(
+            f"{source}: '{field_name}' doit être une liste de commandes "
+            f"(reçu : {type(value).__name__})."
+        )
+    commandes: list[list[str]] = []
+    for idx, item in enumerate(value):
+        if isinstance(item, str):
+            try:
+                argv = shlex.split(item)
+            except ValueError as exc:  # guillemet non fermé
+                raise ValueError(
+                    f"{source}: '{field_name}[{idx}]' n'est pas une commande "
+                    f"analysable ({exc})."
+                ) from None
+        elif isinstance(item, (list, tuple)):
+            argv = [str(mot) for mot in item]
+        else:
+            raise ValueError(
+                f"{source}: '{field_name}[{idx}]' doit être une chaîne ou une "
+                f"liste d'arguments (reçu : {type(item).__name__})."
+            )
+        if not argv:
+            raise ValueError(
+                f"{source}: '{field_name}[{idx}]' est une commande vide."
+            )
+        commandes.append(argv)
+    return commandes
 
 
 def as_mapping_list(value: object, field_name: str, source: Path) -> list[dict[str, Any]]:

--- a/src/dsoxlab/models/lab.py
+++ b/src/dsoxlab/models/lab.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import yaml
 
-from ._contract import as_int, as_mapping, as_mapping_list, as_str_list
+from ._contract import (
+    as_argv,
+    as_argv_list,
+    as_int,
+    as_mapping,
+    as_mapping_list,
+    as_str_list,
+)
 from .runtime import RuntimeConfig, RuntimeType, Service, Target
 
 
@@ -122,7 +129,13 @@ class LabDefinition:
                 run_args=as_str_list(s.get("run_args"), f"runtime.services[{idx}].run_args", lab_yaml),
                 env={str(k): str(v) for k, v in env_raw.items()},
                 ready_tcp=as_int(s.get("ready_tcp"), 0, f"runtime.services[{idx}].ready_tcp", lab_yaml),
+                ready_exec=as_argv(
+                    s.get("ready_exec"), f"runtime.services[{idx}].ready_exec", lab_yaml
+                ),
                 ready_timeout=as_int(s.get("ready_timeout"), 90, f"runtime.services[{idx}].ready_timeout", lab_yaml),
+                post_start=as_argv_list(
+                    s.get("post_start"), f"runtime.services[{idx}].post_start", lab_yaml
+                ),
             ))
 
         runtime = RuntimeConfig(

--- a/src/dsoxlab/models/runtime.py
+++ b/src/dsoxlab/models/runtime.py
@@ -113,11 +113,57 @@ class Service:
     """Variables d'environnement du conteneur, passées en ``-e NOM=valeur``."""
 
     ready_tcp: int = 0
-    """Port TCP (dans le conteneur, côté hôte) à sonder jusqu'à ce qu'il
-    accepte une connexion. 0 = pas d'attente TCP."""
+    """Port **de l'hôte** à sonder jusqu'à ce qu'il accepte une connexion.
+    0 = pas d'attente TCP.
+
+    C'est bien le port publié, celui de gauche dans ``ports``, pas celui du
+    conteneur : la sonde ouvre une connexion sur ``127.0.0.1``. La distinction
+    n'a l'air de rien tant que les deux coïncident, et devient un piège dès
+    qu'on remappe pour cohabiter — avec ``ports: ["8201:8200"]``, un
+    ``ready_tcp: 8200`` sonderait le 8200 de l'hôte, donc **le service de
+    quelqu'un d'autre**, et le déclarerait prêt. Écrire ``ready_tcp: 8201``."""
+
+    ready_exec: list[str] = field(default_factory=list)
+    """Commande de SONDE jouée dans le conteneur jusqu'à ce qu'elle réussisse.
+
+    ``ready_tcp`` ne suffit pas dès que le port est publié : Docker installe un
+    proxy sur le port de l'hôte **au moment du ``run``**, et ce proxy accepte
+    les connexions avant que le service écoute — vérifié, une connexion réussit
+    sur un ``-p 8299:1234`` dont le conteneur n'écoute nulle part. La sonde TCP
+    répond donc « prêt » quasi immédiatement, et ce qui suit part trop tôt.
+
+    Cette commande, elle, s'exécute **dans** le conteneur et interroge le
+    service lui-même (``vault status``, ``pg_isready``, ``redis-cli ping``…).
+    Elle est réessayée jusqu'à ``ready_timeout``. Elle doit être **sans effet** :
+    c'est une question posée au service, pas une initialisation — celle-ci vit
+    dans ``post_start``, qui ne tourne qu'une fois la sonde satisfaite."""
 
     ready_timeout: int = 90
-    """Délai maximum, en secondes, pour que le service devienne disponible."""
+    """Délai maximum, en secondes, pour que le service devienne disponible.
+
+    Vaut pour ``ready_tcp`` et ``ready_exec``."""
+
+    post_start: list[list[str]] = field(default_factory=list)
+    """Commandes à jouer DANS le conteneur une fois le service prêt.
+
+    Un conteneur qui démarre est rarement un service utilisable : une base veut
+    son schéma, un coffre veut ses secrets, un registre veut son dépôt. Sans ce
+    crochet, cette initialisation retombait sur un script bash à la racine du
+    lab, que l'apprenant devait penser à lancer — donc un lab qui se skippe ou
+    qui échoue selon l'humeur du poste.
+
+    Chaque entrée est un **argv** exécuté par ``docker exec``, sans shell : pas
+    d'expansion, pas de pipe, pas de redirection. Le ``lab.yaml`` peut l'écrire
+    en liste (``["vault", "kv", "put", "secret/x", "k=v"]``) ou en chaîne
+    (``vault kv put secret/x k=v``), découpée à la manière du shell.
+
+    **Ces commandes sont rejouées à chaque démarrage**, y compris quand le
+    conteneur tournait déjà : c'est ce qui garantit un état de départ identique
+    d'un lab à l'autre. Elles doivent donc être idempotentes, au même titre
+    qu'un ``setup.yaml``.
+
+    dsoxlab ne les interprète pas : il ne sait pas ce qu'est un secret ni un
+    schéma, il exécute ce que le lab déclare."""
 
 
 @dataclass

--- a/src/dsoxlab/runtimes/services.py
+++ b/src/dsoxlab/runtimes/services.py
@@ -5,6 +5,11 @@ de cloud, une base de données, un registre). Le lab la déclare dans
 ``runtime.services`` (voir :class:`dsoxlab.models.runtime.Service`), et ce module
 démarre le conteneur avant ``run``/``check`` et l'arrête à ``destroy``/``clean``.
 
+Un conteneur debout n'est pas toujours un service utilisable : une base veut son
+schéma, un coffre ses secrets. ``post_start`` joue ces commandes dans le
+conteneur une fois le service prêt, ce qui évite au lab de fournir un script
+bash d'initialisation que l'apprenant devrait penser à lancer.
+
 **dsoxlab reste agnostique.** Ce module lance **l'image que le lab déclare**, sur
 les ports que le lab déclare, et ne connaît ni le cloud, ni le produit émulé.
 Aucune chaîne « aws », « floci » ou autre n'apparaît ici : toute la spécificité
@@ -81,23 +86,78 @@ def _wait_tcp(port: int, timeout: int) -> bool:
     return False
 
 
+def _wait_exec(name: str, argv: list[str], timeout: int) -> bool:
+    """Rejoue une sonde DANS le conteneur jusqu'à ce qu'elle réussisse.
+
+    C'est le seul signal fiable de disponibilité quand le port est publié :
+    ``_wait_tcp`` interroge alors le proxy de Docker, qui accepte les connexions
+    dès le ``run``, avant que le service écoute.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        if run_command(["docker", "exec", name, *argv], check=False, timeout=30).ok:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(1)
+
+
+def _wait_ready(service: Service, name: str) -> None:
+    """Attend que le service réponde vraiment, puis rend la main.
+
+    Deux étages complémentaires : ``ready_tcp`` élimine le conteneur mort-né
+    sans rien exiger de l'image, ``ready_exec`` prouve que le service répond.
+    """
+    if service.ready_tcp and not _wait_tcp(service.ready_tcp, service.ready_timeout):
+        raise ServiceError(
+            f"Le service '{service.name}' n'a pas ouvert le port "
+            f"{service.ready_tcp} en {service.ready_timeout}s."
+        )
+    if service.ready_exec and not _wait_exec(name, service.ready_exec, service.ready_timeout):
+        raise ServiceError(
+            f"Le service '{service.name}' n'a jamais répondu à « "
+            f"{' '.join(service.ready_exec)} » en {service.ready_timeout}s."
+        )
+
+
+def _run_post_start(service: Service, name: str) -> None:
+    """Joue les commandes d'initialisation DANS le conteneur, une fois prêt.
+
+    Après ``ready_tcp``, jamais avant : un port qui accepte une connexion ne
+    garantit pas un service qui répond, et une initialisation jouée trop tôt
+    échoue de façon intermittente — le pire des symptômes à diagnostiquer.
+
+    Sans shell (``docker exec`` reçoit l'argv tel quel), donc pas d'expansion ni
+    de redirection : ce que le lab déclare est ce qui s'exécute.
+    """
+    for argv in service.post_start:
+        res = run_command(["docker", "exec", name, *argv], check=False, timeout=120)
+        if not res.ok:
+            raise ServiceError(
+                f"L'initialisation du service '{service.name}' a échoué sur "
+                f"« {' '.join(argv)} » :\n{(res.stderr or res.stdout).strip()}"
+            )
+
+
 def start(service: Service, repo_id: str) -> str:
     """Démarre (ou réutilise) le conteneur d'un service et attend sa disponibilité.
 
     Idempotent : si le conteneur tourne déjà, on ne le recrée pas. S'il existe
     mais est arrêté, on le retire d'abord. Retourne le nom du conteneur.
 
+    ``post_start`` est rejoué dans les deux cas, y compris sur un conteneur
+    réutilisé : c'est ce qui rend l'état de départ identique d'un lab à l'autre,
+    quel que soit ce que l'exercice précédent a laissé derrière lui.
+
     Raises:
-        ServiceError: Docker indisponible, échec du ``run``, ou service jamais prêt.
+        ServiceError: Docker indisponible, échec du ``run``, service jamais
+            prêt, ou commande ``post_start`` en échec.
     """
     name = container_name(repo_id, service)
 
     if _is_running(name):
-        if service.ready_tcp and not _wait_tcp(service.ready_tcp, service.ready_timeout):
-            raise ServiceError(
-                f"Le service '{service.name}' tourne mais son port "
-                f"{service.ready_tcp} ne répond pas."
-            )
+        _wait_ready(service, name)
+        _run_post_start(service, name)
         return name
 
     if _exists(name):
@@ -117,11 +177,8 @@ def start(service: Service, repo_id: str) -> str:
             f"Le démarrage du service '{service.name}' a échoué :\n{res.stderr.strip()}"
         )
 
-    if service.ready_tcp and not _wait_tcp(service.ready_tcp, service.ready_timeout):
-        raise ServiceError(
-            f"Le service '{service.name}' n'a pas ouvert le port "
-            f"{service.ready_tcp} en {service.ready_timeout}s."
-        )
+    _wait_ready(service, name)
+    _run_post_start(service, name)
     return name
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -20,6 +20,7 @@ import yaml
 from dsoxlab.models.lab import LabDefinition
 from dsoxlab.models.runtime import Service
 from dsoxlab.runtimes import services as svc
+from dsoxlab.utils.shell import run_command
 
 CONTRACT_EXCEPTIONS = (KeyError, ValueError, yaml.YAMLError)
 
@@ -90,10 +91,270 @@ runtime:
     "runtime:\n  type: shell\n  services:\n    - name: x\n",           # image manquante
     "runtime:\n  type: shell\n  services: not-a-list\n",               # services scalaire
     "runtime:\n  type: shell\n  services:\n    - name: x\n      image: y\n      ports: nope\n",  # ports scalaire
+    # post_start scalaire : une seule commande écrite sans tiret. `list("vault…")`
+    # « réussirait » en découpant caractère par caractère, d'où le refus explicite.
+    "runtime:\n  type: shell\n  services:\n    - name: x\n      image: y\n      post_start: vault kv put a b\n",
+    # commande vide : docker exec sans argv échouerait plus loin, sans nommer le lab.
+    "runtime:\n  type: shell\n  services:\n    - name: x\n      image: y\n      post_start: ['']\n",
+    # guillemet non fermé : shlex lève, on veut un ValueError du contrat.
+    "runtime:\n  type: shell\n  services:\n    - name: x\n      image: y\n      post_start: ['vault kv put \"oops']\n",
+    # entrée d'un type impossible à interpréter comme une commande.
+    "runtime:\n  type: shell\n  services:\n    - name: x\n      image: y\n      post_start: [42]\n",
 ])
 def test_service_malforme_reste_dans_le_contrat(tmp_path: Path, bad: str) -> None:
     with pytest.raises(CONTRACT_EXCEPTIONS):
         _lab(tmp_path, bad)
+
+
+# ── ready_exec : la seule preuve de disponibilité ───────────────────────────
+
+def test_ready_exec_accepte_chaine_ou_argv(tmp_path: Path) -> None:
+    lab = _lab(tmp_path, """\
+runtime:
+  type: shell
+  services:
+    - name: vault
+      image: some/vault:1.0
+      ready_exec: vault status
+    - name: db
+      image: postgres:16
+      ready_exec: ["pg_isready", "-q"]
+""")
+    assert lab.runtime.services[0].ready_exec == ["vault", "status"]
+    assert lab.runtime.services[1].ready_exec == ["pg_isready", "-q"]
+
+
+def test_ready_exec_absent_donne_liste_vide(tmp_path: Path) -> None:
+    lab = _lab(tmp_path, "runtime:\n  type: shell\n  services:\n    - name: db\n      image: postgres:16\n")
+    assert lab.runtime.services[0].ready_exec == []
+
+
+def test_ready_exec_est_rejoue_jusqu_au_succes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """La sonde patiente : un service met du temps à répondre après le boot."""
+    tentatives = {"n": 0}
+
+    class _Res:
+        def __init__(self, ok: bool) -> None:
+            self.ok = ok
+            self.stdout = ""
+            self.stderr = ""
+
+    def _fake(cmd: list[str], **kw: object) -> _Res:
+        if cmd[:2] == ["docker", "exec"] and cmd[3:] == ["vault", "status"]:
+            tentatives["n"] += 1
+            return _Res(tentatives["n"] >= 3)  # prêt à la 3e sonde
+        return _Res(True)
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: True)
+    monkeypatch.setattr(svc, "run_command", _fake)
+    monkeypatch.setattr(svc.time, "sleep", lambda s: None)
+
+    service = Service(name="vault", image="x", ready_exec=["vault", "status"], ready_timeout=30)
+    svc.start(service, "repo")
+
+    assert tentatives["n"] == 3
+
+
+def test_ready_exec_jamais_satisfaite_leve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Timeout de la sonde : on lève, on ne lance pas post_start dans le vide."""
+    class _Res:
+        ok = False
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: True)
+    monkeypatch.setattr(svc, "run_command", lambda cmd, **kw: _Res())
+    monkeypatch.setattr(svc.time, "sleep", lambda s: None)
+
+    # ready_timeout=0 : la deadline est atteinte dès le premier échec. Figer
+    # `monotonic` à une constante rendrait au contraire la sortie de boucle
+    # inatteignable, et le test tournerait indéfiniment — vécu à l'écriture.
+    service = Service(name="vault", image="x", ready_exec=["vault", "status"], ready_timeout=0)
+    with pytest.raises(svc.ServiceError) as exc:
+        svc.start(service, "repo")
+    assert "vault status" in str(exc.value)
+
+
+def test_post_start_attend_ready_exec(monkeypatch: pytest.MonkeyPatch) -> None:
+    """L'initialisation ne part qu'une fois la sonde satisfaite.
+
+    C'est tout l'intérêt de ready_exec : sur un port publié, ready_tcp répond
+    « prêt » immédiatement (le proxy Docker accepte avant que le service
+    écoute), et post_start échouait alors sur un « connection refused » venu de
+    l'intérieur du conteneur.
+    """
+    ordre: list[str] = []
+
+    class _Res:
+        def __init__(self, ok: bool = True) -> None:
+            self.ok = ok
+            self.stdout = ""
+            self.stderr = ""
+
+    sondes = {"n": 0}
+
+    def _fake(cmd: list[str], **kw: object) -> _Res:
+        if cmd[3:] == ["vault", "status"]:
+            sondes["n"] += 1
+            pret = sondes["n"] >= 2
+            ordre.append(f"sonde{'-ok' if pret else '-ko'}")
+            return _Res(pret)
+        if cmd[:2] == ["docker", "exec"]:
+            ordre.append("init")
+        return _Res(True)
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: True)
+    monkeypatch.setattr(svc, "run_command", _fake)
+    monkeypatch.setattr(svc.time, "sleep", lambda s: None)
+
+    service = Service(
+        name="vault", image="x",
+        ready_exec=["vault", "status"],
+        post_start=[["vault", "kv", "put", "secret/lab", "k=v"]],
+    )
+    svc.start(service, "repo")
+
+    assert ordre == ["sonde-ko", "sonde-ok", "init"]
+
+
+# ── post_start : initialisation du service ──────────────────────────────────
+
+def test_post_start_absent_donne_liste_vide(tmp_path: Path) -> None:
+    lab = _lab(tmp_path, "runtime:\n  type: shell\n  services:\n    - name: db\n      image: postgres:16\n")
+    assert lab.runtime.services[0].post_start == []
+
+
+def test_post_start_accepte_les_deux_ecritures(tmp_path: Path) -> None:
+    """Chaîne façon shell ou argv explicite : même résultat normalisé."""
+    lab = _lab(tmp_path, """\
+runtime:
+  type: shell
+  services:
+    - name: vault
+      image: some/vault:1.0
+      post_start:
+        - vault kv put secret/lab db_password=Pass api_key=xyz
+        - ["vault", "policy", "write", "lab", "policies/lab.hcl"]
+""")
+    assert lab.runtime.services[0].post_start == [
+        ["vault", "kv", "put", "secret/lab", "db_password=Pass", "api_key=xyz"],
+        ["vault", "policy", "write", "lab", "policies/lab.hcl"],
+    ]
+
+
+def test_post_start_respecte_les_guillemets(tmp_path: Path) -> None:
+    """Un argument à espaces reste UN argument : c'est shlex, pas un split()."""
+    lab = _lab(tmp_path, """\
+runtime:
+  type: shell
+  services:
+    - name: db
+      image: postgres:16
+      post_start:
+        - psql -c "CREATE DATABASE lab"
+""")
+    assert lab.runtime.services[0].post_start == [
+        ["psql", "-c", "CREATE DATABASE lab"],
+    ]
+
+
+def test_post_start_joue_apres_le_demarrage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Les commandes partent en `docker exec`, dans l'ordre, après le run."""
+    appels: list[list[str]] = []
+
+    class _Res:
+        ok = True
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: False)
+    monkeypatch.setattr(svc, "_exists", lambda name: False)
+    monkeypatch.setattr(svc, "run_command",
+                        lambda cmd, **kw: (appels.append(list(cmd)), _Res())[1])
+
+    service = Service(
+        name="vault", image="some/vault:1.0",
+        post_start=[["vault", "kv", "put", "secret/lab", "k=v"], ["vault", "status"]],
+    )
+    svc.start(service, "ansible-training")
+
+    execs = [c for c in appels if c[:2] == ["docker", "exec"]]
+    assert execs == [
+        ["docker", "exec", "dsoxlab-ansible-training-vault", "vault", "kv", "put", "secret/lab", "k=v"],
+        ["docker", "exec", "dsoxlab-ansible-training-vault", "vault", "status"],
+    ]
+    # …et après le `docker run`, jamais avant : un service pas encore prêt
+    # ferait échouer l'initialisation par intermittence.
+    assert appels.index(["docker", "run", "-d", "--name", "dsoxlab-ansible-training-vault",
+                         "some/vault:1.0"]) < appels.index(execs[0])
+
+
+def test_ready_tcp_sonde_le_port_hote_pas_celui_du_conteneur(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Un service remappé attend son port PUBLIÉ.
+
+    Avec ``ports: ["8201:8200"]``, sonder 8200 reviendrait à interroger le 8200
+    de l'hôte, c'est-à-dire un service étranger — qui répondrait « prêt » pour
+    le mauvais serveur. Le cas n'est pas théorique : c'est exactement comme ça
+    qu'un lab a dialogué avec le Vault d'une autre formation.
+    """
+    sondes: list[int] = []
+
+    class _Res:
+        ok = True
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: False)
+    monkeypatch.setattr(svc, "_exists", lambda name: False)
+    monkeypatch.setattr(svc, "run_command", lambda cmd, **kw: _Res())
+    monkeypatch.setattr(svc, "_wait_tcp",
+                        lambda port, timeout: (sondes.append(port), True)[1])
+
+    service = Service(name="vault", image="x", ports=["8201:8200"], ready_tcp=8201)
+    svc.start(service, "repo")
+
+    assert sondes == [8201]
+
+
+def test_post_start_rejoue_sur_conteneur_deja_debout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Conteneur réutilisé : l'initialisation repasse, pour un état de départ identique."""
+    appels: list[list[str]] = []
+
+    class _Res:
+        ok = True
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: True)
+    monkeypatch.setattr(svc, "run_command",
+                        lambda cmd, **kw: (appels.append(list(cmd)), _Res())[1])
+
+    service = Service(name="vault", image="x", post_start=[["init"]])
+    svc.start(service, "repo")
+
+    assert ["docker", "exec", "dsoxlab-repo-vault", "init"] in appels
+    assert not [c for c in appels if c[:2] == ["docker", "run"]]  # pas de recréation
+
+
+def test_post_start_en_echec_leve_service_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Une initialisation ratée doit arrêter le lab, pas le laisser noter un 0."""
+    class _Res:
+        ok = False
+        stdout = ""
+        stderr = "permission denied on secret/lab"
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: True)
+    monkeypatch.setattr(svc, "run_command", lambda cmd, **kw: _Res())
+
+    service = Service(name="vault", image="x", post_start=[["vault", "kv", "put", "secret/lab"]])
+    with pytest.raises(svc.ServiceError) as exc:
+        svc.start(service, "repo")
+    # Le message doit nommer la commande fautive ET la sortie du service : sans
+    # elle, « l'initialisation a échoué » n'aide personne.
+    assert "vault kv put secret/lab" in str(exc.value)
+    assert "permission denied" in str(exc.value)
 
 
 # ── Nommage des conteneurs ──────────────────────────────────────────────────
@@ -128,3 +389,47 @@ def test_start_status_stop_cycle() -> None:
     finally:
         assert svc.stop(s, repo) in (True, False)
         assert svc.status(s, repo).running is False
+
+
+@pytest.mark.skipif(not svc.docker_available(), reason="Docker injoignable")
+def test_post_start_execute_vraiment_dans_le_conteneur() -> None:
+    """post_start contre un vrai Docker : la commande touche l'état du service.
+
+    Les tests ci-dessus mockent ``run_command`` : ils prouvent l'orchestration
+    (bon argv, bon ordre), pas que ``docker exec`` fasse quoi que ce soit. Ici
+    l'initialisation écrit un fichier dans le conteneur, et on va le relire —
+    vérifier la forme de la commande ne prouve pas son effet.
+
+    nginx:alpine parce qu'elle reste debout sans qu'on lui passe de commande :
+    le contrat ``services:`` déclare une image, pas un argv de conteneur.
+    """
+    s = Service(
+        name="pytest-poststart",
+        image="nginx:alpine",
+        post_start=[["sh", "-c", "echo initialise > /preuve-post-start"]],
+    )
+    repo = "dsoxlab-test"
+    try:
+        name = svc.start(s, repo)
+        lu = run_command(["docker", "exec", name, "cat", "/preuve-post-start"],
+                         check=False, timeout=30)
+        assert lu.ok, f"le fichier posé par post_start est illisible : {lu.stderr}"
+        assert lu.stdout.strip() == "initialise"
+    finally:
+        svc.stop(s, repo)
+
+
+@pytest.mark.skipif(not svc.docker_available(), reason="Docker injoignable")
+def test_post_start_en_echec_reel_leve_service_error() -> None:
+    """Une commande qui échoue dans le conteneur remonte en ServiceError."""
+    s = Service(
+        name="pytest-poststart-ko",
+        image="nginx:alpine",
+        post_start=[["sh", "-c", "exit 3"]],
+    )
+    repo = "dsoxlab-test"
+    try:
+        with pytest.raises(svc.ServiceError):
+            svc.start(s, repo)
+    finally:
+        svc.stop(s, repo)

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.37"
+version = "0.1.38"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
…prêt (0.1.38)

Un conteneur qui boote est rarement un service utilisable : une base veut son schéma, un coffre ses secrets, un registre son dépôt. Cette étape retombait sur un script bash à la racine du lab, que l'apprenant devait penser à lancer — d'où des labs qui se skippent quand le service manque, et qui échouent quand il est là mais vide. Vécu sur `vault/integration-hashicorp` d'ansible-training, dont les dépendances manquantes sont restées invisibles des mois durant, le skip absorbant tout.

`post_start` joue les commandes déclarées DANS le conteneur, par `docker exec` et sans shell (ni pipe, ni redirection, ni expansion). Chaque entrée s'écrit en chaîne lisible (`vault kv put secret/lab k=v`, découpée façon shell, guillemets respectés) ou en argv explicite. Elles sont rejouées à chaque démarrage, y compris sur un conteneur déjà debout : c'est ce qui rend l'état de départ identique d'un lab à l'autre, donc elles doivent être idempotentes, au même titre qu'un setup.yaml. Une commande en échec lève, en nommant la commande et la sortie du service.

`ready_exec` répare un défaut du mécanisme livré en 0.1.36 : `ready_tcp` seul est un FAUX POSITIF dès que le port est publié. Docker installe son proxy sur le port de l'hôte au moment du `run`, et ce proxy accepte les connexions avant que le service écoute. Mesuré plutôt que supposé : une connexion réussit sur un `-p 8299:1234` dont le conteneur n'écoute nulle part. C'est ce qui faisait échouer le premier essai de post_start sur un « connection refused » venu de l'intérieur du conteneur. La sonde déclarée s'exécute dans le conteneur (`vault status`, `pg_isready`…) et est réessayée jusqu'à ready_timeout.

Au passage, `ready_tcp` est documenté pour ce qu'il est : un port de l'HÔTE, celui de gauche dans `ports`. La docstring disait « dans le conteneur, côté hôte », ce qui se lit dans les deux sens — et la nuance devient un piège dès qu'un lab remappe pour cohabiter (`ports: ["8201:8200"]` avec `ready_tcp: 8200` sonderait le service d'un autre dépôt et le déclarerait prêt).

dsoxlab reste agnostique : il exécute ce que le lab déclare, et ne sait ni ce qu'est un secret ni ce qu'est un schéma.

Vérifié : 185 tests verts, dont deux d'intégration Docker réelle qui écrivent puis relisent dans le conteneur — les tests mockés ne prouvent que la forme de la commande. Les tests de comportement ont été confirmés par neutralisation du crochet, pour s'assurer qu'ils savent rougir. ruff et mypy --strict propres.

# Summary

<!-- What does this PR change, and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

Only the **Always** block applies to every PR. The other blocks are conditional:
if a block does not apply, say so (`N/A`) rather than leaving it blank — a blank
box reads as "forgotten", an explicit `N/A` reads as "considered".

### Always

- [ ] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit)
- [ ] `uv run mypy src/dsoxlab` passes (strict)
- [ ] `uv run pytest` passes
- [ ] The engine stays domain-agnostic — no domain-specific logic in
      `src/dsoxlab/` (no `if category == "linux"`)
- [ ] No hardcoded personal path or host; `pathlib.Path` throughout
- [ ] Manually tested against **two** lab repositories, to prove the agnostic
      design (e.g. `linux-dsoxlab-training` and `ansible-training`)

### When behavior changes — otherwise N/A

- [ ] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated (the project is
      bilingual; an EN-only entry is an incomplete entry)
- [ ] Version bumped in `pyproject.toml` and `uv.lock` refreshed (`uv lock`).
      `__version__` is derived from the package metadata — there is nothing to
      bump in `src/dsoxlab/__init__.py`.

### When a command or option is added, removed or changed — otherwise N/A

- [ ] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py`
- [ ] `help=_("…")` in `cli.py` and the `fullhelp_commands` section updated in
      EN **and** FR — `fullhelp` must never describe a command that no longer
      exists
- [ ] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched — otherwise N/A

These are CI gates: they fail the build, so run them before pushing.

- [ ] `actionlint` clean
- [ ] `zizmor --offline .github/workflows/` reports no findings
- [ ] `poutine analyze_local . --fail-on-violation` clean
- [ ] Every action pinned to a **full 40-character commit SHA** with a
      `# vX.Y.Z` comment — never `@v4`, never `@main`
- [ ] `step-security/harden-runner` is the job's first step
- [ ] No job renamed, or the required status checks updated accordingly — they
      match job names **exactly**, and a renamed job silently stops being
      required
- [ ] A new third-party action is added to `trustedGithubActions` in
      `.plumber.yaml` (and acknowledged per purl in `.poutine.yml` if its
      creator is not Marketplace-verified)

### When the declarative contract (`meta.yml` / `lab.yaml`) changes — otherwise N/A

- [ ] The contract section of `README.md` reflects the change
- [ ] `fuzz/corpus/` seeds and `fuzz/dict/yaml_contract.dict` cover any new field
- [ ] A malformed value of the new field still raises inside the parser contract
      — `(KeyError, ValueError, yaml.YAMLError)` — so a bad lab is skipped with a
      warning instead of crashing the CLI

## Related issues

<!-- e.g. Closes #123 -->
