### PR TITLE
fix(runtimes/services): ne réutiliser un conteneur que s'il correspond à la déclaration (0.1.40)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,22 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.40] - 2026-08-13
+
+### Corrigé
+
+- **Un conteneur debout n'est réutilisé que s'il correspond à la déclaration.**
+  La réutilisation se décidait sur le seul nom du conteneur. Deux labs d'un même
+  dépôt déclarant un service sous le même `name` mais avec des `ports`, `env`,
+  `image` ou `run_args` différents se partageaient donc le conteneur du premier
+  arrivé : le second démarrait sur un service qui n'avait ni ses ports ni ses
+  arguments de lancement, échouait là où l'apprenant n'avait rien fait de faux,
+  et rien n'en disait la raison. La configuration déclarée est désormais
+  estampillée sur le conteneur en label au `docker run`, puis comparée à la
+  réutilisation ; un conteneur divergent est remplacé. Un conteneur laissé par
+  une version antérieure ne porte pas de label : il est traité comme divergent
+  et recréé une fois.
+
 ## [0.1.39] - 2026-07-28
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.40] - 2026-08-13
+
+### Fixed
+
+- **A running container is reused only if it matches the declaration.** Reuse
+  was decided on the container name alone. Two labs of the same repository
+  declaring a service under the same `name` but with different `ports`, `env`,
+  `image` or `run_args` therefore shared whichever container came first: the
+  second lab started against a service that had neither its ports nor its
+  launch arguments, failed where the learner had done nothing wrong, and nothing
+  reported why. The declared configuration is now stamped on the container as a
+  label at `docker run` and compared on reuse; a divergent container is
+  replaced. A container left by an earlier version carries no label, so it is
+  treated as divergent and recreated once.
+
 ## [0.1.39] - 2026-07-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.39"
+version = "0.1.40"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/runtimes/services.py
+++ b/src/dsoxlab/runtimes/services.py
@@ -21,6 +21,8 @@ est nommé ``dsoxlab-<repo_id>-<service>`` pour éviter les collisions entre dé
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import socket
 import time
@@ -103,6 +105,51 @@ def _exists(name: str) -> bool:
     return run_command(["docker", "inspect", name], check=False, timeout=15).ok
 
 
+_CONFIG_LABEL = "info.dsoxlab.service-config"
+
+
+def _config_fingerprint(service: Service) -> str:
+    """Empreinte de ce que le lab déclare : image, ports, env, arguments bruts.
+
+    Deux labs d'un même dépôt qui déclarent un service de même ``name`` visent
+    le même nom de conteneur. Si leurs déclarations diffèrent, le conteneur du
+    premier ne convient pas au second, et le réutiliser tel quel donne un lab
+    silencieusement inutilisable.
+    """
+    charge = json.dumps(
+        {
+            "image": service.image,
+            "ports": list(service.ports),
+            "env": dict(sorted(service.env.items())),
+            "run_args": list(service.run_args),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(charge.encode("utf-8")).hexdigest()[:16]
+
+
+def _running_fingerprint(name: str) -> str | None:
+    """Empreinte portée par le conteneur en place, ``None`` s'il n'en a pas.
+
+    Un conteneur créé par une version antérieure de dsoxlab n'a pas le label :
+    il est alors traité comme divergent, donc recréé une fois.
+    """
+    res = run_command(
+        ["docker", "inspect", "-f", "{{json .Config.Labels}}", name],
+        check=False,
+        timeout=15,
+    )
+    if not res.ok:
+        return None
+    try:
+        labels = json.loads(res.stdout.strip() or "null") or {}
+    except json.JSONDecodeError:
+        return None
+    valeur = labels.get(_CONFIG_LABEL)
+    return valeur if isinstance(valeur, str) else None
+
+
 def _wait_tcp(port: int, timeout: int) -> bool:
     """Sonde ``localhost:port`` jusqu'à acceptation d'une connexion, ou timeout."""
     deadline = time.monotonic() + timeout
@@ -171,8 +218,16 @@ def _run_post_start(service: Service, name: str) -> None:
 def start(service: Service, repo_id: str) -> str:
     """Démarre (ou réutilise) le conteneur d'un service et attend sa disponibilité.
 
-    Idempotent : si le conteneur tourne déjà, on ne le recrée pas. S'il existe
-    mais est arrêté, on le retire d'abord. Retourne le nom du conteneur.
+    Idempotent : si le conteneur tourne déjà **avec la configuration déclarée**,
+    on ne le recrée pas. S'il existe mais est arrêté, on le retire d'abord.
+    Retourne le nom du conteneur.
+
+    La réutilisation compare l'empreinte de la déclaration à celle du conteneur
+    en place. Sans cette comparaison, deux labs d'un même dépôt déclarant un
+    service homonyme aux options différentes se partagent le conteneur du
+    premier arrivé : le second démarre sur un service qui n'a ni ses ports, ni
+    ses variables, ni ses arguments de lancement, et le lab échoue là où
+    l'apprenant n'a rien fait de faux.
 
     ``post_start`` est rejoué dans les deux cas, y compris sur un conteneur
     réutilisé : c'est ce qui rend l'état de départ identique d'un lab à l'autre,
@@ -183,8 +238,9 @@ def start(service: Service, repo_id: str) -> str:
             prêt, ou commande ``post_start`` en échec.
     """
     name = container_name(repo_id, service)
+    empreinte = _config_fingerprint(service)
 
-    if _is_running(name):
+    if _is_running(name) and _running_fingerprint(name) == empreinte:
         _wait_ready(service, name)
         _run_post_start(service, name)
         return name
@@ -200,7 +256,8 @@ def start(service: Service, repo_id: str) -> str:
     _ensure_network(reseau)
 
     cmd = ["docker", "run", "-d", "--name", name,
-           "--network", reseau, "--network-alias", service.name]
+           "--network", reseau, "--network-alias", service.name,
+           "--label", f"{_CONFIG_LABEL}={empreinte}"]
     for mapping in service.ports:
         cmd += ["-p", mapping]
     for key, value in service.env.items():

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -162,14 +162,16 @@ def test_ready_exec_jamais_satisfaite_leve(monkeypatch: pytest.MonkeyPatch) -> N
         stdout = ""
         stderr = ""
 
-    monkeypatch.setattr(svc, "_is_running", lambda name: True)
-    monkeypatch.setattr(svc, "run_command", lambda cmd, **kw: _Res())
-    monkeypatch.setattr(svc.time, "sleep", lambda s: None)
-
     # ready_timeout=0 : la deadline est atteinte dès le premier échec. Figer
     # `monotonic` à une constante rendrait au contraire la sortie de boucle
     # inatteignable, et le test tournerait indéfiniment — vécu à l'écriture.
     service = Service(name="vault", image="x", ready_exec=["vault", "status"], ready_timeout=0)
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: True)
+    monkeypatch.setattr(svc, "_running_fingerprint",
+                        lambda name: svc._config_fingerprint(service))
+    monkeypatch.setattr(svc, "run_command", lambda cmd, **kw: _Res())
+    monkeypatch.setattr(svc.time, "sleep", lambda s: None)
     with pytest.raises(svc.ServiceError) as exc:
         svc.start(service, "repo")
     assert "vault status" in str(exc.value)
@@ -328,15 +330,116 @@ def test_post_start_rejoue_sur_conteneur_deja_debout(monkeypatch: pytest.MonkeyP
         stdout = ""
         stderr = ""
 
+    service = Service(name="vault", image="x", post_start=[["init"]])
+
     monkeypatch.setattr(svc, "_is_running", lambda name: True)
+    # Le conteneur en place porte bien la configuration déclarée : c'est la
+    # condition de la réutilisation depuis 0.1.40.
+    monkeypatch.setattr(svc, "_running_fingerprint",
+                        lambda name: svc._config_fingerprint(service))
     monkeypatch.setattr(svc, "run_command",
                         lambda cmd, **kw: (appels.append(list(cmd)), _Res())[1])
 
-    service = Service(name="vault", image="x", post_start=[["init"]])
     svc.start(service, "repo")
 
     assert ["docker", "exec", "dsoxlab-repo-vault", "init"] in appels
     assert not [c for c in appels if c[:2] == ["docker", "run"]]  # pas de recréation
+
+
+def test_conteneur_debout_mais_config_divergente_est_recree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deux labs, un même nom de service, des options différentes.
+
+    Le conteneur laissé par le lab précédent n'a ni les ports ni les arguments
+    que celui-ci déclare. Le réutiliser donnerait un lab inutilisable sans que
+    rien ne le signale : il doit être remplacé.
+    """
+    appels: list[list[str]] = []
+
+    class _Res:
+        ok = True
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: True)
+    monkeypatch.setattr(svc, "_exists", lambda name: True)
+    monkeypatch.setattr(svc, "_wait_ready", lambda service, name: None)
+    monkeypatch.setattr(svc, "_running_fingerprint", lambda name: "empreinte-du-lab-precedent")
+    monkeypatch.setattr(svc, "run_command",
+                        lambda cmd, **kw: (appels.append(list(cmd)), _Res())[1])
+
+    service = Service(name="cloud", image="x", ports=["14566:4566"],
+                      run_args=["-u", "root", "-v", "/var/run/docker.sock:/var/run/docker.sock"])
+    svc.start(service, "repo")
+
+    assert ["docker", "rm", "-f", "dsoxlab-repo-cloud"] in appels
+    lancements = [c for c in appels if c[:2] == ["docker", "run"]]
+    assert len(lancements) == 1, "le conteneur divergent doit être relancé"
+    assert "-v" in lancements[0] and "14566:4566" in lancements[0]
+
+
+def test_le_lancement_estampille_la_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sans label posé au `run`, la comparaison suivante ne peut rien conclure."""
+    appels: list[list[str]] = []
+
+    class _Res:
+        ok = True
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: False)
+    monkeypatch.setattr(svc, "_exists", lambda name: False)
+    monkeypatch.setattr(svc, "_wait_ready", lambda service, name: None)
+    monkeypatch.setattr(svc, "run_command",
+                        lambda cmd, **kw: (appels.append(list(cmd)), _Res())[1])
+
+    service = Service(name="cloud", image="x", ports=["14566:4566"])
+    svc.start(service, "repo")
+
+    lancement = [c for c in appels if c[:2] == ["docker", "run"]][0]
+    attendu = f"{svc._CONFIG_LABEL}={svc._config_fingerprint(service)}"
+    assert "--label" in lancement
+    assert attendu in lancement
+
+
+def test_l_empreinte_distingue_ce_qui_change_le_conteneur() -> None:
+    """Image, ports, variables et arguments bruts font un conteneur différent."""
+    base = Service(name="cloud", image="img:1", ports=["4566:4566"],
+                   env={"A": "1"}, run_args=["-u", "root"])
+    empreinte = svc._config_fingerprint(base)
+
+    assert empreinte == svc._config_fingerprint(
+        Service(name="cloud", image="img:1", ports=["4566:4566"],
+                env={"A": "1"}, run_args=["-u", "root"])
+    )
+    # Le nom du service ne change pas le conteneur produit : il nomme déjà le
+    # conteneur, et l'inclure ferait diverger l'empreinte pour rien.
+    assert empreinte != svc._config_fingerprint(
+        Service(name="cloud", image="img:2", ports=["4566:4566"],
+                env={"A": "1"}, run_args=["-u", "root"]))
+    assert empreinte != svc._config_fingerprint(
+        Service(name="cloud", image="img:1", ports=["14566:4566"],
+                env={"A": "1"}, run_args=["-u", "root"]))
+    assert empreinte != svc._config_fingerprint(
+        Service(name="cloud", image="img:1", ports=["4566:4566"],
+                env={"A": "2"}, run_args=["-u", "root"]))
+    assert empreinte != svc._config_fingerprint(
+        Service(name="cloud", image="img:1", ports=["4566:4566"],
+                env={"A": "1"}, run_args=["-u", "nobody"]))
+
+
+def test_conteneur_sans_label_est_traite_comme_divergent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Un conteneur d'une version antérieure n'a pas de label : on le recrée une fois."""
+    class _Res:
+        ok = True
+        stdout = "null"
+        stderr = ""
+
+    monkeypatch.setattr(svc, "run_command", lambda cmd, **kw: _Res())
+    assert svc._running_fingerprint("dsoxlab-repo-cloud") is None
 
 
 def test_post_start_en_echec_leve_service_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -346,10 +449,13 @@ def test_post_start_en_echec_leve_service_error(monkeypatch: pytest.MonkeyPatch)
         stdout = ""
         stderr = "permission denied on secret/lab"
 
+    service = Service(name="vault", image="x", post_start=[["vault", "kv", "put", "secret/lab"]])
+
     monkeypatch.setattr(svc, "_is_running", lambda name: True)
+    monkeypatch.setattr(svc, "_running_fingerprint",
+                        lambda name: svc._config_fingerprint(service))
     monkeypatch.setattr(svc, "run_command", lambda cmd, **kw: _Res())
 
-    service = Service(name="vault", image="x", post_start=[["vault", "kv", "put", "secret/lab"]])
     with pytest.raises(svc.ServiceError) as exc:
         svc.start(service, "repo")
     # Le message doit nommer la commande fautive ET la sortie du service : sans

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.39"
+version = "0.1.40"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
# Summary

Container reuse was decided on the container **name** alone. Two labs of the
same repository declaring a service under the same `name`, but with different
`ports`, `env`, `image` or `run_args`, therefore shared whichever container came
first. The second lab started against a service that had neither its ports nor
its launch arguments, failed where the learner had done nothing wrong, and
nothing reported why.

Found on `terraform-training`: the emulator left behind by the
`backend-s3-remote-state` lab does not carry the Docker socket that the
`provider-aws-first-ec2` lab requires. The instance would have stayed in
`pending` indefinitely, and the lab would have scored 0 with no explanation.

The declared configuration (image, ports, env, run_args) is now hashed and
stamped on the container as a label at `docker run`, then compared on reuse; a
divergent container is replaced. A container left by an earlier version carries
no label, so it is treated as divergent and recreated once.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit) —
      run through the pre-commit hooks, which passed
- [x] `uv run mypy src/dsoxlab` passes (strict) — 48 source files, no issue
- [x] `uv run pytest` passes — **193 passed**, including 4 new tests
- [x] The engine stays domain-agnostic — the fingerprint is computed from the
      declared fields only; no product, cloud or domain name appears anywhere in
      the change
- [x] No hardcoded personal path or host; `pathlib.Path` throughout
- [x] Manually tested against **two** lab repositories:
      - `terraform-training` — a container declared **without** the Docker socket
        is replaced by one that declares it; the lab then scores 11/11
      - `ansible-training` (`vault-integration-passbolt`, **two** services) —
        both start with distinct fingerprints, and a re-run reuses them (identical
        container IDs before and after)

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.39 → 0.1.40) and `uv.lock`
      refreshed

### When a command or option is added, removed or changed

N/A — no command, option or user-facing string is added, removed or changed.
The fix is entirely internal to `runtimes/services.py`, so there is no i18n key
to add and no `fullhelp` entry to update.

### When `.github/workflows/` is touched

N/A — no workflow file is touched by this PR.

### When the declarative contract (`meta.yml` / `lab.yaml`) changes

N/A — the contract is unchanged. No field is added, removed or reinterpreted;
`runtime.services` is read exactly as before. Only the decision to reuse or
recreate a container changes.

## Verification

Beyond the mocked unit tests, the behaviour was checked for real, since mocks
cannot prove a container was actually replaced:

| Check | Result |
| --- | --- |
| Same declaration replayed | container reused (identical ID) |
| Declaration changed (ports, `run_args`, `env`) | container **replaced** |
| New container's host port | actually rebound to the newly declared port |
| New container's `run_args` | `User=root` and the mount actually applied |
| Container with no label (earlier version) | treated as divergent, recreated once |

## Related issues

N/A
