### PR TITLE
ci(release): monter l'action de publication PyPI en v1.14.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI (Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true
           print-hash: true


### PR DESCRIPTION
# Summary

The 0.1.40 release built fine but **failed at upload**, for a reason unrelated
to its content:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

`build-system.requires` declares `hatchling` with no upper bound, and hatchling
now emits wheels with `Metadata-Version: 2.5`. The pinned action shipped
`twine==6.1.0` / `packaging==25.0`, which do not know that metadata version.

Measured on the action's own pinned requirements:

| Action version | `twine` | `packaging` |
| --- | --- | --- |
| v1.14.0 (current) | 6.1.0 | 25.0 — rejects `Metadata-Version: 2.5` |
| v1.14.2 | 7.0.0 | 26.2 — accepts it |

So this is the cause, not a workaround. No dsoxlab version changes, no package
behavior changes; only the uploader moves.

Consequence to be aware of: **tag `v0.1.40` is already pushed and points at a
commit that still carries the old workflow.** Re-running that run would replay
the faulty definition. Republishing 0.1.40 therefore needs the tag to be moved
onto a commit that contains this fix — handled separately, once this is merged.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz` passes — no Python file is
      touched; the pre-commit hooks reported `no files to check`
- [x] `uv run mypy src/dsoxlab` passes — same, no Python file touched
- [x] `uv run pytest` passes — 193 tests, unchanged by this PR
- [x] The engine stays domain-agnostic — no `src/dsoxlab/` file is touched
- [x] No hardcoded personal path or host
- [x] Manually tested against **two** lab repositories — N/A in spirit, since no
      engine code changes; the two-repository test was carried out in #64, whose
      release this PR unblocks

### When behavior changes

N/A — no behavior of the published package changes. The version stays 0.1.40 and
its CHANGELOG entry already exists; adding a line about the uploader would
describe CI plumbing, not a user-visible change. Nothing to bump: re-bumping
would desynchronise the already-pushed `v0.1.40` tag.

### When a command or option is added, removed or changed

N/A — no command, option or user-facing string is touched.

### When `.github/workflows/` is touched

- [x] `actionlint` clean — no output
- [x] `zizmor --offline .github/workflows/` reports no findings — "No findings
      to report. Good job!" across all four workflows
- [x] `poutine analyze_local . --fail-on-violation` clean — every rule `Passed`
- [x] Action pinned to a **full 40-character commit SHA** with a `# vX.Y.Z`
      comment — `dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2`,
      dereferenced from the annotated tag object to the commit it points at
- [x] `step-security/harden-runner` is the job's first step — unchanged
- [x] No job renamed — only the `uses:` line changes, so required status checks
      are untouched
- [x] A new third-party action added to `trustedGithubActions` — N/A, this is
      not a new action: `.plumber.yaml` already lists `pypa/gh-action-pypi-publish`
      **by name**, not by SHA, so no policy file needs updating

### When the declarative contract changes

N/A — the contract is untouched.

## Related issues

Unblocks the failed release run for `v0.1.40`.
