### PR TITLE
feat(provision): rendre l'attente des hôtes réglable, et installer l'agent Incus au besoin (0.1.41)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,41 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.41] - 2026-08-19
+
+### Ajouté
+
+- **`DSOXLAB_HOST_READY_TIMEOUT` règle la durée pendant laquelle `provision`
+  attend qu'un hôte devienne joignable.** Le délai était figé à 180 s. Sur une
+  machine modeste, le démarrage simultané de plusieurs VM sature le processeur :
+  un rapport d'usage a mesuré un hôte prêt à 181 s, une seconde après l'abandon
+  de l'attente, quand un audit sur 8 vCPU mesurait les mêmes hôtes prêts en
+  45 s. Le facteur limitant est le processeur au démarrage parallèle, et le
+  matériel de l'apprenant est une propriété de sa machine plutôt que du dépôt de
+  labs : c'est donc une variable d'environnement et non une clé du `meta.yml`.
+  Une valeur qui n'est pas un nombre positif retombe sur le défaut au lieu de
+  faire échouer le provisionnement, et le message d'expiration nomme désormais
+  la variable.
+
+- **Les VM AlmaLinux installent l'agent Incus depuis le CD-ROM `agent:config`
+  quand l'image ne l'a pas fait elle-même.** La famille RHEL ne fournit pas le
+  driver 9p (mesuré : aucune entrée `9p` dans `/proc/filesystems`), qui est la
+  voie par laquelle les images cloud récupèrent normalement cet agent. Sans
+  agent, Incus ne remonte aucune IP et l'attente expire sur une VM qui a
+  pourtant parfaitement démarré.
+
+  Il s'agit d'un filet de sécurité et non de la correction d'un défaut
+  reproduit : sur Incus 6.0.0 avec `images:almalinux/10/cloud`, l'agent arrive
+  déjà par ce même CD-ROM et le provisionnement réussit sans ce bloc. Il couvre
+  les environnements où ce n'est pas le cas, ce qu'un utilisateur a rapporté en
+  usage réel.
+
+  Le bloc est sans effet partout ailleurs, et il se décide sur la présence de
+  `install.sh` plutôt que sur celle de `/dev/sr0`, car le provider KVM attache
+  lui aussi un CD-ROM (son seed NoCloud). Il ne peut pas non plus sortir en
+  erreur : un `runcmd` en échec fait finir cloud-init en `status: error`, ce qui
+  suffit à bloquer cette même attente.
+
 ## [0.1.40] - 2026-08-13
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.41] - 2026-08-19
+
+### Added
+
+- **`DSOXLAB_HOST_READY_TIMEOUT` sets how long `provision` waits for a host to
+  become reachable.** The delay was hard-coded to 180 s. On a modest machine,
+  booting several VMs at once saturates the CPU: a usage report measured a host
+  ready at 181 s, one second after the wait had given up, while an audit on
+  8 vCPU measured the same hosts ready in 45 s. The CPU at parallel boot is the
+  limiting factor, and the learner's hardware is a property of their machine
+  rather than of the labs repository, so this is an environment variable and
+  not a `meta.yml` key. A value that is not a positive number falls back to the
+  default instead of failing the provision, and the timeout message now names
+  the variable.
+
+- **AlmaLinux VMs install the Incus agent from the `agent:config` CD-ROM when
+  the image has not done it itself.** The RHEL family ships no 9p driver
+  (measured: no `9p` entry in `/proc/filesystems`), which is how cloud images
+  normally fetch that agent. Without an agent Incus reports no IP at all, and
+  the readiness wait expires on a VM that booted perfectly.
+
+  This is a safety net, not the fix of a reproduced defect: on Incus 6.0.0 with
+  `images:almalinux/10/cloud`, the agent already arrives through that very
+  CD-ROM and provisioning succeeds without this block. It covers the setups
+  where it does not, which is what a user reported in real use.
+
+  The block is a no-op everywhere else, and it discriminates on the presence of
+  `install.sh` rather than on `/dev/sr0`, because the KVM provider attaches a
+  CD-ROM too (its NoCloud seed). It can never exit non-zero either: a failing
+  `runcmd` ends cloud-init in `status: error`, which on its own is enough to
+  hang that same wait.
+
 ## [0.1.40] - 2026-08-13
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.40"
+version = "0.1.41"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -125,7 +125,7 @@ STRINGS: dict[str, str] = {
     "provision_provider_conflict": "Cannot provision on '{current}': provider '{others}' still has active lab infrastructure.\nincus and KVM share the lab's network name and subnet, so they can't run at the same time.\nFinish or tear down the other one first:\n  DSOXLAB_PROVIDER={other} dsoxlab destroy",
     "provision_waiting_ssh": "Waiting for hosts to become reachable (SSH + cloud-init)…",
     "provision_waiting_ssh_host": "Waiting for {host} (SSH + cloud-init), attempt {attempt}…",
-    "provision_ssh_timeout": "Host readiness timed out: {error}\nThe VM may still be booting — retry `dsoxlab run` in a moment.",
+    "provision_ssh_timeout": "Host readiness timed out: {error}\nThe VM may still be booting — retry `dsoxlab run` in a moment.\nOn a modest machine, booting several VMs at once saturates the CPU and overruns this delay. Raise it:\n  DSOXLAB_HOST_READY_TIMEOUT=360 dsoxlab provision",
     "confirm_destroy":
         "Destroy the whole {provider} infrastructure? "
         "All VM data will be lost",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -125,7 +125,7 @@ STRINGS: dict[str, str] = {
     "provision_provider_conflict": "Impossible de provisionner sur « {current} » : le provider « {others} » a encore une infra de lab active.\nincus et KVM partagent le nom de réseau et le subnet du lab, ils ne peuvent pas tourner en même temps.\nTermine ou détruis l'autre d'abord :\n  DSOXLAB_PROVIDER={other} dsoxlab destroy",
     "provision_waiting_ssh": "Attente que les hôtes soient joignables (SSH + cloud-init)…",
     "provision_waiting_ssh_host": "Attente de {host} (SSH + cloud-init), tentative {attempt}…",
-    "provision_ssh_timeout": "Délai d'attente dépassé : {error}\nLa VM démarre peut-être encore — relance `dsoxlab run` dans un instant.",
+    "provision_ssh_timeout": "Délai d'attente dépassé : {error}\nLa VM démarre peut-être encore : relance `dsoxlab run` dans un instant.\nSur une machine modeste, le démarrage simultané de plusieurs VMs sature le CPU et dépasse ce délai. Allonge-le :\n  DSOXLAB_HOST_READY_TIMEOUT=360 dsoxlab provision",
     "confirm_destroy":
         "Détruire toute l'infrastructure du provider {provider} ? "
         "Les données des VM seront perdues",

--- a/src/dsoxlab/infra/inventory.py
+++ b/src/dsoxlab/infra/inventory.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import subprocess
 import time
@@ -351,6 +352,52 @@ class HostReadyTimeout(RuntimeError):
     """Levée quand un host ne devient pas joignable en SSH dans le délai imparti."""
 
 
+#: Variable d'environnement qui règle l'attente de disponibilité des hosts.
+HOST_READY_TIMEOUT_ENV = "DSOXLAB_HOST_READY_TIMEOUT"
+
+#: Défaut, en secondes. Confortable sur un poste dédié, juste sur un hôte
+#: modeste : le boot parallèle de plusieurs VMs y sature le CPU, et un rapport
+#: d'usage a mesuré un host prêt à 181 s, soit une seconde après l'abandon.
+HOST_READY_TIMEOUT_DEFAULT = 180.0
+
+
+def _host_ready_timeout(explicite: float | None) -> float:
+    """Résout le délai d'attente : argument, puis variable d'env, puis défaut.
+
+    Un délai en dur ne convient pas à tous les postes. Le matériel de l'apprenant
+    n'est pas un paramètre du dépôt de labs : c'est une propriété de SA machine,
+    donc une variable d'environnement, pas une clé du ``meta.yml``.
+
+    Une valeur non numérique ou négative est ignorée au profit du défaut : sur
+    ce chemin, un provision qui échoue parce qu'une variable est mal écrite
+    serait bien pire que le délai qu'elle voulait corriger.
+    """
+    if explicite is not None:
+        return explicite
+    brut = os.environ.get(HOST_READY_TIMEOUT_ENV, "").strip()
+    if not brut:
+        return HOST_READY_TIMEOUT_DEFAULT
+    try:
+        valeur = float(brut)
+    except ValueError:
+        logger.warning(
+            "%s=%r n'est pas un nombre : on garde %.0f s.",
+            HOST_READY_TIMEOUT_ENV,
+            brut,
+            HOST_READY_TIMEOUT_DEFAULT,
+        )
+        return HOST_READY_TIMEOUT_DEFAULT
+    if valeur <= 0:
+        logger.warning(
+            "%s=%r doit être positif : on garde %.0f s.",
+            HOST_READY_TIMEOUT_ENV,
+            brut,
+            HOST_READY_TIMEOUT_DEFAULT,
+        )
+        return HOST_READY_TIMEOUT_DEFAULT
+    return valeur
+
+
 def _reset_kvm_domain(repo_meta: RepoMetadata, fqdn: str) -> bool:
     """Envoie un ``virsh reset`` à un domaine KVM. Retourne True si tenté.
 
@@ -377,7 +424,7 @@ def wait_for_hosts_ready(
     repo_meta: RepoMetadata,
     hosts: list[str],
     *,
-    timeout: float = 180.0,
+    timeout: float | None = None,
     poll_interval: float = 3.0,
     connect_timeout: int = 8,
     reset_after: float = 60.0,
@@ -396,7 +443,8 @@ def wait_for_hosts_ready(
     Args:
         repo_meta: métadonnées du dépôt (pour construire le ssh_config).
         hosts: FQDN à attendre (typiquement ``result.hosts`` du provision).
-        timeout: délai global maximum, en secondes, par host.
+        timeout: délai global maximum, en secondes, par host. ``None`` (défaut)
+            résout par ``DSOXLAB_HOST_READY_TIMEOUT``, sinon 180 s.
         poll_interval: pause entre deux tentatives, en secondes.
         connect_timeout: ``ConnectTimeout`` SSH de chaque tentative, en secondes.
         on_attempt: callback ``(fqdn, numéro_tentative)`` pour l'affichage.
@@ -406,6 +454,8 @@ def wait_for_hosts_ready(
     """
     if not hosts:
         return
+
+    timeout = _host_ready_timeout(timeout)
 
     inventory = build_inventory(
         repo_meta, terraform_outputs=read_terraform_outputs(repo_meta)

--- a/src/dsoxlab/templates/cloud-init/almalinux.yaml.tmpl
+++ b/src/dsoxlab/templates/cloud-init/almalinux.yaml.tmpl
@@ -106,3 +106,37 @@ runcmd:
   # L'activation est conservée : le jour où un channel est déclaré (ou sur
   # un provider qui en fournit un), le service démarrera au boot.
   - [ systemctl, enable, qemu-guest-agent ]
+
+  # Agent Incus. Sans lui, `dsoxlab provision` échoue sur un provider incus
+  # alors que la VM a parfaitement booté.
+  #
+  # Le chargeur d'agent des images cloud monte le config drive en 9p. Or la
+  # famille RHEL (AlmaLinux) n'a pas ce driver : l'agent n'est jamais récupéré,
+  # `incus exec` répond « VM agent isn't currently running », et Incus ne
+  # remonte aucune IP, et l'attente réseau du provision expire systématiquement.
+  # Incus prévoit exactement ce cas : le device `agent:config` (déclaré par
+  # templates/terraform/incus/main.tf) expose les mêmes fichiers, et leur
+  # `install.sh`, sur un CD-ROM ISO 9660.
+  #
+  # Deux précautions font tout l'intérêt de la forme ci-dessous :
+  #
+  # 1. On discrimine sur `install.sh`, PAS sur l'existence de /dev/sr0. Le
+  #    provider KVM attache lui aussi un CD-ROM, le seed cloud-init NoCloud
+  #    (cf. devices.disks[].device = "cdrom" dans terraform/kvm/main.tf) :
+  #    un test sur /dev/sr0 seul ne distingue donc rien, et ferait tourner
+  #    ce bloc à vide sur KVM.
+  # 2. Le `exit 0` final n'est pas cosmétique. Un runcmd qui sort non nul fait
+  #    finir cloud-init en `status: error`, et l'attente de provision reste
+  #    alors bloquée sur une VM pourtant prête : c'est très exactement le
+  #    piège déjà documenté ci-dessus pour qemu-guest-agent.
+  - |
+    for dev in /dev/sr[0-9]*; do
+      [ -b "$dev" ] || continue
+      mkdir -p /run/incus_config || continue
+      mount -t iso9660 -o ro "$dev" /run/incus_config 2>/dev/null || continue
+      if [ -f /run/incus_config/install.sh ]; then
+        (cd /run/incus_config && bash install.sh) || true
+      fi
+      umount /run/incus_config 2>/dev/null || true
+    done
+    exit 0

--- a/tests/test_cloud_init_incus_agent.py
+++ b/tests/test_cloud_init_incus_agent.py
@@ -1,0 +1,102 @@
+"""Le bloc qui installe l'agent Incus dans le cloud-init AlmaLinux.
+
+Pourquoi ce bloc existe : les images cloud montent leur config drive en 9p pour
+récupérer l'agent, or la famille RHEL n'a pas ce driver. Sans agent, Incus ne
+remonte aucune IP et ``dsoxlab provision`` expire sur son attente réseau alors
+que la VM a parfaitement booté. Incus prévoit ce cas avec le device
+``agent:config``, qui expose les mêmes fichiers sur un CD-ROM ISO 9660.
+
+Pourquoi ce test existe : le bloc doit être un no-op **silencieux et sans échec**
+partout ailleurs. Deux pièges, tous deux déjà payés dans ce projet :
+
+- le provider KVM attache lui aussi un CD-ROM (le seed cloud-init NoCloud), donc
+  tester la seule existence de ``/dev/sr0`` ne discrimine rien ;
+- un ``runcmd`` qui sort non nul fait finir cloud-init en ``status: error``, ce
+  qui bloque l'attente de provision sur une VM pourtant prête : exactement ce
+  qui s'est produit avec ``systemctl enable --now qemu-guest-agent``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+import pytest
+import yaml
+
+from dsoxlab.templates import cloud_init_template, template_root
+
+
+def _runcmd(stem: str) -> list[object]:
+    """Rend le ``runcmd`` d'un template cloud-init, variables substituées."""
+    brut = cloud_init_template(stem).read_text(encoding="utf-8")
+    rendu = brut.replace("${hostname}", "alma-rhcsa-1.lab").replace(
+        "${ssh_pubkey}", "ssh-ed25519 AAAAC3Nz factice"
+    )
+    # Une interpolation Terraform oubliée lèverait à l'apply, jamais en test.
+    restes = re.findall(r"\$\{[^}]*\}|%\{[^}]*\}", rendu)
+    assert not restes, f"interpolations non résolues dans {stem} : {restes}"
+    doc = yaml.safe_load(rendu)
+    return list(doc["runcmd"])
+
+
+def _bloc_agent() -> str:
+    blocs = [
+        c for c in _runcmd("almalinux") if isinstance(c, str) and "install.sh" in c
+    ]
+    assert len(blocs) == 1, f"attendu 1 bloc agent Incus, trouvé {len(blocs)}"
+    return blocs[0]
+
+
+def test_le_cloud_init_almalinux_installe_l_agent_incus() -> None:
+    assert "iso9660" in _bloc_agent(), (
+        "l'agent doit être récupéré depuis le CD-ROM agent:config"
+    )
+
+
+def test_le_discriminant_est_install_sh_pas_le_device() -> None:
+    """Le seul test qui distingue Incus de KVM est la présence de install.sh.
+
+    Le provider KVM attache son seed NoCloud en CD-ROM (cf.
+    ``templates/terraform/kvm/main.tf``, devices.disks[].device = "cdrom") :
+    /dev/sr0 y existe donc aussi.
+    """
+    bloc = _bloc_agent()
+    assert "-f /run/incus_config/install.sh" in bloc, (
+        "le bloc doit vérifier la présence de install.sh avant de l'exécuter"
+    )
+    main_tf = (template_root() / "terraform" / "kvm" / "main.tf").read_text(
+        encoding="utf-8"
+    )
+    assert 'device = "cdrom"' in main_tf, (
+        "prémisse de ce test : KVM attache bien un CD-ROM. Si ce n'est plus le "
+        "cas, le discriminant peut être simplifié."
+    )
+
+
+def test_le_bloc_ne_peut_pas_faire_echouer_cloud_init() -> None:
+    assert _bloc_agent().rstrip().endswith("exit 0"), (
+        "un runcmd non nul fait finir cloud-init en status: error, ce qui bloque "
+        "l'attente de provision sur une VM pourtant prête"
+    )
+
+
+@pytest.mark.parametrize("shell", ["sh", "bash"])
+def test_le_bloc_est_du_shell_valide(shell: str) -> None:
+    """cloud-init passe une entrée runcmd de type chaîne au shell système."""
+    proc = subprocess.run(
+        [shell, "-n"], input=_bloc_agent(), text=True, capture_output=True
+    )
+    assert proc.returncode == 0, f"{shell} rejette le bloc :\n{proc.stderr}"
+
+
+def test_les_autres_distros_n_ont_pas_ce_bloc() -> None:
+    """Ubuntu et Debian ont le driver 9p : leur agent est récupéré tout seul.
+
+    Y ajouter le bloc serait du bruit, et surtout une divergence à maintenir.
+    """
+    for stem in ("ubuntu", "debian"):
+        blocs = [
+            c for c in _runcmd(stem) if isinstance(c, str) and "install.sh" in c
+        ]
+        assert not blocs, f"{stem} n'a pas besoin du contournement 9p"

--- a/tests/test_host_ready_timeout.py
+++ b/tests/test_host_ready_timeout.py
@@ -1,0 +1,61 @@
+"""Résolution du délai d'attente des hôtes après un provision.
+
+Le délai était figé à 180 s. Sur un poste modeste, le démarrage simultané de
+plusieurs VMs sature le CPU : un rapport d'usage a mesuré un hôte prêt à 181 s,
+soit une seconde après l'abandon. Le matériel de l'apprenant n'est pas une
+propriété du dépôt de labs, donc le réglage est une variable d'environnement et
+non une clé du ``meta.yml``.
+
+Ce qui est prouvé ici : la précédence (argument > variable > défaut), et le fait
+qu'une variable mal écrite ne fasse **jamais** échouer un provision.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dsoxlab.infra.inventory import (
+    HOST_READY_TIMEOUT_DEFAULT,
+    HOST_READY_TIMEOUT_ENV,
+    _host_ready_timeout,
+)
+
+
+def test_defaut_sans_variable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(HOST_READY_TIMEOUT_ENV, raising=False)
+    assert _host_ready_timeout(None) == HOST_READY_TIMEOUT_DEFAULT
+
+
+def test_la_variable_est_lue(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(HOST_READY_TIMEOUT_ENV, "360")
+    assert _host_ready_timeout(None) == 360.0
+
+
+def test_la_variable_accepte_un_flottant(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(HOST_READY_TIMEOUT_ENV, "90.5")
+    assert _host_ready_timeout(None) == 90.5
+
+
+def test_les_espaces_sont_tolerees(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`export VAR=" 300 "` ne doit pas retomber silencieusement sur le défaut."""
+    monkeypatch.setenv(HOST_READY_TIMEOUT_ENV, "  300  ")
+    assert _host_ready_timeout(None) == 300.0
+
+
+def test_l_argument_explicite_prime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Un appelant qui impose un délai garde la main sur l'environnement."""
+    monkeypatch.setenv(HOST_READY_TIMEOUT_ENV, "360")
+    assert _host_ready_timeout(42.0) == 42.0
+
+
+@pytest.mark.parametrize("valeur", ["", "   ", "abc", "5m", "0", "-30", "nan-ish"])
+def test_une_valeur_invalide_retombe_sur_le_defaut(
+    monkeypatch: pytest.MonkeyPatch, valeur: str
+) -> None:
+    """Une variable mal écrite ne doit pas casser le provision.
+
+    Lever ici serait pire que le mal : l'apprenant qui tape ``=5m`` verrait son
+    provisionnement échouer à cause du réglage censé le sauver.
+    """
+    monkeypatch.setenv(HOST_READY_TIMEOUT_ENV, valeur)
+    assert _host_ready_timeout(None) == HOST_READY_TIMEOUT_DEFAULT

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.40"
+version = "0.1.41"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
# Summary

Deux ajouts autour d'un même symptôme rapporté par un utilisateur ([linux-dsoxlab-training#36](https://github.com/stephrobert/linux-dsoxlab-training/issues/36)) : `dsoxlab provision` qui abandonne sur son attente réseau alors que la VM a parfaitement démarré.

**1. `DSOXLAB_HOST_READY_TIMEOUT` règle l'attente.** Le délai était figé à 180 s. Le rapport d'usage mesure un hôte prêt à **181 s**, une seconde après l'abandon ; un audit joué pour cette PR mesure les mêmes hôtes prêts en **45 s sur 8 vCPU**. Le facteur limitant est le processeur au démarrage parallèle des VM. Le matériel de l'apprenant étant une propriété de sa machine et non du dépôt de labs, le réglage est une variable d'environnement et non une clé du `meta.yml`. Une valeur qui n'est pas un nombre positif retombe sur le défaut plutôt que de faire échouer le provisionnement, et le message d'expiration nomme désormais la variable.

**2. L'agent Incus est installé depuis le CD-ROM `agent:config` quand l'image ne l'a pas fait.** La famille RHEL ne fournit pas le driver 9p (mesuré : aucune entrée `9p` dans `/proc/filesystems`), qui est la voie normale de récupération de cet agent. Sans agent, Incus ne remonte aucune IP.

## Ce que cette PR ne prétend pas faire

Un audit joué sur une VM Ubuntu 24.04 neuve montre que **le défaut n'est pas reproductible** dans l'environnement testé : sur Incus 6.0.0 avec `images:almalinux/10/cloud`, l'agent arrive déjà par ce même CD-ROM et le provisionnement réussit en 119 s **avec le 0.1.40**, qui ne contient pas ce bloc.

Le bloc est donc un **filet**, pas la correction d'un défaut reproduit, et le CHANGELOG le dit ainsi. Il couvre les environnements où l'image ou la version d'Incus ne fournit pas l'agent, ce que le rapporteur a mesuré chez lui (`incus exec` répondait « VM agent isn't currently running »). Le levier qui répond à son symptôme réel est le point 1, son propre troisième argument : le sous-dimensionnement.

## Deux précautions par rapport au correctif proposé dans l'issue

- Le bloc se décide sur la présence de **`install.sh`**, pas sur celle de `/dev/sr0` : le provider KVM attache lui aussi un CD-ROM (son seed cloud-init NoCloud, `devices.disks[].device = "cdrom"`), donc tester le device seul ne discrimine rien et ferait tourner le bloc à vide sur KVM.
- Il ne peut pas sortir en erreur : un `runcmd` non nul fait finir cloud-init en `status: error`, ce qui suffit à bloquer l'attente même dont il est question. C'est le piège déjà documenté dans ce fichier pour `qemu-guest-agent`.

## Preuve

Comportement du bloc cloud-init joué sur **trois scénarios**, avec des stubs à la place de `mount` :

| Scénario | Attendu | Obtenu |
|---|---|---|
| Média Incus porteur d'`install.sh` | installation jouée | `INSTALL_JOUE`, rc=0 |
| Média KVM (seed NoCloud) | aucune exécution | monté, rien joué, démonté, rc=0 |
| Aucun CD-ROM | aucune exécution | rc=0 |

Les trois sortent en 0, ce qui est le point critique.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `ruff check src/dsoxlab tests` passes (joué, plus le hook pre-commit `ruff (lint + security)`)
- [x] `mypy src/dsoxlab` passes (strict) : `Success: no issues found in 48 source files`
- [x] `pytest` passes : **207 passed, 4 skipped** (les 4 sautés exigent Docker, absent de la machine)
- [x] The engine stays domain-agnostic : le bloc cloud-init ne nomme aucun produit, il monte le média que le provider expose et exécute l'`install.sh` qu'il y trouve
- [x] No hardcoded personal path or host ; `pathlib.Path` throughout
- [x] Manually tested against **two** lab repositories : `linux-dsoxlab-training` (84 labs découverts sur 84, `validate-structure` vert) et `terraform-training` (87 sur 87, aucun bloc `infra:`, hyperviseurs bien classés en informatif par `doctor`)

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.40 → 0.1.41) and `uv.lock` refreshed

### When a command or option is added, removed or changed

- [x] Keys updated in **both** `i18n/strings/en.py` and `i18n/strings/fr.py` (`provision_ssh_timeout` nomme la nouvelle variable dans les deux langues)
- [x] `fullhelp` : **N/A**, aucune commande ni option de CLI n'est ajoutée ou modifiée. Le réglage passe par une variable d'environnement, comme `DSOXLAB_PROVIDER` ou `DSOXLAB_LANG`, et se découvre par le message d'expiration lui-même.
- [x] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched

**N/A** : aucun fichier de `.github/workflows/` n'est touché par cette PR.

### When the declarative contract (`meta.yml` / `lab.yaml`) changes

**N/A** : le contrat déclaratif est inchangé. Aucun champ ajouté, aucun champ dont la sémantique bouge, donc rien à couvrir côté `fuzz/corpus/` ni côté section contrat du README.

## Tests ajoutés

- `tests/test_host_ready_timeout.py` : précédence argument > variable > défaut, et **7 valeurs invalides** qui doivent toutes retomber sur le défaut plutôt que lever.
- `tests/test_cloud_init_incus_agent.py` : présence du bloc, discriminant sur `install.sh`, `exit 0` final, validité du script pour `sh` **et** `bash`, et absence du bloc chez Ubuntu et Debian, qui ont le driver 9p.

## Related issues

Refs stephrobert/linux-dsoxlab-training#36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
