### PR TITLE
chore(ci): grouper les mises à jour dependabot, une branche par lot et non par paquet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,22 @@ updates:
     # usually yanked within days, so a cooldown shrinks the exposure window.
     cooldown:
       default-days: 7
+    # One PR a week for everything that is not a major bump. Ungrouped, a
+    # single week produced four separate branches (ruff, pre-commit, typer,
+    # types-pyyaml), each with its own CI run, for updates nobody reviews one
+    # by one anyway.
+    #
+    # Majors stay on their own: they are the ones that break, and they are
+    # worth reading. Grouping them would also mean a single incompatible
+    # dependency blocks every other update in the same PR.
+    #
+    # Security updates are deliberately left ungrouped (the default,
+    # `applies-to: version-updates`): they are urgent and deserve a targeted
+    # PR, not a wait for the weekly batch.
+    groups:
+      python-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -20,3 +36,16 @@ updates:
       prefix: "chore(ci)"
     cooldown:
       default-days: 7
+    # Same rule, and the case for it is even clearer here: the three
+    # `github/codeql-action/*` actions always ship the same version on the
+    # same day, so they used to open three PRs that were only ever merged
+    # together.
+    #
+    # Note for a future edit: the `semver-{major,minor,patch}-days` cooldown
+    # tiers are NOT supported for the github-actions ecosystem, only
+    # `default-days` is. Declaring them fails validation on GitHub's side,
+    # which this project already learned the hard way.
+    groups:
+      actions-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,25 @@ repos:
         language: system
         pass_filenames: false
 
+      # An invalid dependabot.yml fails silently: GitHub rejects the whole file
+      # and simply stops opening update PRs, which looks exactly like "no
+      # updates available".
+      #
+      # What this catches, measured by feeding it each mistake: a misspelled
+      # key (`groupes:` for `groups:`), an invented `update-types` value, an
+      # unknown ecosystem.
+      #
+      # What it does NOT catch, also measured: per-ecosystem restrictions. The
+      # `semver-*-days` cooldown tiers that this project once declared under
+      # github-actions, which GitHub refuses, pass the schema without a word
+      # because they are legal for other ecosystems. So this hook narrows the
+      # gap, it does not close it.
+      - id: dependabot-schema
+        name: dependabot.yml matches the official schema
+        entry: uvx check-jsonschema --builtin-schema vendor.dependabot
+        language: system
+        files: '^\.github/dependabot\.yml$'
+
       # Full test suite runs on push (kept off the per-commit path for speed).
       - id: pytest
         name: pytest


### PR DESCRIPTION
# Summary

**Neuf PR dependabot étaient ouvertes en même temps** sur ce dépôt. Trois d'entre elles portaient les trois actions `github/codeql-action/*`, qui sortent toujours la même version le même jour et ne se fusionnent jamais séparément. Chacune ouvre une branche et déclenche une CI complète, pour un lot que personne ne relit paquet par paquet.

Un groupe par écosystème rassemble désormais tout ce qui n'est ni majeur ni une alerte de sécurité.

| Avant | Après |
|---|---|
| `codeql-action/init`, `codeql-action/upload-sarif`, `plumber`, `actions/checkout` | **1 PR** `actions-minor-and-patch` |
| `ruff`, `pre-commit`, `typer`, `types-pyyaml` | **1 PR** `python-minor-and-patch` |
| `setup-uv` 8.3.2 → 10.0.0 | **1 PR**, seule, comme il se doit |

Soit **3 PR au lieu de 9**.

## Deux choix explicités

**Les majeures restent individuelles.** Ce sont elles qui cassent, elles méritent d'être lues, et les grouper ferait qu'une seule dépendance incompatible bloquerait toutes les autres mises à jour du même lot.

**Les alertes de sécurité restent hors groupe**, ce qui est le défaut (`applies-to: version-updates`). Elles sont urgentes et méritent une PR ciblée plutôt que d'attendre le lot hebdomadaire.

## Le garde-fou, et ce qu'il ne fait pas

Une `dependabot.yml` invalide est refusée **en bloc** par GitHub, qui cesse alors d'ouvrir des PR : cela ressemble exactement à « aucune mise à jour disponible ». Un hook valide donc le fichier contre le schéma officiel quand il change.

Sa portée a été **mesurée**, en lui soumettant chacune de ces fautes :

| Faute | Verdict |
|---|---|
| Clé mal orthographiée (`groupes:` pour `groups:`) | rejetée |
| Valeur d'`update-types` inventée (`"mineur"`) | rejetée |
| Écosystème inexistant | rejetée |
| Paliers `semver-*-days` sous `github-actions` | **acceptée**, alors que GitHub les refuse |

Le dernier cas est celui que ce projet a déjà payé. Le schéma le laisse passer parce qu'il est légal pour d'autres écosystèmes. Le commentaire du hook le dit noir sur blanc, pour ne pas promettre plus qu'il ne tient.

## Effet sur les 9 PR ouvertes

Dependabot consolidera au prochain passage hebdomadaire : il ferme les PR individuelles devenues redondantes et ouvre les lots. Rien à faire à la main, sinon fermer les PR existantes si vous voulez que cela aille plus vite.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [x] Security / supply chain

## Checklist

### Always

- [x] `ruff` : **N/A** sur le fond (aucun fichier Python touché), mais le hook a tourné au commit et passe
- [x] `mypy` : **N/A**, aucun fichier Python touché
- [x] `pytest` : **N/A** sur le fond ; la suite reste verte, elle a tourné au push
- [x] The engine stays domain-agnostic : aucun code moteur touché
- [x] No hardcoded personal path or host
- [x] Manually tested against **two** lab repositories : **N/A**, cette PR ne touche aucun comportement de la CLI. La configuration jumelle est proposée en parallèle sur `linux-dsoxlab-training`.

### When behavior changes

**N/A** : aucun comportement de `dsoxlab` ne change. Rien à porter au CHANGELOG ni à la version, cette PR ne modifie que l'outillage du dépôt.

### When a command or option is added, removed or changed

**N/A** : aucune commande ni option.

### When `.github/workflows/` is touched

**N/A** : `.github/dependabot.yml` n'est pas un workflow. Aucun fichier de `.github/workflows/` n'est modifié, donc ni `actionlint`, ni `zizmor`, ni `poutine`, ni l'épinglage par SHA ne sont concernés. Aucune action tierce n'est ajoutée.

### When the declarative contract changes

**N/A** : le contrat est inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
