### PR TITLE
feat(doctor): nommer ce qui manque avant l'échec, pas après (0.1.42)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,70 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.42] - 2026-08-19
+
+Un audit joué sur une VM Ubuntu 24.04 neuve a mesuré **six interventions non
+documentées** entre un `dsoxlab doctor` vert et le premier lab vm jouable. Un
+débutant s'arrête à la première. Cette version comble l'écart : le diagnostic
+nomme désormais ce qui manque, avant l'échec plutôt qu'après.
+
+### Corrigé
+
+- **`ansible-core` est déclaré en dépendance, et un lab vm peut enfin
+  tourner.** `ansible-runner` ne le tire pas, contrairement à ce qu'affirmait
+  le commentaire de ce projet : le tool installé pesait 18 Mo et son `bin/` ne
+  contenait ni `ansible` ni `ansible-playbook`. Tout `dsoxlab run` sur un lab
+  vm sortait en `rc=127`, code shell de « commande introuvable », que rien ne
+  traduisait. Le contrôle aggravait le cas en ne testant que l'import du module
+  `ansible_runner` : il répondait OK sur une machine où aucun playbook ne
+  pouvait tourner. Il teste maintenant les deux moitiés, et le message nomme
+  `ansible-core` au lieu d'envoyer réinstaller ce qui est déjà là.
+
+- **`instructor bootstrap` ne sort plus en 0 après avoir affiché une erreur
+  bloquante.** Il annonçait « ✘ terraform absent du PATH » et rendait un
+  succès. Un apprenant qui vérifie son code de retour, ou un script
+  d'installation, en concluait que tout allait bien, alors que la clé SSH
+  venait d'être créée pour une infrastructure que rien ne pourrait
+  provisionner.
+
+- **Le message d'erreur de Terraform ne renvoie plus vers une commande qui ne
+  l'installe pas.** `provision` disait « Lance : dsoxlab instructor bootstrap »,
+  qui se contente à son tour de signaler l'absence. La boucle était fermée. Il
+  donne désormais l'URL d'installation.
+
+- **`doctor` n'écrit plus « non requis ici » au-dessus d'un composant qui est
+  requis.** Sur un catalogue de 64 labs vm sur 84 dont aucun provider n'est
+  encore choisi, les deux hyperviseurs figuraient sous « Informatif, non requis
+  ici », suivis de « ces composants ne bloquent rien dans ce dépôt ». Les
+  contrôles restent délibérément hors du tableau requis, car `--fix`
+  proposerait sinon d'installer kvm **et** incus pour un choix qui n'est pas
+  fait : c'est le libellé qui devait dire la vérité.
+
+### Ajouté
+
+- **`doctor` vérifie Terraform, `ansible-playbook`, le pool libvirt et l'outil
+  ISO.** Terraform n'était vérifié nulle part, alors que `provision` ne peut
+  rien faire sans lui. Le pool libvirt `default` n'existe pas sur une
+  installation fraîche, et le provisionnement échouait sur un « Pool Not Found »
+  brut. Incus fabrique son CD-ROM `agent:config` sur l'hôte, donc sans
+  `genisoimage` aucune instance ne démarre. Chacun n'apparaît que là où il
+  s'applique : un catalogue entièrement shell n'en voit aucun, et les contrôles
+  de configuration se taisent tant que l'hyperviseur lui-même manque, pour
+  qu'une seule cause ne produise pas trois lignes rouges.
+
+- **Le pool de stockage libvirt est configurable** par
+  `meta.yml: infra.providers.kvm.storage_pool`. Le nom était écrit en dur à
+  quatre endroits du template KVM, donc un dépôt ne pouvait pas viser le sien.
+
+- **Les échecs connus du provisionnement viennent avec leur cause et leur
+  correctif.** Terraform est exact mais opaque pour qui découvre l'outil. Trois
+  messages ont une cause connue et un remède d'une ligne : AppArmor qui refuse
+  les disques des VM, le pool de stockage absent, et une machine laissée par un
+  provisionnement précédent en échec. Le cas AppArmor n'est avancé qu'**après**
+  l'échec et jamais en prédiction : mesuré sur une machine où AppArmor est
+  actif, l'override absent, et huit domaines libvirt en fonctionnement sans
+  incident, son absence ne prouve donc rien à elle seule.
+
 ## [0.1.41] - 2026-08-19
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.42] - 2026-08-19
+
+An audit run on a fresh Ubuntu 24.04 VM measured **six undocumented steps**
+between a green `dsoxlab doctor` and the first playable vm lab. A beginner
+stops at the first one. This release closes that gap: the diagnostic now names
+what is missing, before the failure rather than after it.
+
+### Fixed
+
+- **`ansible-core` is now a declared dependency, so a vm lab can actually
+  run.** `ansible-runner` does not pull it in, contrary to what this project's
+  own comment claimed: the installed tool weighed 18 MB and its `bin/`
+  contained neither `ansible` nor `ansible-playbook`. Every `dsoxlab run` on a
+  vm lab exited with `rc=127`, the shell code for "command not found", which
+  nothing translated. The check made it worse by testing only that the
+  `ansible_runner` module imports: it reported OK on a machine where no
+  playbook could run. It now tests both halves, and the error message names
+  `ansible-core` rather than sending the user to reinstall what they already
+  have.
+
+- **`instructor bootstrap` no longer exits 0 after printing a blocking
+  error.** It reported `✘ terraform not found in PATH` and returned success. A
+  learner checking the exit code, or an install script, concluded all was well
+  while the SSH key had just been created for infrastructure nothing could
+  provision.
+
+- **The Terraform error no longer points at a command that does not install
+  it.** `provision` said "run: dsoxlab instructor bootstrap", which only
+  reports the absence in turn. The loop was closed. It now gives the install
+  URL.
+
+- **`doctor` no longer writes "not required here" above a component that is
+  required.** On a catalog with 64 vm labs out of 84 and no provider selected
+  yet, both hypervisors were listed under "Informational — not required here",
+  followed by "these components block nothing in this repo". The checks
+  deliberately stay out of the required table, since `--fix` would otherwise
+  offer to install kvm **and** incus for a choice not yet made; it is the
+  heading that had to tell the truth.
+
+### Added
+
+- **`doctor` checks Terraform, `ansible-playbook`, the libvirt pool and the ISO
+  tool.** Terraform was verified nowhere, though `provision` cannot run without
+  it. The libvirt `default` pool does not exist on a fresh install, and
+  provisioning failed on a raw "Pool Not Found". Incus builds its
+  `agent:config` CD-ROM on the host, so without `genisoimage` no instance
+  starts at all. Each of these only appears when it applies: a shell-only
+  catalog sees none of them, and the configuration checks stay silent while the
+  hypervisor itself is missing, so one cause does not produce three red lines.
+
+- **The libvirt storage pool is configurable** through
+  `meta.yml: infra.providers.kvm.storage_pool`. The name was hardcoded in four
+  places of the KVM template, so a repository could not target its own pool.
+
+- **Known provisioning failures now come with their cause and their fix.**
+  Terraform is exact but opaque to a newcomer. Three messages have a known
+  cause and a one-line remedy: AppArmor denying VM disks, the missing storage
+  pool, and a domain left behind by an earlier failed run. Note that the
+  AppArmor case is only ever raised **after** the failure, never as a
+  prediction: measured on a machine where AppArmor is enabled, the override
+  absent, and eight libvirt domains running without incident, so its absence
+  proves nothing on its own.
+
 ## [0.1.41] - 2026-08-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.41"
+version = "0.1.42"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -34,10 +34,20 @@ dependencies = [
     "pyyaml>=6",
     "click>=8",
     # ansible-runner pilote ansible-core programmatiquement (API officielle
-    # Red Hat utilisée par AAP et ansible-navigator). Tire ansible-core en
-    # transitive — environ 100 MB sur disque ; acceptable pour un outil de
-    # formation devops.
+    # Red Hat utilisée par AAP et ansible-navigator).
+    #
+    # ATTENTION, ce commentaire a longtemps affirmé le contraire : ansible-runner
+    # ne tire PAS ansible-core en transitif. Mesuré sur une machine neuve, le
+    # tool installé pesait 18 Mo et son bin/ ne contenait ni `ansible` ni
+    # `ansible-playbook`. Conséquence : tout `dsoxlab run` sur un lab vm sortait
+    # en rc=127, code shell de « commande introuvable », que rien ne traduisait.
+    #
+    # ansible-core est donc déclaré explicitement. Il pèse environ 100 Mo, y
+    # compris pour un catalogue entièrement `shell` qui ne s'en servira jamais ;
+    # c'est le prix d'un outil qui marche à l'installation plutôt qu'après une
+    # commande que rien ne documente.
     "ansible-runner>=2.4",
+    "ansible-core>=2.16",
     # pytest + pytest-testinfra : dsoxlab check les invoque pour valider
     # les labs. Embarqués dans le tool install pour que l'apprenant n'ait
     # rien à installer localement (cohérent avec la philosophie "dsoxlab

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -1466,6 +1466,18 @@ def provision(
         raise typer.Exit(3)
     except Exception as exc:  # noqa: BLE001 — message utilisateur direct
         error(_("provision_failed", error=str(exc)))
+        # Terraform est exact mais opaque pour qui découvre l'outil. Quand la
+        # cause est connue et le correctif tient en une ligne, on les donne
+        # plutôt que de laisser l'apprenant chercher : c'est là qu'il est
+        # bloqué, et c'est le seul moment où l'on peut l'affirmer sans risque
+        # de fausse alerte.
+        from .services.doctor import explique_echec_provision
+
+        connu = explique_echec_provision(str(exc))
+        if connu is not None:
+            explication, commande = connu
+            info(explication)
+            info(f"  {commande}")
         raise typer.Exit(4)
 
     # Étape 3 : attendre que les VMs soient réellement joignables (sshd +
@@ -2133,15 +2145,26 @@ def instructor_bootstrap(
     from .infra import ansible as ansible_infra
     from .infra import terraform as tf
 
+    manquant = False
+
     if not tf.is_available():
         error(_("bootstrap_no_terraform"))
+        manquant = True
     else:
         info(_("bootstrap_terraform_ok"))
 
     if not ansible_infra.is_available():
         error(_("bootstrap_no_ansible_runner"))
+        manquant = True
     else:
         info(_("bootstrap_ansible_runner_ok"))
+
+    # Sortir en 0 après avoir affiché une erreur bloquante trompe autant un
+    # apprenant qui vérifie son code de retour qu'un script d'installation :
+    # la clé SSH est bien créée, mais rien ne pourra la provisionner. Le code
+    # de retour doit dire la même chose que l'écran.
+    if manquant:
+        raise typer.Exit(1)
 
 
 # ── fullhelp ──────────────────────────────────────────────────────────────────

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -423,6 +423,10 @@ silent.
     "check_incus":    "incus",
     "check_kvm":      "virsh/KVM",
     "check_provider": "Infra provider",
+    "check_terraform":    "Terraform",
+    "check_ansible":      "ansible-playbook",
+    "check_libvirt_pool": "libvirt pool",
+    "check_iso_tool":     "genisoimage",
     "check_labs":     "Labs detected",
     "check_lab_home": "LAB_HOME",
 
@@ -438,6 +442,31 @@ silent.
     "detail_pytest_bundled": "bundled with dsoxlab (used by 'check')",
     "detail_pytest_via":     "via {cmd}",
     "detail_provider_unresolved": "declared candidates: {candidates} — none selected",
+    "detail_terraform_missing":
+        "not found: `provision` cannot create the machines",
+    "detail_ansible_missing":
+        "not found: `run` cannot play a vm lab's setup.yaml "
+        "(ansible-runner does not install it)",
+    "detail_ansible_ok":     "present",
+    "detail_pool_missing":
+        "the `{pool}` pool does not exist: `provision` will fail with "
+        "\"Pool Not Found\"",
+    "detail_pool_unknown":   "cannot be checked without virsh",
+    "explain_apparmor_denied":
+        "Known cause: AppArmor denies the VM disks. virt-aa-helper cannot "
+        "resolve a disk declared by pool reference, so none of them enters the "
+        "domain profile. Grant the permission, including the `k` right "
+        "(without it: \"Failed to lock byte 100\"):",
+    "explain_pool_not_found":
+        "Known cause: the libvirt storage pool does not exist. A fresh install "
+        "declares none. Create it:",
+    "explain_domain_exists":
+        "Known cause: an earlier provisioning failed AFTER defining this "
+        "machine, so it never entered the Terraform state and `destroy` cannot "
+        "see it. Remove it by hand:",
+    "detail_iso_tool_missing":
+        "not found: incus builds the agent:config CD-ROM on the host, "
+        "without it no VM starts",
     "detail_unknown_error":  "unknown error",
     "detail_labs_count":     "{count} lab(s) in {root}",
 
@@ -449,8 +478,9 @@ silent.
     "doctor_note_remote_provider":
         "Provider {provider} runs in the cloud: no local hypervisor needed.",
     "doctor_note_provider_unresolved":
-        "This repo declares several providers. Pick one with "
-        "[bold]dsoxlab use --provider <name>[/bold] before provisioning.",
+        "This repo has labs that require a VM, and no provider is selected. "
+        "Pick one with [bold]dsoxlab use --provider <name>[/bold]: until then, "
+        "none of those labs can run.",
 
     # ── doctor — fix ──────────────────────────────────────────────────────────
     "fix_nothing": "No remediation needed.",
@@ -524,6 +554,12 @@ silent.
     # ── console — doctor ──────────────────────────────────────────────────────
     "doctor_table_title":    "Required for this repo",
     "doctor_optional_title": "Informational — not required here",
+    "doctor_choose_title": "Hypervisors: one is required, none selected",
+    "doctor_choose_hint":
+        "This repo has labs that require a VM. Pick a provider with "
+        "[bold]dsoxlab use --provider <name>[/bold], then run doctor again: it "
+        "will only diagnose that one. [bold]--fix[/bold] installs nothing until "
+        "the choice is made, since one is needed and not both.",
     "doctor_optional_hint":
         "These components block nothing in this repo: [bold]--fix[/bold] "
         "leaves them alone. Install them only if you want that provider.",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -421,6 +421,10 @@ hors ligne, elle se tait.
     "check_incus":    "incus",
     "check_kvm":      "virsh/KVM",
     "check_provider": "Provider d'infra",
+    "check_terraform":    "Terraform",
+    "check_ansible":      "ansible-playbook",
+    "check_libvirt_pool": "Pool libvirt",
+    "check_iso_tool":     "genisoimage",
     "check_labs":     "Labs détectés",
     "check_lab_home": "LAB_HOME",
 
@@ -436,6 +440,31 @@ hors ligne, elle se tait.
     "detail_pytest_bundled": "embarqué avec dsoxlab (celui qu'utilise « check »)",
     "detail_pytest_via":     "via {cmd}",
     "detail_provider_unresolved": "candidats déclarés : {candidates} — aucun choisi",
+    "detail_terraform_missing":
+        "introuvable : « provision » ne peut pas créer les machines",
+    "detail_ansible_missing":
+        "introuvable : « run » ne peut pas jouer le setup.yaml d'un lab vm "
+        "(ansible-runner ne l'installe pas)",
+    "detail_ansible_ok":     "présent",
+    "detail_pool_missing":
+        "le pool « {pool} » n'existe pas : « provision » échouera sur "
+        "« Pool Not Found »",
+    "detail_pool_unknown":   "non vérifiable sans virsh",
+    "explain_apparmor_denied":
+        "Cause connue : AppArmor refuse les disques des VM. virt-aa-helper ne "
+        "sait pas résoudre un disque déclaré par référence de pool, donc aucun "
+        "n'entre dans le profil du domaine. Pose l'autorisation, le droit « k » "
+        "compris (sans lui : « Failed to lock byte 100 ») :",
+    "explain_pool_not_found":
+        "Cause connue : le pool de stockage libvirt n'existe pas. Une "
+        "installation fraîche n'en déclare aucun. Crée-le :",
+    "explain_domain_exists":
+        "Cause connue : un provisionnement précédent a échoué APRÈS avoir "
+        "défini cette machine, qui n'est donc pas dans le state Terraform. "
+        "« destroy » ne peut pas la voir. Retire-la à la main :",
+    "detail_iso_tool_missing":
+        "introuvable : incus fabrique le CD-ROM agent:config sur l'hôte, "
+        "sans lui aucune VM ne démarre",
     "detail_unknown_error":  "erreur inconnue",
     "detail_labs_count":     "{count} lab(s) dans {root}",
 
@@ -449,8 +478,9 @@ hors ligne, elle se tait.
         "Le provider {provider} tourne dans le cloud : aucun hyperviseur "
         "local n'est nécessaire.",
     "doctor_note_provider_unresolved":
-        "Ce dépôt déclare plusieurs providers. Choisissez-en un avec "
-        "[bold]dsoxlab use --provider <nom>[/bold] avant de provisionner.",
+        "Ce dépôt a des labs qui exigent une VM, et aucun provider n'est "
+        "choisi. Choisissez-en un avec [bold]dsoxlab use --provider <nom>"
+        "[/bold] : tant que ce n'est pas fait, aucun de ces labs ne tourne.",
 
     # ── doctor — remédiation ──────────────────────────────────────────────────
     "fix_nothing": "Aucune remédiation nécessaire.",
@@ -523,6 +553,12 @@ hors ligne, elle se tait.
     # ── console — doctor ──────────────────────────────────────────────────────
     "doctor_table_title":    "Requis pour ce dépôt",
     "doctor_optional_title": "Informatif — non requis ici",
+    "doctor_choose_title": "Hyperviseurs : il en faut un, aucun n'est choisi",
+    "doctor_choose_hint":
+        "Ce dépôt a des labs qui exigent une VM. Choisissez un provider avec "
+        "[bold]dsoxlab use --provider <nom>[/bold], puis relancez doctor : il "
+        "ne diagnostiquera plus que celui-là. [bold]--fix[/bold] n'installe "
+        "rien tant que le choix n'est pas fait, il en faut un et non les deux.",
     "doctor_optional_hint":
         "Ces composants ne bloquent rien dans ce dépôt : [bold]--fix[/bold] "
         "ne les traite pas. Installez-les seulement si vous voulez ce provider.",

--- a/src/dsoxlab/infra/ansible.py
+++ b/src/dsoxlab/infra/ansible.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import tempfile
 from collections.abc import Callable
 from contextlib import suppress
@@ -65,12 +66,32 @@ class AnsibleNotInstalled(RuntimeError):
 
 
 def is_available() -> bool:
-    """Retourne True si ``ansible-runner`` est importable et opérationnel."""
+    """True si un playbook peut réellement être joué.
+
+    Tester le seul import d'``ansible_runner`` ne suffit pas, et c'est un faux
+    positif coûteux : ``ansible-runner`` **ne tire pas** ``ansible-core``, et le
+    binaire qu'il finit par exécuter est ``ansible-playbook``. Sur une machine
+    où il manque, ce diagnostic répondait « OK » pendant que tout ``dsoxlab
+    run`` sur un lab ``vm`` sortait en ``rc=127``, sans que rien ne relie les
+    deux.
+
+    On vérifie donc les deux moitiés : la bibliothèque, et l'exécutable.
+    """
     try:
         import ansible_runner  # noqa: F401
     except ImportError:
         return False
-    return True
+    return has_ansible_playbook()
+
+
+def has_ansible_playbook() -> bool:
+    """``ansible-playbook`` est-il dans le PATH ?
+
+    Séparé d'``is_available()`` pour que le diagnostic puisse distinguer les
+    deux causes : la bibliothèque absente et l'exécutable absent ne se
+    réparent pas de la même façon.
+    """
+    return shutil.which("ansible-playbook") is not None
 
 
 def run_playbook(
@@ -107,11 +128,23 @@ def run_playbook(
         AnsibleNotInstalled: Si ``ansible-runner`` n'est pas importable.
         FileNotFoundError: Si le playbook n'existe pas.
     """
-    if not is_available():
+    # Les deux moitiés manquent pour des raisons différentes et se réparent
+    # différemment : les confondre dans un seul message envoyait l'utilisateur
+    # réinstaller une bibliothèque qu'il avait déjà.
+    try:
+        import ansible_runner  # noqa: F401
+    except ImportError:
         raise AnsibleNotInstalled(
-            "ansible-runner non installé. Lance : "
+            "ansible-runner n'est pas installé. Lance : "
             "uv tool install --force --with ansible-runner dsoxlab "
             "ou : pipx inject dsoxlab ansible-runner"
+        ) from None
+
+    if not has_ansible_playbook():
+        raise AnsibleNotInstalled(
+            "ansible-playbook est absent du PATH : un lab vm ne peut pas jouer "
+            "son setup.yaml sans lui. ansible-runner pilote ansible-core mais "
+            "ne l'installe pas. Lance : uv tool install ansible-core"
         )
 
     if not playbook_path.is_file():

--- a/src/dsoxlab/infra/terraform.py
+++ b/src/dsoxlab/infra/terraform.py
@@ -270,7 +270,8 @@ def init(
     tf_dir = workdir(repo_meta)
     if not is_available():
         raise TerraformNotInstalled(
-            "terraform absent du PATH. Lance : dsoxlab instructor bootstrap"
+            "terraform est absent du PATH : il provisionne les machines des labs vm.\n"
+            "Installe-le : https://developer.hashicorp.com/terraform/install"
         )
 
     cmd = ["terraform", f"-chdir={tf_dir}", "init", "-input=false"]
@@ -411,7 +412,8 @@ def apply(
     """
     if not is_available():
         raise TerraformNotInstalled(
-            "terraform absent du PATH. Lance : dsoxlab instructor bootstrap"
+            "terraform est absent du PATH : il provisionne les machines des labs vm.\n"
+            "Installe-le : https://developer.hashicorp.com/terraform/install"
         )
 
     tf_dir = workdir(repo_meta)
@@ -557,7 +559,8 @@ def destroy(
     """
     if not is_available():
         raise TerraformNotInstalled(
-            "terraform absent du PATH. Lance : dsoxlab instructor bootstrap"
+            "terraform est absent du PATH : il provisionne les machines des labs vm.\n"
+            "Installe-le : https://developer.hashicorp.com/terraform/install"
         )
 
     tf_dir = workdir(repo_meta)

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -284,10 +284,12 @@ def print_doctor(report: DoctorReport) -> None:
     ))
 
     if report.optional:
+        # Titre et pied viennent du rapport : « non requis ici » est faux quand
+        # le dépôt a des labs vm et qu'aucun provider n'est encore choisi.
         console.print(_doctor_table(
-            _('doctor_optional_title'), report.optional, blocking=False,
+            _(report.optional_title_key), report.optional, blocking=False,
         ))
-        console.print(f"[dim]{_('doctor_optional_hint')}[/dim]")
+        console.print(f"[dim]{_(report.optional_hint_key)}[/dim]")
 
     for note in report.notes:
         console.print(f"[cyan]ℹ[/cyan] {note}")

--- a/src/dsoxlab/services/doctor.py
+++ b/src/dsoxlab/services/doctor.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from ..i18n import _
+from ..infra import ansible as ansible_infra
 from ..models import LabDefinition, RepoMetadata
 from ..models.runtime import RuntimeType
 from .lab_service import get_all_labs, resolve_pytest_cmd
@@ -81,6 +82,17 @@ class DoctorReport:
     optional: list[Check] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
     """Phrases qui expliquent *pourquoi* un composant est informatif ici."""
+
+    optional_title_key: str = "doctor_optional_title"
+    optional_hint_key: str = "doctor_optional_hint"
+    """Titre et pied du second tableau. Ils sont variables parce qu'ils
+    mentaient dans un cas précis : sur un catalogue qui compte des labs ``vm``
+    mais dont aucun provider n'est encore choisi, ce tableau s'intitulait
+    « non requis ici » et affirmait « ces composants ne bloquent rien », sous
+    les deux hyperviseurs dont l'un est indispensable pour jouer 64 labs sur
+    84. Les checks restent hors du requis, sans quoi ``--fix`` proposerait
+    d'installer kvm **et** incus pour un choix qui n'est pas fait ; c'est le
+    libellé qui devait dire la vérité, pas le classement."""
 
     def failing(self) -> list[Check]:
         return [c for c in self.required if not c.ok]
@@ -183,6 +195,177 @@ def _check_kvm() -> Check:
     return Check(_("check_kvm"), True, first_line)
 
 
+def _check_terraform() -> Check:
+    """Terraform provisionne les machines, quel que soit le provider.
+
+    Il ne figurait dans aucun contrôle, alors que ``provision`` s'arrête net
+    sans lui. Pire, son message renvoyait vers ``dsoxlab instructor bootstrap``,
+    qui se contente de signaler l'absence sans jamais l'installer : l'apprenant
+    tournait en rond entre deux commandes qui lui disaient la même chose.
+    """
+    if shutil.which("terraform") is None:
+        return Check(
+            _("check_terraform"), False, _("detail_terraform_missing"),
+            hint="https://developer.hashicorp.com/terraform/install",
+        )
+    result = subprocess.run(
+        ["terraform", "version"], capture_output=True, text=True, timeout=5,
+    )
+    first = result.stdout.splitlines()[0] if result.stdout else "ok"
+    return Check(_("check_terraform"), True, first)
+
+
+def _check_ansible() -> Check:
+    """``run`` sur un lab vm joue un playbook : il faut ``ansible-playbook``.
+
+    ``ansible-runner`` ne tire pas ``ansible-core``. Le contrôle portait sur
+    l'import de la bibliothèque, donc il était vert sur une machine où aucun
+    playbook ne pouvait tourner, et ``run`` sortait en ``rc=127`` sans que rien
+    ne relie les deux.
+    """
+    if not ansible_infra.has_ansible_playbook():
+        return Check(
+            _("check_ansible"), False, _("detail_ansible_missing"),
+            fix="uv tool install ansible-core",
+        )
+    return Check(_("check_ansible"), True, _("detail_ansible_ok"))
+
+
+def _check_libvirt_pool(pool: str) -> Check:
+    """Le template KVM écrit ses volumes dans un pool libvirt.
+
+    Une Ubuntu fraîche avec ``libvirt-daemon-system`` n'en déclare aucun :
+    ``virsh pool-list --all`` est vide, et ``provision`` échoue sur un « Pool
+    Not Found » brut de Terraform, que rien n'explique.
+
+    Le nom vient de ``meta.yml: infra.providers.kvm.storage_pool``, faute de
+    quoi ``default``. Le contrôle porte donc sur le pool que le dépôt vise
+    réellement, et non sur un nom présumé.
+    """
+    try:
+        probe = subprocess.run(
+            ["virsh", "-c", "qemu:///system", "pool-list", "--name"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # virsh absent ou injoignable : c'est le contrôle KVM qui le dira,
+        # celui-ci n'a rien à ajouter et ne doit pas doubler le rouge.
+        return Check(_("check_libvirt_pool"), True, _("detail_pool_unknown"))
+
+    if probe.returncode == 0 and pool in probe.stdout.split():
+        return Check(_("check_libvirt_pool"), True, pool)
+    return Check(
+        _("check_libvirt_pool"), False, _("detail_pool_missing", pool=pool),
+        fix=(
+            f"sudo virsh pool-define-as {pool} dir --target "
+            f"/var/lib/libvirt/images && sudo virsh pool-build {pool} && "
+            f"sudo virsh pool-start {pool} && sudo virsh pool-autostart {pool}"
+        ),
+    )
+
+
+#: Fichier d'override AppArmor qui rend les images libvirt lisibles par qemu.
+_APPARMOR_OVERRIDE = Path("/etc/apparmor.d/local/abstractions/libvirt-qemu")
+
+
+def apparmor_override_absent() -> bool:
+    """AppArmor est-il actif SANS l'override qui autorise les images libvirt ?
+
+    Volontairement **pas** un ``Check``. Sur une Ubuntu 24.04 fraîche, l'absence
+    de cet override fait échouer tout démarrage de domaine : ``virt-aa-helper``
+    construit le profil à partir du XML, or terraform-provider-libvirt déclare
+    ses disques par référence de pool (``<disk type='volume'>``), une forme
+    qu'il ne sait pas résoudre en chemin. Aucun disque n'entre dans le profil,
+    et qemu se voit tout refuser par un « Permission denied » qui ressemble à un
+    problème de propriétaire sans en être un.
+
+    Mais l'inverse n'est pas vrai, et c'est ce qui interdit d'en faire un
+    diagnostic préventif : mesuré sur une machine où AppArmor est actif, où cet
+    override est absent, et où huit domaines libvirt tournent pourtant sans
+    incident. La version de ``virt-aa-helper``, le pilote de sécurité déclaré
+    dans ``qemu.conf`` et l'emplacement réel des images changent la conclusion.
+
+    Ce module s'interdit précisément ce genre d'affirmation : un rouge affiché
+    devant une commande qui fonctionne est ce qui décourageait au premier
+    lancement. On garde donc l'information pour le seul moment où elle est
+    certaine, celui où le provisionnement a réellement échoué là-dessus.
+    """
+    if not Path("/sys/module/apparmor/parameters/enabled").is_file():
+        return False
+    try:
+        return "/var/lib/libvirt/images/" not in _APPARMOR_OVERRIDE.read_text(
+            encoding="utf-8"
+        )
+    except OSError:
+        return True
+
+
+def apparmor_fix_command() -> str:
+    """La commande qui pose l'override. Le droit ``k`` n'est pas décoratif :
+    avec ``r`` seul, l'erreur devient « Failed to lock byte 100 »."""
+    return (
+        "echo '  /var/lib/libvirt/images/** rwk,' | sudo tee "
+        f"{_APPARMOR_OVERRIDE} && sudo systemctl restart libvirtd"
+    )
+
+
+def explique_echec_provision(message: str) -> tuple[str, str] | None:
+    """Reconnaît une cause connue dans l'erreur brute d'un provisionnement.
+
+    Terraform rend des messages exacts mais opaques pour qui découvre l'outil.
+    Deux d'entre eux ont une cause connue et un correctif d'une ligne, et ce
+    sont ceux qui arrêtent un débutant sur une machine fraîche.
+
+    Rendre ``(explication, commande)``, ou ``None`` si rien n'est reconnu : on
+    ne devine pas, on nomme ce qu'on sait nommer.
+    """
+    bas = message.lower()
+
+    # « Permission denied » sur une image du pool : l'échec type d'AppArmor
+    # décrit dans apparmor_override_absent(). On ne le propose QUE si
+    # l'override manque effectivement, sans quoi ce serait une fausse piste.
+    if "permission denied" in bas and "/var/lib/libvirt/images" in bas:
+        if apparmor_override_absent():
+            return _("explain_apparmor_denied"), apparmor_fix_command()
+
+    # « Pool not found » : le pool `default` n'existe pas sur une installation
+    # fraîche. Le contrôle de doctor l'attrape en amont, mais un provisionnement
+    # lancé sans diagnostic préalable tombe directement ici.
+    if "pool not found" in bas or "no storage pool with matching name" in bas:
+        return _("explain_pool_not_found"), (
+            "sudo virsh pool-define-as default dir --target "
+            "/var/lib/libvirt/images && sudo virsh pool-build default && "
+            "sudo virsh pool-start default && sudo virsh pool-autostart default"
+        )
+
+    # « already exists » sur un domaine : un provisionnement précédent a échoué
+    # APRÈS avoir défini la machine, qui n'est donc pas dans le state Terraform.
+    # `destroy` ne peut pas la voir, et le message ne dit pas quoi faire.
+    if "already exists with uuid" in bas:
+        return _("explain_domain_exists"), (
+            "virsh -c qemu:///system undefine --nvram <machine>"
+        )
+
+    return None
+
+
+def _check_iso_tool() -> Check:
+    """Incus fabrique le CD-ROM ``agent:config`` sur l'hôte.
+
+    Sans ``mkisofs`` ni ``genisoimage``, aucune instance de type
+    ``virtual-machine`` ne démarre : « Neither mkisofs nor genisoimage could be
+    found in $PATH ». Rien ne le documentait, et la remédiation d'incus se
+    limitait à installer incus.
+    """
+    for outil in ("genisoimage", "mkisofs", "xorrisofs"):
+        if shutil.which(outil):
+            return Check(_("check_iso_tool"), True, outil)
+    return Check(
+        _("check_iso_tool"), False, _("detail_iso_tool_missing"),
+        fix="sudo apt install genisoimage",
+    )
+
+
 def _check_labs(root: Path, labs: list[LabDefinition]) -> Check:
     return Check(
         _("check_labs"), len(labs) > 0,
@@ -246,6 +429,13 @@ def collect_checks(root: Path, repo_meta: RepoMetadata | None) -> DoctorReport:
     else:
         # Plusieurs candidats déclarés, aucun choisi. On ne devine pas à la
         # place de l'apprenant : on nomme le choix qui reste à faire.
+        #
+        # On arrive ici avec `needs_vm` vrai : un hyperviseur EST indispensable.
+        # Les checks restent pourtant hors du requis, et c'est délibéré : les y
+        # mettre ferait proposer à `--fix` d'installer kvm **et** incus, pour un
+        # choix que l'apprenant n'a pas encore fait. C'est le libellé du tableau
+        # qui mentait, en annonçant « non requis ici » et « ces composants ne
+        # bloquent rien » au-dessus du composant qui bloque 64 labs sur 84.
         first = candidates[0] if candidates else "kvm"
         report.required.append(Check(
             _("check_provider"), False,
@@ -254,7 +444,32 @@ def collect_checks(root: Path, repo_meta: RepoMetadata | None) -> DoctorReport:
             status_key="status_choose",
         ))
         report.optional.extend(_sort_hypervisors(list(_LOCAL_HYPERVISORS)))
+        report.optional_title_key = "doctor_choose_title"
+        report.optional_hint_key = "doctor_choose_hint"
         report.notes.append(_("doctor_note_provider_unresolved"))
+
+    # Outillage exigé par `provision` et `run` dès qu'un lab a besoin d'une VM,
+    # quel que soit le provider. Ces deux-là manquaient au diagnostic, et leur
+    # absence ne se manifestait qu'au premier échec, en langage Terraform ou en
+    # `rc=127`.
+    if needs_vm:
+        report.required.append(_check_terraform())
+        report.required.append(_check_ansible())
+        # Contrôles propres à un hyperviseur : ils n'ont de sens qu'une fois le
+        # provider choisi, sinon ils affichent du rouge pour un backend que ce
+        # poste n'utilisera peut-être jamais.
+        # Ces contrôles-ci portent sur la CONFIGURATION d'un hyperviseur déjà
+        # installé. Les jouer quand l'hyperviseur lui-même manque empilerait
+        # trois lignes rouges pour une seule cause, et noierait celle qui
+        # compte : c'est exactement ce qui décourageait au premier lancement.
+        if active == "kvm" and hypervisors["kvm"].ok:
+            pool = "default"
+            if repo_meta is not None:
+                pool = str(repo_meta.infra.provider_config().get("storage_pool")
+                           or "default")
+            report.required.append(_check_libvirt_pool(pool))
+        elif active == "incus" and hypervisors["incus"].ok:
+            report.required.append(_check_iso_tool())
 
     report.required.append(_check_labs(root, labs))
     report.required.append(_check_lab_home(root))

--- a/src/dsoxlab/services/doctor.py
+++ b/src/dsoxlab/services/doctor.py
@@ -208,9 +208,18 @@ def _check_terraform() -> Check:
             _("check_terraform"), False, _("detail_terraform_missing"),
             hint="https://developer.hashicorp.com/terraform/install",
         )
-    result = subprocess.run(
-        ["terraform", "version"], capture_output=True, text=True, timeout=5,
-    )
+    # Le binaire peut être dans le PATH sans être exécutable, ou disparaître
+    # entre les deux appels. Un diagnostic qui plante en cherchant à
+    # diagnostiquer est le pire des cas : il emporte toute la commande.
+    try:
+        result = subprocess.run(
+            ["terraform", "version"], capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return Check(
+            _("check_terraform"), False, _("detail_terraform_missing"),
+            hint="https://developer.hashicorp.com/terraform/install",
+        )
     first = result.stdout.splitlines()[0] if result.stdout else "ok"
     return Check(_("check_terraform"), True, first)
 

--- a/src/dsoxlab/templates/terraform/kvm/main.tf
+++ b/src/dsoxlab/templates/terraform/kvm/main.tf
@@ -28,6 +28,14 @@ locals {
 
   ssh_pubkey = lookup(var.provider_config, "ssh_pubkey", "")
 
+  # Pool libvirt où atterrissent volumes et images de base. Le nom était écrit
+  # en dur à quatre endroits, or « default » n'existe PAS sur une installation
+  # fraîche : sur une Ubuntu 24.04 avec libvirt-daemon-system, `virsh pool-list
+  # --all` est vide, et le provisionnement s'arrête sur un « Pool Not Found »
+  # brut de Terraform que rien n'explique. Un dépôt peut désormais viser son
+  # propre pool via meta.yml : infra.providers.kvm.storage_pool.
+  storage_pool = lookup(var.provider_config, "storage_pool", "default")
+
   # Mapping distro pédagogique → nom du template cloud-init packagé
   # dans dsoxlab/templates/cloud-init/<name>.yaml.tmpl. Aligné avec
   # le provider outscale (cf. terraform/outscale/main.tf).
@@ -158,7 +166,7 @@ resource "libvirt_volume" "base_image" {
   # son state ne contient pas le volume créé par le premier.
   # Coût assumé : l'image cloud est dupliquée par dépôt (sparse, ~600 Mo à 2 Go).
   name = "dsoxlab-base-${var.repo_id}-${each.key}.qcow2"
-  pool = "default"
+  pool = local.storage_pool
 
   # 10 GiB : capacity requise quand le serveur HTTP ne renvoie pas de
   # Content-Length (cas du miroir AlmaLinux derrière redirection).
@@ -188,7 +196,7 @@ resource "libvirt_volume" "host" {
   for_each = { for h in local.hosts_with_idx : h.name => h }
 
   name     = "${each.value.name}.qcow2"
-  pool     = "default"
+  pool     = local.storage_pool
   capacity = each.value.disk_gb * 1024 * 1024 * 1024 # GiB → bytes
 
   target = {
@@ -269,7 +277,7 @@ resource "libvirt_volume" "extra" {
   }
 
   name     = "${each.value.name}-extra.qcow2"
-  pool     = "default"
+  pool     = local.storage_pool
   capacity = each.value.extra_disk_gb * 1024 * 1024 * 1024
 
   target = {
@@ -285,7 +293,7 @@ resource "libvirt_volume" "cloudinit" {
   for_each = { for h in local.hosts_with_idx : h.name => h }
 
   name = "${each.value.name}-cloudinit.iso"
-  pool = "default"
+  pool = local.storage_pool
 
   create = {
     content = {

--- a/src/dsoxlab/templates/terraform/kvm/variables.tf
+++ b/src/dsoxlab/templates/terraform/kvm/variables.tf
@@ -27,7 +27,7 @@ variable "hosts" {
 }
 
 variable "provider_config" {
-  description = "Overrides spécifiques au provider KVM (libvirt_uri, bridge_name, images_dir, ssh_pubkey, image_url_<distro>)."
+  description = "Overrides spécifiques au provider KVM (libvirt_uri, bridge_name, images_dir, ssh_pubkey, storage_pool, image_url_<distro>)."
   type        = map(string)
   default     = {}
 }

--- a/tests/test_ansible_availability.py
+++ b/tests/test_ansible_availability.py
@@ -1,0 +1,85 @@
+"""`ansible-runner` importable ne veut pas dire qu'un playbook peut tourner.
+
+Mesuré sur une machine neuve : `uv tool install dsoxlab` posait un outil de
+18 Mo dont le `bin/` ne contenait ni `ansible` ni `ansible-playbook`. Le
+commentaire du `pyproject.toml` affirmait pourtant qu'ansible-core arrivait en
+transitif.
+
+Le coût de cet écart : `is_available()` répondait vrai, `dsoxlab doctor`
+affichait « ansible-runner: OK », et tout `dsoxlab run` sur un lab `vm` sortait
+en `rc=127`, code shell de « commande introuvable » que rien ne traduisait.
+
+Ce module épingle les deux moitiés du contrôle, et le message qui les
+distingue : la bibliothèque absente et l'exécutable absent ne se réparent pas
+de la même façon.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dsoxlab.infra import ansible as ansible_infra
+
+
+def test_sans_ansible_playbook_rien_n_est_disponible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le faux positif qui coûtait un rc=127 inexplicable."""
+    monkeypatch.setattr(ansible_infra.shutil, "which", lambda name: None)
+    assert ansible_infra.has_ansible_playbook() is False
+    assert ansible_infra.is_available() is False
+
+
+def test_avec_ansible_playbook_tout_est_disponible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        ansible_infra.shutil, "which",
+        lambda name: "/usr/bin/ansible-playbook" if name == "ansible-playbook" else None,
+    )
+    assert ansible_infra.has_ansible_playbook() is True
+    assert ansible_infra.is_available() is True
+
+
+def test_le_message_nomme_l_executable_manquant(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Un message qui parle d'ansible-runner enverrait réinstaller ce qui est
+    déjà là. Il doit nommer ansible-core, qui est ce qui manque."""
+    monkeypatch.setattr(ansible_infra, "has_ansible_playbook", lambda: False)
+    playbook = tmp_path / "setup.yaml"
+    playbook.write_text("- hosts: all\n", encoding="utf-8")
+
+    with pytest.raises(ansible_infra.AnsibleNotInstalled) as leve:
+        ansible_infra.run_playbook(playbook_path=playbook, inventory={})
+
+    message = str(leve.value)
+    assert "ansible-playbook" in message
+    assert "ansible-core" in message
+
+
+def test_l_exception_est_une_runtime_error() -> None:
+    """La CLI attrape `RuntimeError` pour rendre une phrase plutôt qu'une
+    traceback : si cette filiation disparaît, le message redevient un plantage.
+    """
+    assert issubclass(ansible_infra.AnsibleNotInstalled, RuntimeError)
+
+
+def test_ansible_core_est_declare_en_dependance() -> None:
+    """Le correctif de fond : ansible-runner ne le tire pas.
+
+    Ce test lit `pyproject.toml` plutôt que l'environnement : ce qui compte est
+    ce qui sera installé chez l'utilisateur, pas ce que porte cette machine-ci.
+    """
+    import tomllib
+
+    racine = Path(__file__).resolve().parent.parent
+    data = tomllib.loads((racine / "pyproject.toml").read_text(encoding="utf-8"))
+    deps = data["project"]["dependencies"]
+
+    assert any(d.startswith("ansible-core") for d in deps), (
+        "ansible-core doit être déclaré explicitement : ansible-runner ne "
+        "l'installe pas, et sans lui tout lab vm sort en rc=127"
+    )

--- a/tests/test_cloud_init_templates.py
+++ b/tests/test_cloud_init_templates.py
@@ -70,3 +70,28 @@ def test_no_orphan_cloud_init_used() -> None:
     for tmpl in cloud_init_dir.glob("*.yaml.tmpl"):
         stem = tmpl.name[: -len(".yaml.tmpl")]
         assert cloud_init_template(stem) == tmpl
+
+
+def test_le_pool_libvirt_n_est_plus_code_en_dur() -> None:
+    """Le pool `default` n'existe pas sur une installation fraîche.
+
+    Sur une Ubuntu 24.04 avec `libvirt-daemon-system`, `virsh pool-list --all`
+    est vide : le provisionnement s'arrêtait sur un « Pool Not Found » brut de
+    Terraform, sans qu'aucun réglage ne permette d'en viser un autre. Le nom
+    était écrit en dur à quatre endroits du `main.tf`.
+    """
+    main_tf = (template_root() / "terraform" / "kvm" / "main.tf").read_text(
+        encoding="utf-8"
+    )
+
+    assert not re.search(r'^\s*pool\s*=\s*"default"', main_tf, re.MULTILINE), (
+        "aucun `pool = \"default\"` ne doit rester : le pool se lit dans "
+        "provider_config, sinon un dépôt ne peut pas viser le sien"
+    )
+    assert 'storage_pool = lookup(var.provider_config, "storage_pool", "default")' in main_tf, (
+        "le pool doit venir de meta.yml: infra.providers.kvm.storage_pool, "
+        "avec `default` comme repli"
+    )
+    assert main_tf.count("pool = local.storage_pool") + main_tf.count(
+        "pool     = local.storage_pool"
+    ) == 4, "les quatre emplacements doivent tous passer par le local"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -74,6 +74,26 @@ def stub_hypervisors(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _outillage_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Terraform et ansible-playbook considérés installés, dans tout ce module.
+
+    Sans cela, ces tests mesurent la machine qui les exécute : ils passaient en
+    local, où les deux outils sont là, et échouaient sur un runner CI qui ne les
+    a pas. Ce que ce module vérifie est le CLASSEMENT des checks, pas la
+    présence réelle des outils, laquelle est couverte par
+    `test_doctor_installation.py`.
+    """
+    monkeypatch.setattr(
+        doctor, "_check_terraform",
+        lambda: doctor.Check(_("check_terraform"), True, "Terraform v1.0.0"),
+    )
+    monkeypatch.setattr(
+        doctor, "_check_ansible",
+        lambda: doctor.Check(_("check_ansible"), True, "ok"),
+    )
+
+
 def _labs(monkeypatch: pytest.MonkeyPatch, labs: list[LabDefinition]) -> None:
     monkeypatch.setattr(doctor, "get_all_labs", lambda root: labs)
 

--- a/tests/test_doctor_installation.py
+++ b/tests/test_doctor_installation.py
@@ -81,6 +81,24 @@ def hyperviseur_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
+def outillage_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Terraform et ansible-playbook installés.
+
+    Les tests qui portent sur autre chose ne doivent pas dépendre de la machine
+    qui les exécute : ceux-ci passaient en local et tombaient sur un runner CI
+    dépourvu de terraform.
+    """
+    monkeypatch.setattr(
+        doctor, "_check_terraform",
+        lambda: doctor.Check(_("check_terraform"), True, "Terraform v1.0.0"),
+    )
+    monkeypatch.setattr(
+        doctor, "_check_ansible",
+        lambda: doctor.Check(_("check_ansible"), True, "ok"),
+    )
+
+
+@pytest.fixture
 def outillage_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ni terraform ni ansible-playbook, comme sur une machine neuve."""
     monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
@@ -243,7 +261,10 @@ def test_sans_declaration_le_pool_verifie_est_default(
 # ── le tableau informatif cesse de mentir ─────────────────────────────────────
 
 def test_sans_provider_choisi_le_tableau_ne_dit_plus_non_requis(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hyperviseur_ok: None
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    hyperviseur_ok: None,
+    outillage_present: None,
 ) -> None:
     """Le tableau s'intitulait « non requis ici » et affirmait « ces composants
     ne bloquent rien », au-dessus des deux hyperviseurs dont l'un est
@@ -258,7 +279,11 @@ def test_sans_provider_choisi_le_tableau_ne_dit_plus_non_requis(
 
     assert report.optional_title_key == "doctor_choose_title"
     assert report.optional_hint_key == "doctor_choose_hint"
-    assert not report.fixable(), "--fix ne doit rien proposer tant qu'aucun choix"
+    reparables = {c.label for c in report.fixable()}
+    assert _("check_kvm") not in reparables
+    assert _("check_incus") not in reparables, (
+        "--fix ne doit pas installer un hyperviseur pour un choix non fait"
+    )
 
 
 def test_un_depot_sans_lab_vm_garde_le_tableau_informatif(

--- a/tests/test_doctor_installation.py
+++ b/tests/test_doctor_installation.py
@@ -1,0 +1,339 @@
+"""Ce que `doctor` doit dire d'une machine qui n'est pas encore prête.
+
+Ces cas viennent d'un audit joué sur une VM Ubuntu 24.04 neuve : entre un
+`dsoxlab doctor` **vert** et le premier lab `vm` jouable, il fallait six
+interventions que rien ne documentait. Le diagnostic passait à côté de chacune,
+et l'apprenant les découvrait une par une, en langage Terraform ou en `rc=127`.
+
+Chaque test ci-dessous épingle une de ces omissions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dsoxlab.i18n import _
+from dsoxlab.models.lab import LabDefinition, ValidationConfig
+from dsoxlab.models.repo import InfraDefinition, RepoMetadata
+from dsoxlab.models.runtime import RuntimeConfig, RuntimeType, Target
+from dsoxlab.services import doctor
+
+
+def _lab(lab_id: str, runtime_type: RuntimeType) -> LabDefinition:
+    targets = (
+        []
+        if runtime_type is RuntimeType.SHELL
+        else [Target(name="rhel", host="node1.lab")]
+    )
+    return LabDefinition(
+        id=lab_id,
+        title=lab_id,
+        level="l1",
+        skills=["s"],
+        runtime=RuntimeConfig(type=runtime_type, targets=targets),
+        distros=["alma10"],
+        doc_url="https://example.test/doc",
+        validation=ValidationConfig(),
+    )
+
+
+def _repo(
+    provider: str = "",
+    candidates: list[str] | None = None,
+    overrides: dict[str, dict[str, object]] | None = None,
+) -> RepoMetadata:
+    return RepoMetadata(
+        id="demo",
+        category="demo",
+        infra=InfraDefinition(
+            provider=provider,
+            providers_available=candidates or [],
+            providers=overrides or {},
+        ),
+    )
+
+
+def _labs(monkeypatch: pytest.MonkeyPatch, labs: list[LabDefinition]) -> None:
+    monkeypatch.setattr(doctor, "get_all_labs", lambda root: labs)
+
+
+def _labels(checks: list[doctor.Check]) -> set[str]:
+    return {c.label for c in checks}
+
+
+@pytest.fixture
+def hyperviseur_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Les deux hyperviseurs installés et fonctionnels.
+
+    Les sondes réelles lancent virsh et incus : plusieurs secondes, et un
+    résultat qui dépend de la machine. Ce qu'on vérifie ici est le contenu du
+    diagnostic, pas les sondes.
+    """
+    monkeypatch.setattr(
+        doctor, "_hypervisor_checks",
+        lambda: {
+            "kvm": doctor.Check(_("check_kvm"), True, "libvirt 10.0.0"),
+            "incus": doctor.Check(_("check_incus"), True, "daemon ok"),
+        },
+    )
+
+
+@pytest.fixture
+def outillage_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ni terraform ni ansible-playbook, comme sur une machine neuve."""
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        doctor.ansible_infra, "has_ansible_playbook", lambda: False
+    )
+
+
+# ── terraform et ansible, les deux absents du diagnostic ──────────────────────
+
+def test_terraform_et_ansible_sont_requis_par_un_depot_a_labs_vm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    hyperviseur_ok: None,
+    outillage_absent: None,
+) -> None:
+    """Sans eux, `provision` et `run` échouent. Ils manquaient au diagnostic.
+
+    Terraform n'était vérifié nulle part, et le contrôle d'ansible portait sur
+    l'import de la bibliothèque : il était vert sur une machine où aucun
+    playbook ne pouvait tourner.
+    """
+    _labs(monkeypatch, [_lab("a", RuntimeType.VM)])
+    report = doctor.collect_checks(tmp_path, _repo(provider="kvm"))
+
+    requis = _labels(report.required)
+    assert _("check_terraform") in requis
+    assert _("check_ansible") in requis
+
+    echecs = _labels(report.failing())
+    assert _("check_terraform") in echecs
+    assert _("check_ansible") in echecs
+
+
+def test_un_depot_sans_lab_vm_n_exige_ni_terraform_ni_ansible(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    hyperviseur_ok: None,
+    outillage_absent: None,
+) -> None:
+    """`terraform-training` est entièrement `shell` : rien de tout cela ne le
+    concerne, et le lui montrer en rouge serait le décourager pour rien."""
+    _labs(monkeypatch, [_lab("a", RuntimeType.SHELL)])
+    report = doctor.collect_checks(tmp_path, _repo())
+
+    requis = _labels(report.required)
+    assert _("check_terraform") not in requis
+    assert _("check_ansible") not in requis
+
+
+def test_ansible_est_reparable_automatiquement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    hyperviseur_ok: None,
+    outillage_absent: None,
+) -> None:
+    """`uv tool install ansible-core` est sûr et sans ambiguïté : --fix le joue.
+
+    Terraform, lui, ne porte qu'un `hint` : son installation passe par un dépôt
+    tiers, ce n'est pas à l'outil de la décider.
+    """
+    _labs(monkeypatch, [_lab("a", RuntimeType.VM)])
+    report = doctor.collect_checks(tmp_path, _repo(provider="kvm"))
+
+    par_label = {c.label: c for c in report.required}
+    assert par_label[_("check_ansible")].fix == "uv tool install ansible-core"
+    assert par_label[_("check_terraform")].fix is None
+    assert "terraform" in (par_label[_("check_terraform")].hint or "")
+
+
+# ── les contrôles de configuration ne parlent qu'après l'installation ─────────
+
+def test_les_controles_kvm_se_taisent_si_virsh_manque(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Trois lignes rouges pour une seule cause noient celle qui compte.
+
+    Le contrôle du pool porte sur la CONFIGURATION d'un libvirt déjà installé :
+    l'afficher quand libvirt lui-même manque n'apprend rien.
+    """
+    monkeypatch.setattr(
+        doctor, "_hypervisor_checks",
+        lambda: {
+            "kvm": doctor.Check(_("check_kvm"), False, "not found", fix="apt install"),
+            "incus": doctor.Check(_("check_incus"), True, "ok"),
+        },
+    )
+    _labs(monkeypatch, [_lab("a", RuntimeType.VM)])
+    report = doctor.collect_checks(tmp_path, _repo(provider="kvm"))
+
+    requis = _labels(report.required)
+    assert _("check_kvm") in requis
+    assert _("check_libvirt_pool") not in requis
+
+
+def test_les_controles_kvm_apparaissent_une_fois_virsh_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hyperviseur_ok: None
+) -> None:
+    _labs(monkeypatch, [_lab("a", RuntimeType.VM)])
+    report = doctor.collect_checks(tmp_path, _repo(provider="kvm"))
+
+    requis = _labels(report.required)
+    assert _("check_libvirt_pool") in requis
+    # genisoimage ne concerne qu'incus : sur kvm, ce serait du bruit.
+    assert _("check_iso_tool") not in requis
+
+
+def test_genisoimage_est_exige_sur_incus_seulement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hyperviseur_ok: None
+) -> None:
+    """Incus fabrique le CD-ROM `agent:config` sur l'hôte : sans outil ISO,
+    aucune instance de type virtual-machine ne démarre."""
+    _labs(monkeypatch, [_lab("a", RuntimeType.VM)])
+    report = doctor.collect_checks(tmp_path, _repo(provider="incus"))
+
+    assert _("check_iso_tool") in _labels(report.required)
+    assert _("check_libvirt_pool") not in _labels(report.required)
+
+
+# ── le pool visé est celui du dépôt, pas un nom présumé ───────────────────────
+
+def test_le_pool_verifie_est_celui_que_le_depot_declare(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hyperviseur_ok: None
+) -> None:
+    """Un dépôt peut viser son propre pool via infra.providers.kvm.storage_pool.
+
+    Vérifier « default » en dur afficherait alors du rouge sur un pool
+    parfaitement configuré.
+    """
+    vus: list[str] = []
+
+    def _faux_check(pool: str) -> doctor.Check:
+        vus.append(pool)
+        return doctor.Check(_("check_libvirt_pool"), True, pool)
+
+    monkeypatch.setattr(doctor, "_check_libvirt_pool", _faux_check)
+    _labs(monkeypatch, [_lab("a", RuntimeType.VM)])
+    doctor.collect_checks(
+        tmp_path,
+        _repo(provider="kvm", overrides={"kvm": {"storage_pool": "labs-pool"}}),
+    )
+
+    assert vus == ["labs-pool"]
+
+
+def test_sans_declaration_le_pool_verifie_est_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hyperviseur_ok: None
+) -> None:
+    vus: list[str] = []
+    monkeypatch.setattr(
+        doctor, "_check_libvirt_pool",
+        lambda pool: (vus.append(pool), doctor.Check("p", True, pool))[1],
+    )
+    _labs(monkeypatch, [_lab("a", RuntimeType.VM)])
+    doctor.collect_checks(tmp_path, _repo(provider="kvm"))
+
+    assert vus == ["default"]
+
+
+# ── le tableau informatif cesse de mentir ─────────────────────────────────────
+
+def test_sans_provider_choisi_le_tableau_ne_dit_plus_non_requis(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hyperviseur_ok: None
+) -> None:
+    """Le tableau s'intitulait « non requis ici » et affirmait « ces composants
+    ne bloquent rien », au-dessus des deux hyperviseurs dont l'un est
+    indispensable pour jouer 64 labs sur 84.
+
+    Les checks restent hors du requis, sans quoi `--fix` proposerait
+    d'installer kvm ET incus pour un choix qui n'est pas fait : c'est le
+    libellé qui devait changer.
+    """
+    _labs(monkeypatch, [_lab("a", RuntimeType.VM)])
+    report = doctor.collect_checks(tmp_path, _repo(candidates=["kvm", "incus"]))
+
+    assert report.optional_title_key == "doctor_choose_title"
+    assert report.optional_hint_key == "doctor_choose_hint"
+    assert not report.fixable(), "--fix ne doit rien proposer tant qu'aucun choix"
+
+
+def test_un_depot_sans_lab_vm_garde_le_tableau_informatif(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hyperviseur_ok: None
+) -> None:
+    """Là, « non requis ici » est vrai, et doit le rester."""
+    _labs(monkeypatch, [_lab("a", RuntimeType.SHELL)])
+    report = doctor.collect_checks(tmp_path, _repo())
+
+    assert report.optional_title_key == "doctor_optional_title"
+    assert report.optional_hint_key == "doctor_optional_hint"
+
+
+@pytest.mark.parametrize(
+    "cle",
+    ["doctor_choose_title", "doctor_choose_hint"],
+)
+def test_les_nouvelles_cles_existent_dans_les_deux_langues(cle: str) -> None:
+    """Une clé qui n'existe que d'un côté n'existe pas."""
+    from dsoxlab.i18n.strings.en import STRINGS as EN
+    from dsoxlab.i18n.strings.fr import STRINGS as FR
+
+    assert cle in EN and cle in FR
+    assert EN[cle] != FR[cle], "une traduction identique est probablement oubliée"
+
+
+# ── ce qu'on ne peut pas affirmer d'avance, on le dit à l'échec ───────────────
+
+@pytest.mark.parametrize(
+    ("erreur", "attendu"),
+    [
+        (
+            "Error: Pool Not Found\nStorage pool 'default' not found",
+            "explain_pool_not_found",
+        ),
+        (
+            "operation failed: domain 'alma-rhcsa-2.lab' already exists with "
+            "uuid 95409cf2-d226-44c8-b8ee-16b5bd614ce6",
+            "explain_domain_exists",
+        ),
+    ],
+)
+def test_les_erreurs_terraform_connues_sont_traduites(
+    erreur: str, attendu: str
+) -> None:
+    """Terraform est exact et opaque. Quand la cause est connue et le correctif
+    tient en une ligne, on les donne au lieu de laisser chercher."""
+    resultat = doctor.explique_echec_provision(erreur)
+
+    assert resultat is not None, f"« {erreur[:40]}… » doit être reconnu"
+    explication, commande = resultat
+    assert explication == _(attendu)
+    assert commande, "une explication sans commande n'aide qu'à moitié"
+
+
+def test_l_apparmor_n_est_propose_que_si_l_override_manque(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sinon ce serait une fausse piste : mesuré sur une machine où l'override
+    est absent et où huit domaines tournent pourtant sans incident, donc son
+    absence ne prouve rien à elle seule. On ne l'avance qu'une fois le
+    « Permission denied » réellement survenu."""
+    erreur = "Could not open '/var/lib/libvirt/images/x.qcow2': Permission denied"
+
+    monkeypatch.setattr(doctor, "apparmor_override_absent", lambda: True)
+    resultat = doctor.explique_echec_provision(erreur)
+    assert resultat is not None
+    assert resultat[0] == _("explain_apparmor_denied")
+    assert " rwk," in resultat[1], "le droit k est indispensable, pas r seul"
+
+    monkeypatch.setattr(doctor, "apparmor_override_absent", lambda: False)
+    assert doctor.explique_echec_provision(erreur) is None
+
+
+def test_une_erreur_inconnue_ne_produit_aucune_explication() -> None:
+    """On ne devine pas : une explication inventée coûte plus qu'aucune."""
+    assert doctor.explique_echec_provision("boom") is None
+    assert doctor.explique_echec_provision("") is None

--- a/tests/test_instructor_bootstrap.py
+++ b/tests/test_instructor_bootstrap.py
@@ -43,13 +43,24 @@ def test_refuse_de_generer_hors_dun_depot_de_labs(tmp_path: Path) -> None:
     )
 
 
-def test_un_vrai_depot_de_labs_passe_le_garde_fou(tmp_path: Path) -> None:
+def test_un_vrai_depot_de_labs_passe_le_garde_fou(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Avec `meta.yml`, la commande travaille normalement.
 
     On lui présente une clé déjà en place : le chemin nominal est donc couvert
     sans dépendre de `ssh-keygen`, et surtout sans écrire de clé privée depuis
     une suite de tests.
+
+    L'outillage est stubé présent : depuis que le code de retour reflète les
+    outils manquants, ce test mesurerait sinon la machine qui l'exécute, et il
+    tomberait sur un runner CI dépourvu de terraform.
     """
+    from dsoxlab.infra import ansible as ansible_infra
+    from dsoxlab.infra import terraform as tf
+
+    monkeypatch.setattr(tf, "is_available", lambda: True)
+    monkeypatch.setattr(ansible_infra, "is_available", lambda: True)
     (tmp_path / "meta.yml").write_text(META_MINIMAL, encoding="utf-8")
     ssh_dir = tmp_path / "ssh"
     ssh_dir.mkdir()

--- a/tests/test_instructor_bootstrap.py
+++ b/tests/test_instructor_bootstrap.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from typer.testing import CliRunner
 
 from dsoxlab.cli import app
@@ -61,3 +63,50 @@ def test_un_vrai_depot_de_labs_passe_le_garde_fou(tmp_path: Path) -> None:
     assert resultat.exit_code == 0
     # La clé en place n'est pas écrasée : c'est celle des VM déjà provisionnées.
     assert (ssh_dir / "id_ed25519").read_text(encoding="utf-8") == "clé factice"
+
+
+def test_le_code_de_retour_dit_la_meme_chose_que_l_ecran(
+    tmp_path: Path, monkeypatch: "pytest.MonkeyPatch"
+) -> None:
+    """Sortir en 0 après avoir affiché une erreur bloquante trompe deux fois.
+
+    Mesuré sur une machine neuve : la commande affichait « ✘ terraform absent
+    du PATH » puis rendait 0. Un apprenant qui vérifie son code de retour, ou
+    un script d'installation, en concluait que tout allait bien, alors que la
+    clé venait d'être créée pour une infrastructure que rien ne pourra
+    provisionner.
+    """
+    from dsoxlab.infra import ansible as ansible_infra
+    from dsoxlab.infra import terraform as tf
+
+    (tmp_path / "meta.yml").write_text(META_MINIMAL, encoding="utf-8")
+    monkeypatch.setattr(tf, "is_available", lambda: False)
+    monkeypatch.setattr(ansible_infra, "is_available", lambda: True)
+
+    resultat = runner.invoke(
+        app, ["instructor", "bootstrap", "--lab-home", str(tmp_path)]
+    )
+
+    assert resultat.exit_code == 1, (
+        "un outil requis manquant doit se voir dans le code de retour"
+    )
+    # La clé, elle, a bien été générée : l'échec porte sur l'outillage, et le
+    # dire sans avoir rien fait serait tout aussi faux.
+    assert (tmp_path / "ssh" / "id_ed25519").is_file()
+
+
+def test_tout_en_place_sort_en_zero(
+    tmp_path: Path, monkeypatch: "pytest.MonkeyPatch"
+) -> None:
+    from dsoxlab.infra import ansible as ansible_infra
+    from dsoxlab.infra import terraform as tf
+
+    (tmp_path / "meta.yml").write_text(META_MINIMAL, encoding="utf-8")
+    monkeypatch.setattr(tf, "is_available", lambda: True)
+    monkeypatch.setattr(ansible_infra, "is_available", lambda: True)
+
+    resultat = runner.invoke(
+        app, ["instructor", "bootstrap", "--lab-home", str(tmp_path)]
+    )
+
+    assert resultat.exit_code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version < '3.12'",
 ]
 
 [[package]]
@@ -13,6 +14,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "ansible-core"
+version = "2.19.12"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "resolvelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/1e/1d76138cf063c40135e2d24dfdcc9d9128593331a25d4846794dc5629814/ansible_core-2.19.12.tar.gz", hash = "sha256:cfb63b021558d5daddb1d0cd35886a5e1b18db2fc254d1f342e1527c62dac058", size = 3436037, upload-time = "2026-08-10T16:43:33.175Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/e2/cb186c0bf7ccc1d04566746d1e961c075f2c48840ea3da28d26932e78101/ansible_core-2.19.12-py3-none-any.whl", hash = "sha256:b6bbdf05952852ad908861d652a9009c8474f1fe9c63a77ec202979a329d7d99", size = 2416747, upload-time = "2026-08-10T16:43:31.508Z" },
+]
+
+[[package]]
+name = "ansible-core"
+version = "2.21.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15'",
+]
+dependencies = [
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "resolvelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/11/cb53834d320c38d739e756e2458852d6e74a6c7018a9ab9f6d4ab5e5196e/ansible_core-2.21.3.tar.gz", hash = "sha256:4194fbd82273cbacfd06d86d74d2d7168c3c4b8426c03e93562cd7217f811ae1", size = 3397615, upload-time = "2026-08-10T16:46:14.554Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/fa/938fe0504372377af2bef42abe0d8e463fdcd011ad803eaf300e4577dd7a/ansible_core-2.21.3-py3-none-any.whl", hash = "sha256:9e7dd367f7dc5d5e9fc5ae1baf8af9c4edc09e916a73a40108a3f32e3ad93f10", size = 2446988, upload-time = "2026-08-10T16:46:12.947Z" },
 ]
 
 [[package]]
@@ -82,6 +122,104 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/d2/16d99a0c4948febc0ebd133a13b2f688ff7f8cb04da971e1128872ce0c03/cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12", size = 183838, upload-time = "2026-08-03T21:19:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/95/31b535a9f0220ae9f357de4a08d57ce89cb417653c2fd9f075f50822a388/cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1", size = 184168, upload-time = "2026-08-03T21:19:30.764Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/4707a0dc1f203f5dde5a907b0d4e3c25d71120241048bd5bc6f1bb9d4e71/cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0", size = 211805, upload-time = "2026-08-03T21:19:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/66/c19feabb28485b6e0bbaaafa90837a1ef5d302e90f2178bd33f17a49879b/cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813", size = 218716, upload-time = "2026-08-03T21:19:32.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/92/500760486c8baab49a7a8a58ba7fc3355ec3974b454b8a09e528efde9e1d/cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990", size = 205569, upload-time = "2026-08-03T21:19:34.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/a67c733254d6e7373f7822f8082d8d6beade791e0cf12a7611f376fa61c7/cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af", size = 204907, upload-time = "2026-08-03T21:19:35.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a4/4399daaf8f7dfee9d7c3327fdb0426ee041cc63edc358b93911ceb2bfc7a/cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632", size = 217807, upload-time = "2026-08-03T21:19:36.286Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f7/dabe6da2466ecbd82dc62e7342dc6b1065dad990c06f00f0ede9ebf2a0ed/cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd", size = 221252, upload-time = "2026-08-03T21:19:37.416Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/616202d8e51342c07d2534c510111c4cc37201775ce8f60802c9335d1edd/cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a", size = 214214, upload-time = "2026-08-03T21:19:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c6/ab025d75d2c26c19b087c0124e75ee31cb65032f4fe345d356d8c507ab97/cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa", size = 219408, upload-time = "2026-08-03T21:19:39.809Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/7e8109f65445bdc673a7b54f02c677de462db75674220fd1335efc8eb598/cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3", size = 174470, upload-time = "2026-08-03T21:19:41.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c0/77ba02423c2f7d7091143c45cd49e0e6575c4c1967394bb542bd923a9b74/cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0", size = 185096, upload-time = "2026-08-03T21:19:42.615Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/47/9f1f85f9672ceda4984dc6c4f8824e8558992a2972c3d3c81fb8eb28d4ba/cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455", size = 179941, upload-time = "2026-08-03T21:19:43.747Z" },
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -112,6 +250,62 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/951032a3bf22a5697c83183fb6294a4843772947a70e616c57b3ff5f522e/cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41", size = 3989258, upload-time = "2026-07-31T14:23:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d8/f52538140cc719df62a01cf87d1c7142318d235817109d6f4054d7c352d6/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533", size = 5314552, upload-time = "2026-07-31T14:24:06.31Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/2cf79bbfc4d12ca106437a6e170d6aaa01a373e93093118aaaef0e801bd4/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d", size = 5273110, upload-time = "2026-07-31T14:24:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
+    { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9a/02ffe35b2853d121689871eb5dce862092562b3a1ed5cc98f1aaed441506/cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269", size = 3816291, upload-time = "2026-07-31T14:24:22.125Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/3e/e54cde8c01631a5a8226ccd617eab9e57fd5cfdad90f1a9e6bb570794631/cryptography-50.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5e34edd123674534acd70147f0ca331eaa2c74e6325fb2028c886aa26ba0b68c", size = 3963170, upload-time = "2026-07-31T14:24:51.968Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b6/0b9e125e90f3d2dcf599a218a899cda7326a3158cfa258723f0b398b08f6/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:8eb5e1172eb569ea8a872796576e6a67c276351728b6455d5beb01242b027c6a", size = 4692441, upload-time = "2026-07-31T14:24:53.743Z" },
+    { url = "https://files.pythonhosted.org/packages/53/c9/a5151588710785a96d7bc4de27d4cd62f263bbbcb203cfe29df537eb6505/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:910d11e1a385c654bf738bf3e6b8e6ed5de0f5610fcae2be9e5b398d8081d20e", size = 4699810, upload-time = "2026-07-31T14:24:55.746Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/1a/15b92b25eb6ce3089cd49377ae990a0f3ad485a510f968aed1f19dbdcdf2/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:62598a8a57f815db4c6259a4e97d857dab56697e7de8e8ab02352ab74da1995d", size = 4691924, upload-time = "2026-07-31T14:24:58.082Z" },
+    { url = "https://files.pythonhosted.org/packages/62/15/219075012ab13e8905f3cd572204f4acb4b111df787104346b9bc0cea789/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:07479a1cb08219ab719147e742e76090c9c773321959bb94946fffdd397a6437", size = 4699593, upload-time = "2026-07-31T14:24:59.951Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b5/c2c5fce26f0ee40d21bafe7f191d29a34b35a65ac4fe8a1191d1983612e9/cryptography-50.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c99c003e088647b8a5b7c145d6f78c335f6348332b62e142d411c4b63d1460b9", size = 3813796, upload-time = "2026-07-31T14:25:02.298Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -122,9 +316,11 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.41"
+version = "0.1.42"
 source = { editable = "." }
 dependencies = [
+    { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "ansible-core", version = "2.21.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "ansible-runner" },
     { name = "click" },
     { name = "pytest" },
@@ -148,6 +344,7 @@ fuzz = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ansible-core", specifier = ">=2.16" },
     { name = "ansible-runner", specifier = ">=2.4" },
     { name = "click", specifier = ">=8" },
     { name = "pytest", specifier = ">=8" },
@@ -192,6 +389,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -288,6 +497,80 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -443,6 +726,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -557,6 +849,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "resolvelib"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/14/4669927e06631070edb968c78fdb6ce8992e27c9ab2cde4b3993e22ac7af/resolvelib-1.2.1.tar.gz", hash = "sha256:7d08a2022f6e16ce405d60b68c390f054efcfd0477d4b9bd019cc941c28fad1c", size = 24575, upload-time = "2025-10-11T01:07:44.582Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/23/c941a0d0353681ca138489983c4309e0f5095dfd902e1357004f2357ddf2/resolvelib-1.2.1-py3-none-any.whl", hash = "sha256:fb06b66c8da04172d9e72a21d7d06186d8919e32ae5ab5cdf5b9d920be805ac2", size = 18737, upload-time = "2025-10-11T01:07:43.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #98
Closes #99
Closes #102
Closes #105
Closes #106
Refs #93
Refs #94

# Summary

Un audit joué sur une VM Ubuntu 24.04 neuve a mesuré **six interventions non documentées** entre un `dsoxlab doctor` **vert** et le premier lab `vm` jouable. Un débutant s'arrête à la première. Ce lot les prend une par une : le diagnostic nomme désormais ce qui manque, avant l'échec plutôt qu'après.

| Issue | Défaut |
|---|---|
| #105 | `ansible-core` jamais installé, tout `run` sur un lab vm sortait en `rc=127` |
| #102 | Terraform vérifié nulle part, et son message renvoyait vers une commande qui ne l'installe pas |
| #99 | `instructor bootstrap` sortait en 0 après avoir affiché une erreur bloquante |
| #98 | `doctor` écrivait « non requis ici » au-dessus du composant qui bloque 64 labs sur 84 |
| #106 | `genisoimage` prérequis silencieux d'Incus |
| #94 | Pool libvirt codé en dur, inexistant sur une installation fraîche |
| #93 | AppArmor bloque les disques, sans diagnostic (traité autrement, voir plus bas) |

## Trois points qui méritent une lecture

### Le faux positif que j'ai écrit, puis retiré

J'ai d'abord implémenté #93 comme un contrôle préventif : AppArmor actif + override absent ⇒ rouge. Testé sur la machine de développement, **il déclarait KO un poste qui fait tourner huit domaines libvirt sans incident**. AppArmor y est actif, l'override absent, et tout fonctionne : la version de `virt-aa-helper`, le pilote de sécurité de `qemu.conf` et l'emplacement réel des images changent la conclusion.

L'absence d'override ne prouve donc rien à elle seule. Or la docstring de ce module s'interdit exactement cela : « Le diagnostic était rouge, la commande fonctionnait, et la remédiation faisait installer à l'apprenant ce qu'il possédait déjà. »

Le contrôle préventif a été retiré au profit d'un **diagnostic à l'échec** : quand `provision` échoue réellement sur `Permission denied` dans le pool d'images, et seulement alors, la cause et le correctif d'une ligne sont affichés. Deux autres messages Terraform connus reçoivent le même traitement (pool absent, domaine orphelin). Aucun faux positif possible, et l'aide arrive là où l'utilisateur est bloqué.

### Un test existant a évité une régression

Pour #98, la correction évidente était de passer les hyperviseurs en « requis ». Un test a refusé : `--fix` aurait alors proposé d'installer **kvm et incus** pour un choix que l'apprenant n'a pas encore fait.

C'est le libellé qui mentait, pas le classement. Les checks restent hors du requis, et le tableau porte désormais un titre et un pied variables : « Hyperviseurs : il en faut un, aucun n'est choisi », au lieu de « non requis ici » suivi de « ces composants ne bloquent rien ».

### Une dépendance en plus, assumée

`ansible-core` est désormais déclaré. Il pèse environ 100 Mo, y compris pour un catalogue entièrement `shell` qui ne s'en servira jamais. C'est le prix d'un outil qui marche à l'installation : `ansible-runner` seul est inutilisable, et le commentaire du `pyproject.toml` affirmait le contraire depuis le début.

## Preuve, sur les deux dépôts fournisseurs

| Dépôt | Résultat |
|---|---|
| `terraform-training` (87 labs, tous `shell`, aucun bloc `infra:`) | **Aucun** des nouveaux contrôles n'apparaît, le tableau garde « Informatif, non requis ici ». Aucun bruit ajouté. |
| `linux-dsoxlab-training` (84 labs, 64 en `vm`), provider kvm | Terraform, ansible-playbook et Pool libvirt affichés et verts. Plus de faux positif AppArmor. |

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `ruff check src/dsoxlab tests` passes (hook `ruff (lint + security)` vert au commit)
- [x] `mypy src/dsoxlab` passes (strict) : `Success: no issues found in 48 source files`
- [x] `pytest` passes : **235 passed** (207 avant, soit **+28 tests**)
- [x] The engine stays domain-agnostic : aucun nom de domaine ni de catalogue dans le code ; les nouveaux contrôles se décident sur `needs_vm` et le provider actif, comme les précédents
- [x] No hardcoded personal path or host ; `pathlib.Path` throughout
- [x] Manually tested against **two** lab repositories (tableau ci-dessus)

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.41 → 0.1.42) and `uv.lock` refreshed

### When a command or option is added, removed or changed

- [x] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py` (parité vérifiée par script : 336 clés de chaque côté, écart nul ; les quatre clés AppArmor devenues mortes ont été retirées)
- [x] `fullhelp` : **N/A**, aucune commande ni option n'est ajoutée, retirée ou modifiée. Seuls le contenu du diagnostic et un code de retour changent.
- [x] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched

**N/A** : aucun workflow modifié.

### When the declarative contract changes

Le contrat **s'étend sans casser** : `infra.providers.kvm.storage_pool` est une clé nouvelle et facultative, dans un mapping d'overrides déjà libre (`_provider_overrides` accepte tout mapping). Aucun champ existant ne change de sémantique.

- [x] La section contrat du `README.md` : **N/A**, elle documente `infra.providers` comme un mapping d'overrides par provider, ce qui couvre déjà cette clé.
- [x] `fuzz/corpus/` : **N/A**, aucun champ nouveau dans le chemin de parsing des labs ; `storage_pool` est lu côté Terraform, jamais par le parseur de contrat.
- [x] Une valeur malformée reste inoffensive : une valeur non-string est convertie par `str()` et produit un pool inexistant, que le contrôle signale au lieu de laisser Terraform échouer.

## Tests ajoutés

- `tests/test_doctor_installation.py` (16 cas) : présence des contrôles selon le dépôt et le provider, silence quand l'hyperviseur manque, pool lu depuis le dépôt, titre du tableau, et les trois erreurs connues traduites.
- `tests/test_ansible_availability.py` (5 cas) : les deux moitiés du contrôle, le message qui nomme `ansible-core`, la filiation `RuntimeError` sans laquelle la CLI rendrait une traceback, et `ansible-core` déclaré dans `pyproject.toml`.
- `tests/test_instructor_bootstrap.py` (+2) : le code de retour dit la même chose que l'écran, dans les deux sens.
- `tests/test_cloud_init_templates.py` (+1) : plus aucun `pool = "default"` en dur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
