### PR TITLE
feat(release): vérifier que la version est arrivée, pas seulement qu'elle peut partir

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,6 +66,28 @@ Two details of that pipeline are deliberate. The `publish` job runs no project
 code and holds `id-token: write` only; and `github_release` runs after PyPI
 succeeds, so no Release ever advertises a version that failed to upload.
 
+7. **Confirm the release actually landed**, once the workflow is done:
+
+   ```bash
+   python3 scripts/check-release.py --publiee
+   ```
+
+   A green workflow is not proof that the version is installable. When 0.1.42
+   was published, the upload had received two `200 OK` from PyPI and the
+   project page answered, yet `https://pypi.org/simple/dsoxlab/` — the only
+   index pip and uv read to resolve a version — did not list it yet. During
+   those minutes, `uv tool install dsoxlab` silently installed the *previous*
+   version.
+
+   This check looks at the tag on `origin`, at the Release assets (wheel,
+   sdist, provenance), and at the simple index. It distinguishes "published but
+   not served yet", which is a matter of waiting, from "absent from PyPI",
+   which means the upload never happened despite a green job.
+
+   One last trap it prints as a reminder: uv caches the index, so verifying by
+   installing needs `uv tool install --force --refresh dsoxlab`. Without
+   `--refresh`, uv happily reinstalls the version it already knows.
+
 `provenance.intoto.jsonl` is attached as a release asset on purpose: it is a
 *distinct* artifact from the attestation recorded on GitHub's API, and it is the
 one OpenSSF Scorecard's Signed-Releases control looks for. That control scores

--- a/scripts/check-release.py
+++ b/scripts/check-release.py
@@ -7,12 +7,20 @@ numéro de version consommé ne se réutilise jamais. D'où ce contrôle local,
 qui rejoue à froid les cinq étapes que RELEASING confie à la vigilance
 humaine, et qui a un cas de figure réel derrière chaque test.
 
+Le pendant existe pour l'APRÈS. Le workflow vert ne prouve pas que la version
+est installable : à la publication de la 0.1.42, l'upload avait bien reçu deux
+« 200 OK » de PyPI, la page projet répondait, et pourtant l'index simple, le
+seul que lisent pip et uv, ne listait pas encore la version. Un « c'est
+publié » fondé sur le statut du workflow était faux pendant plusieurs minutes.
+
 Usage :
     python3 scripts/check-release.py           # déduit la version du pyproject
     python3 scripts/check-release.py v0.1.28   # vérifie un tag précis
+    python3 scripts/check-release.py --publiee # APRÈS le tag : est-ce arrivé ?
 
 Sortie 0 : le tag peut être posé, la commande exacte est affichée.
 Sortie 1 : au moins un contrôle a échoué, chacun dit quoi corriger.
+Sortie 2 : rien n'est faux, mais il est trop tôt. Relancer plus tard.
 """
 
 from __future__ import annotations
@@ -228,12 +236,150 @@ def _verifier_ci(r: Rapport) -> None:
         r.ok("CI verte sur ce commit")
 
 
+# ── après le tag : la version est-elle réellement arrivée ? ──────────────────
+
+def _index_simple() -> str | None:
+    """Le contenu de l'index simple de PyPI, ou None s'il est injoignable.
+
+    C'est CET index que lisent pip et uv pour résoudre une version, et lui seul
+    fait foi. L'API JSON et la page projet peuvent répondre avant lui.
+    """
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - URL constante, https
+            "https://pypi.org/simple/dsoxlab/", timeout=10
+        ) as reponse:
+            return reponse.read().decode("utf-8", "replace")
+    except (urllib.error.URLError, OSError):
+        return None
+
+
+def _verifier_installable(r: Rapport, version: str) -> None:
+    """La version est-elle visible là où un installateur la cherche ?
+
+    Mesuré sur la 0.1.42 : la page projet et l'API JSON répondaient 200 alors
+    que l'index simple ne la listait pas encore, et `uv tool install` posait
+    donc la version précédente sans broncher.
+    """
+    index = _index_simple()
+    if index is None:
+        r.note(
+            "Index PyPI injoignable",
+            "Contrôle sauté. Vérifie à la main : "
+            "curl -s https://pypi.org/simple/dsoxlab/ | grep " + version,
+        )
+        return
+
+    if f"dsoxlab-{version}" in index:
+        r.ok(f"La version {version} est servie par l'index PyPI")
+        return
+
+    # L'API JSON répond-elle déjà ? La distinction dit s'il faut attendre ou
+    # s'inquiéter : connue de l'API mais absente de l'index, c'est la
+    # propagation ; inconnue des deux, l'upload n'a pas eu lieu.
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - URL constante, https
+            f"https://pypi.org/pypi/dsoxlab/{version}/json", timeout=10
+        ) as reponse:
+            connue = reponse.status == 200
+    except (urllib.error.URLError, OSError):
+        connue = False
+
+    if connue:
+        r.attendre(
+            f"La version {version} est publiée mais pas encore servie",
+            "L'index simple n'a pas fini de propager. Attends une minute puis "
+            "relance. N'annonce pas la publication tant que ce contrôle est "
+            "orange : un utilisateur qui installe maintenant aura la version "
+            "précédente.",
+        )
+    else:
+        r.ko(
+            f"La version {version} est absente de PyPI",
+            "Le workflow Release a-t-il vraiment publié ? Regarde le job "
+            "« Publish to PyPI » : un job vert peut avoir sauté l'upload.",
+        )
+
+
+def _verifier_release_github(r: Rapport, tag: str) -> None:
+    """La Release GitHub porte les artefacts et la provenance."""
+    sortie = subprocess.run(
+        ["gh", "release", "view", tag, "--json", "tagName,assets"],
+        cwd=RACINE, capture_output=True, text=True,
+    )
+    if sortie.returncode != 0:
+        r.ko(
+            f"Aucune Release GitHub pour {tag}",
+            "Le workflow Release ne part que sur push de tag. Vérifie qu'il a "
+            "tourné : gh run list --workflow Release",
+        )
+        return
+    try:
+        assets = json.loads(sortie.stdout).get("assets", [])
+    except ValueError:
+        r.note("Release GitHub illisible", "Vérifie à la main.")
+        return
+    noms = [a.get("name", "") for a in assets]
+    manquants = [
+        quoi for quoi, motif in (
+            ("le wheel", ".whl"),
+            ("la tarball", ".tar.gz"),
+            ("la provenance", "intoto"),
+        )
+        if not any(motif in n for n in noms)
+    ]
+    if manquants:
+        r.ko(
+            f"Release {tag} incomplète : il manque {', '.join(manquants)}",
+            f"Artefacts présents : {', '.join(noms) or 'aucun'}",
+        )
+    else:
+        r.ok(f"Release GitHub {tag} complète", f"({len(noms)} artefacts)")
+
+
+def _verifier_tag_pousse(r: Rapport, tag: str) -> None:
+    sortie = git("ls-remote", "--tags", "origin", f"refs/tags/{tag}")
+    if tag in sortie:
+        r.ok(f"Le tag {tag} est sur origin")
+    else:
+        r.ko(
+            f"Le tag {tag} n'est pas sur origin",
+            f"git push origin {tag} : sans push, aucun workflow ne part.",
+        )
+
+
+def controler_publication(version: str, tag: str) -> int:
+    """Le pendant d'après le tag : la release est-elle réellement livrée ?"""
+    print(f"\n{GRAS}Contrôle après publication de {tag}{RAZ}\n")
+    r = Rapport()
+    _verifier_tag_pousse(r, tag)
+    _verifier_release_github(r, tag)
+    _verifier_installable(r, version)
+
+    print()
+    if r.echecs:
+        print(f"{ROUGE}{GRAS}{len(r.echecs)} contrôle(s) en échec.{RAZ} "
+              "La publication n'est pas terminée.\n")
+        return 1
+    if r.attentes:
+        print(f"{JAUNE}{GRAS}Publié, mais pas encore servi.{RAZ} "
+              "Relance dans une minute.\n")
+        return 2
+    print(f"{VERT}{GRAS}La version {version} est livrée.{RAZ}\n")
+    print("    Pour l'installer, pense au cache : "
+          "uv tool install --force --refresh dsoxlab\n")
+    return 0
+
+
 def main() -> int:
     version = version_empaquetee()
     if version is None:
         print(f"{ROUGE}pyproject.toml ne déclare aucune version.{RAZ}")
         return 1
-    tag = sys.argv[1] if len(sys.argv) > 1 else f"v{version}"
+    arguments = [a for a in sys.argv[1:] if a != "--publiee"]
+    tag = arguments[0] if arguments else f"v{version}"
+
+    if "--publiee" in sys.argv:
+        return controler_publication(version, tag)
 
     print(f"\n{GRAS}Contrôle avant tag {tag}{RAZ}\n")
     r = Rapport()


### PR DESCRIPTION
# Summary

`check-release.py` s'arrêtait au tag : il vérifiait que la version était **libre** sur PyPI, jamais qu'elle y était **arrivée**.

## Le cas qui a manqué, mesuré aujourd'hui

À la publication de la 0.1.42, le workflow était vert. Les logs montraient deux `200 OK` de `upload.pypi.org` pour le wheel et la tarball. La page projet répondait 200. L'API JSON aussi.

Et pourtant :

```console
$ curl -s https://pypi.org/simple/dsoxlab/ | grep -c 0.1.42
0
$ uv tool install --force dsoxlab && dsoxlab --version
dsoxlab 0.1.41
```

`https://pypi.org/simple/` est le **seul** index que pip et uv lisent pour résoudre une version. Pendant plusieurs minutes, annoncer « c'est publié » aurait été faux : un utilisateur installant à ce moment-là recevait la version précédente, sans le moindre avertissement.

## Ce que fait `--publiee`

Trois contrôles sur l'après-tag :

| Contrôle | Ce qu'il attrape |
|---|---|
| Le tag est sur `origin` | Sans push, aucun workflow ne part |
| La Release GitHub porte ses 3 artefacts | Wheel, sdist et `provenance.intoto.jsonl` |
| La version est servie par l'index simple | Le seul qui compte pour un installateur |

Le dernier **distingue deux situations que le statut du workflow confond** :

- connue de l'API JSON mais absente de l'index ⇒ propagation en cours, il n'y a qu'à attendre (**code 2**) ;
- inconnue des deux ⇒ l'upload n'a pas eu lieu malgré un job vert (**code 1**).

Il rappelle aussi le dernier piège : uv met l'index en cache, donc vérifier par une installation exige `--refresh`, sans quoi uv réinstalle la version qu'il connaît déjà.

## Preuve : le garde-fou sait dire non

Un contrôle qui ne refuse jamais rien ne prouve rien. Les quatre cas ont été joués :

| Cas | Attendu | Obtenu |
|---|---|---|
| Version inexistante (`0.9.99`) | rouge | `✘ La version 0.9.99 est absente de PyPI` |
| Version réellement publiée (`0.1.42`) | vert | `✔ servie par l'index PyPI` |
| Tag jamais poussé (`v9.9.9`) | rouge | `✘ Le tag v9.9.9 n'est pas sur origin` |
| Release GitHub absente | rouge | `✘ Aucune Release GitHub pour v9.9.9` |

Et sur la vraie 0.1.42, le mode complet rend 0 :

```
Contrôle après publication de v0.1.42

  ✔ Le tag v0.1.42 est sur origin
  ✔ Release GitHub v0.1.42 complète (3 artefacts)
  ✔ La version 0.1.42 est servie par l'index PyPI

La version 0.1.42 est livrée.
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `ruff check` passes sur le script modifié
- [x] `mypy` : **N/A** sur le fond, `scripts/` est hors du périmètre déclaré (`files = ["src/dsoxlab"]`) ; le hook a tourné au commit et passe
- [x] `pytest` : inchangé, aucun code du paquet n'est touché
- [x] The engine stays domain-agnostic : aucun code moteur modifié
- [x] No hardcoded personal path or host ; `pathlib.Path` throughout
- [x] Manually tested against **two** lab repositories : **N/A**, ce script ne lit aucun catalogue. Il a en revanche été joué contre la vraie release 0.1.42 et contre quatre cas d'échec.

### When behavior changes

- [x] CHANGELOG : **N/A**. Le paquet publié est inchangé : `scripts/` n'est pas empaqueté (`packages = ["src/dsoxlab"]`), rien de ce que reçoit un utilisateur ne bouge. C'est de l'outillage de mainteneur, comme la PR dependabot #109.
- [x] Version bump : **N/A**, pour la même raison.

### When a command or option is added, removed or changed

**N/A** : `--publiee` est une option d'un script de mainteneur, pas de la CLI `dsoxlab`. Ni l'aide Typer, ni les catalogues i18n, ni `fullhelp` ne sont concernés. La procédure est documentée là où elle se lit, dans `RELEASING.md`.

### When `.github/workflows/` is touched

**N/A** : aucun workflow modifié.

### When the declarative contract changes

**N/A** : contrat inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
