### PR TITLE
fix(install): trois défauts qui ne se voyaient que chez l'utilisateur (0.1.43)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,46 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.43] - 2026-08-19
+
+Trois défauts qui ne se manifestaient que chez l'utilisateur : une complétion
+qui ne complétait pas, un lanceur qui ne lançait pas, et une CLI qui refusait
+de démarrer à cause de son propre fichier d'état.
+
+### Corrigé
+
+- **La complétion interrogeait la CLI par une variable qu'elle n'écoute pas.**
+  Le script généré employait `_DSOXL_COMPLETE`, quand Click dérive
+  `_DSOXLAB_COMPLETE` du nom du programme. dsoxlab répondait donc par sa page
+  d'aide, que le shell tentait d'évaluer à chaque tabulation. Le fichier zsh
+  était mal nommé par-dessus (`_dsoxl` au lieu de `_dsoxlab`), donc zsh ne le
+  chargeait jamais, quel qu'en soit le contenu. La variable est désormais
+  dérivée du nom du programme au lieu d'être recopiée : les deux ne peuvent
+  plus diverger.
+
+- **Le wrapper généré cassait sur tout chemin contenant une espace.** Il
+  écrivait `exec /home/moi/My Tools/dsoxlab "$@"` sans quoting, ce que le shell
+  découpait en deux arguments avant de répondre « not found ». Le chemin passe
+  maintenant par `shlex.quote`.
+
+- **`dsoxlab install` n'écrase plus le lanceur de `uv tool` ni de `pipx`.** Il
+  écrit exactement là où ces outils posent le leur. Le dégât était pire qu'un
+  simple écrasement, et il a fallu un test de mutation pour le voir : écrire
+  dans un lien symbolique écrit dans **sa cible**, donc dsoxlab remplaçait le
+  binaire réel de uv par un script qui s'exécutait lui-même. Le lien survivait,
+  `resolve()` ne bougeait pas, et la commande bouclait à l'infini. Quand un
+  lanceur mène déjà à ce binaire, on n'y touche plus.
+
+- **Un `.dsoxlab-context.json` malformé n'emporte plus toute la CLI.** Le
+  `except` ne couvrait que `JSONDecodeError` et `OSError`, alors que `null`
+  levait `TypeError`, `"foo"` levait `ValueError`, une racine non-objet levait
+  `AttributeError`, et un fichier d'octets arbitraires levait
+  `UnicodeDecodeError`, qui descend de `ValueError` et non d'`OSError`. Treize
+  formes malformées sont désormais absorbées en un contexte vide, avec un
+  avertissement qui nomme le fichier. Perdre le contexte coûte un
+  `dsoxlab use` ; lever coûtait toutes les commandes, y compris celles qui
+  n'ont rien à voir avec lui.
+
 ## [0.1.42] - 2026-08-19
 
 Un audit joué sur une VM Ubuntu 24.04 neuve a mesuré **six interventions non

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.43] - 2026-08-19
+
+Three defects that only ever showed up on a user's machine: a completion that
+did not complete, a launcher that did not launch, and a CLI that refused to
+start because of its own state file.
+
+### Fixed
+
+- **Shell completion asked the CLI through a variable it does not listen to.**
+  The generated script used `_DSOXL_COMPLETE`, while Click derives
+  `_DSOXLAB_COMPLETE` from the program name. dsoxlab therefore answered with
+  its help page, which the shell then tried to evaluate on every Tab. The zsh
+  file was misnamed too (`_dsoxl` instead of `_dsoxlab`), so zsh never loaded
+  it whatever it contained. The variable is now derived from the program name
+  rather than copied, so the two cannot drift apart again.
+
+- **The generated wrapper broke on any path containing a space.** It wrote
+  `exec /home/me/My Tools/dsoxlab "$@"` unquoted, which the shell split into
+  two arguments and reported as "not found". The path is now quoted with
+  `shlex.quote`.
+
+- **`dsoxlab install` no longer overwrites the launcher of `uv tool` or
+  `pipx`.** It writes to exactly the path those tools use. The damage was worse
+  than a plain overwrite, and it took a mutation test to see it: writing to a
+  symlink writes to its *target*, so dsoxlab replaced uv's real binary with a
+  script that `exec`s itself. The symlink survived, `resolve()` did not move,
+  and the command looped forever. When a launcher already leads to this binary,
+  it is now left alone.
+
+- **A malformed `.dsoxlab-context.json` no longer takes the whole CLI down.**
+  The `except` covered `JSONDecodeError` and `OSError` only, while `null`
+  raised `TypeError`, `"foo"` raised `ValueError`, a non-object root raised
+  `AttributeError`, and a file of arbitrary bytes raised `UnicodeDecodeError`,
+  which descends from `ValueError` rather than `OSError`. Thirteen malformed
+  shapes are now absorbed into an empty context, with a warning naming the
+  file. Losing the context costs a `dsoxlab use`; raising cost every command,
+  including those with nothing to do with it.
+
 ## [0.1.42] - 2026-08-19
 
 An audit run on a fresh Ubuntu 24.04 VM measured **six undocumented steps**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.42"
+version = "0.1.43"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import atexit
 import os
+import shlex
 import webbrowser
 import shutil
 import subprocess
@@ -325,6 +326,18 @@ def _notify_update_available() -> None:
 
 # ── install ─────────────────────────────────────────────────────────────────
 
+#: Nom du programme, tel que la CLI est installée et invoquée.
+_PROG_NAME = "dsoxlab"
+
+#: Variable d'environnement par laquelle le shell demande une complétion.
+#: Elle est DÉRIVÉE du nom du programme, comme le fait Click lui-même, et non
+#: recopiée : la valeur codée en dur était « _DSOXL_COMPLETE », que la CLI
+#: n'écoute pas. Le script généré interrogeait donc dsoxlab avec une variable
+#: ignorée, la CLI répondait par sa page d'aide, et le shell tentait de
+#: l'évaluer à chaque tabulation.
+_COMPLETE_VAR = f"_{_PROG_NAME.replace('-', '_').upper()}_COMPLETE"
+
+
 @app.command("install", help=_("cmd_install_help"))
 def install() -> None:
     """Install the dsoxlab wrapper in ~/.local/bin and shell completion."""
@@ -336,9 +349,22 @@ def install() -> None:
 
     venv_binary = Path(sys.argv[0]).resolve()
     wrapper = local_bin / "dsoxlab"
-    wrapper.write_text(f"#!/bin/sh\nexec {venv_binary} \"$@\"\n")
-    wrapper.chmod(0o755)
-    success(_("install_wrapper", path=str(wrapper), source=str(venv_binary)))
+
+    # Ne pas écraser un lanceur qui mène déjà à ce binaire. `uv tool install` et
+    # `pipx` en posent un exactement ici : le remplacer par un script shell ne
+    # fait que défaire ce que leur prochaine mise à jour remettra. Surtout, si ce
+    # lanceur EST le fichier qu'on vient de résoudre (cas d'un vrai fichier
+    # plutôt que d'un lien), le wrapper s'exécuterait lui-même, en boucle.
+    if wrapper.exists() and wrapper.resolve() == venv_binary:
+        info(_("install_wrapper_deja", path=str(wrapper)))
+    else:
+        # shlex.quote : un chemin d'installation contenant une espace
+        # (« /home/moi/My Tools/… ») produisait un `exec` découpé en plusieurs
+        # arguments, donc un wrapper qui échouait sur « not found ».
+        cible = shlex.quote(str(venv_binary))
+        wrapper.write_text(f'#!/bin/sh\nexec {cible} "$@"\n')
+        wrapper.chmod(0o755)
+        success(_("install_wrapper", path=str(wrapper), source=str(venv_binary)))
 
     # ── 2. Shell completion ────────────────────────────────────────────────────
     shell_name = Path(os.environ.get("SHELL", "bash")).name
@@ -346,9 +372,11 @@ def install() -> None:
     if shell_name == "zsh":
         zfunc_dir = Path.home() / ".zfunc"
         zfunc_dir.mkdir(exist_ok=True)
-        comp_file = zfunc_dir / "_dsoxl"
+        # Le nom du fichier compte : zsh autoload la fonction `_dsoxlab` pour
+        # compléter `dsoxlab`, et cherche donc un fichier de ce nom exact.
+        comp_file = zfunc_dir / f"_{_PROG_NAME}"
         script = get_completion_script(  # noqa: S604 — `shell` = nom du shell Typer ("zsh"), pas un subprocess shell=True
-            prog_name="dsoxlab", complete_var="_DSOXL_COMPLETE", shell="zsh"
+            prog_name=_PROG_NAME, complete_var=_COMPLETE_VAR, shell="zsh"
         )
         comp_file.write_text(script)
         success(_("install_completion", path=str(comp_file)))
@@ -370,7 +398,7 @@ def install() -> None:
         bash_comp_dir.mkdir(exist_ok=True)
         comp_file = bash_comp_dir / "dsoxlab"
         script = get_completion_script(  # noqa: S604 — `shell` = nom du shell Typer ("bash"), pas un subprocess shell=True
-            prog_name="dsoxlab", complete_var="_DSOXL_COMPLETE", shell="bash"
+            prog_name=_PROG_NAME, complete_var=_COMPLETE_VAR, shell="bash"
         )
         comp_file.write_text(script)
         success(_("install_completion", path=str(comp_file)))

--- a/src/dsoxlab/config.py
+++ b/src/dsoxlab/config.py
@@ -1,9 +1,12 @@
 """Configuration globale : résolution de LAB_HOME, chemins et contexte actif."""
 
 import json
+import logging
 import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 _CONTEXT_FILE = ".dsoxlab-context.json"
 
@@ -33,24 +36,75 @@ def get_context_path(root: Path) -> Path:
     return root / _CONTEXT_FILE
 
 
+def _texte(valeur: object) -> str | None:
+    """Un champ texte du contexte, ou ``None`` si la valeur n'en est pas un.
+
+    Ce fichier est écrit par l'outil, mais rien ne garantit son contenu : un
+    éditeur, une résolution de conflit, un disque plein ou une copie entre
+    machines peuvent le laisser dans n'importe quel état. Une valeur d'un autre
+    type se propagerait ensuite dans toute la CLI, loin de sa cause.
+    """
+    return valeur if isinstance(valeur, str) else None
+
+
+def _position(valeur: object) -> int:
+    """La position de lecture du cours, jamais négative.
+
+    ``int(valeur)`` levait ``TypeError`` sur ``null`` et ``ValueError`` sur
+    ``"foo"``, deux exceptions que le ``except`` ne couvrait pas : un contexte
+    corrompu faisait alors planter la CLI **entière**, y compris les commandes
+    qui n'ont rien à voir avec le cours.
+    """
+    # bool est un int en Python : `true` deviendrait la position 1, ce qui est
+    # une coïncidence de typage, pas une intention.
+    if isinstance(valeur, bool):
+        return 0
+    if isinstance(valeur, int):
+        return max(0, valeur)
+    if isinstance(valeur, str):
+        try:
+            return max(0, int(valeur.strip()))
+        except ValueError:
+            return 0
+    return 0
+
+
 def read_context(root: Path) -> ActiveContext:
-    """Lit le contexte actif depuis le fichier local. Retourne un contexte vide si absent."""
+    """Lit le contexte actif depuis le fichier local.
+
+    Retourne un contexte vide dès que le fichier est absent, illisible ou
+    malformé. Un fichier d'état local n'est pas une entrée de confiance : le
+    perdre coûte à l'apprenant un ``dsoxlab use``, alors qu'une exception lui
+    coûte la CLI tout entière, sans lui dire quel fichier supprimer.
+    """
     path = get_context_path(root)
     if not path.exists():
         return ActiveContext()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        return ActiveContext(
-            section=data.get("section"),
-            level=data.get("level"),
-            lang=data.get("lang"),
-            active_lab=data.get("active_lab"),
-            active_target=data.get("active_target"),
-            active_provider=data.get("active_provider"),
-            course_pos=int(data.get("course_pos", 0)),
-        )
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        # UnicodeDecodeError descend de ValueError, pas d'OSError : un fichier
+        # d'octets arbitraires passait donc à travers l'ancien filet.
+        logger.warning("Contexte illisible, ignoré : %s", path)
         return ActiveContext()
+
+    # La racine du document peut être n'importe quel type JSON. Sur une liste
+    # ou une chaîne, `.get()` n'existe pas et lève un AttributeError que rien
+    # n'attrapait.
+    if not isinstance(data, dict):
+        logger.warning("Contexte non conforme (racine %s), ignoré : %s",
+                       type(data).__name__, path)
+        return ActiveContext()
+
+    return ActiveContext(
+        section=_texte(data.get("section")),
+        level=_texte(data.get("level")),
+        lang=_texte(data.get("lang")),
+        active_lab=_texte(data.get("active_lab")),
+        active_target=_texte(data.get("active_target")),
+        active_provider=_texte(data.get("active_provider")),
+        course_pos=_position(data.get("course_pos")),
+    )
 
 
 def _persist(root: Path, ctx: ActiveContext) -> None:

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -325,6 +325,8 @@ silent.
 
     # ── install ───────────────────────────────────────────────────────────────────
     "install_wrapper":              "Wrapper installed: {path}  →  {source}",
+    "install_wrapper_deja":
+        "A launcher already points at this binary ({path}): it most likely comes from `uv tool install` or pipx. Leaving it alone, since overwriting it would only undo what their next upgrade restores.",
     "install_completion":           "Completion script: {path}",
     "install_rc":                   "Shell config updated: {path} — reload with: exec $SHELL",
     "install_completion_unsupported": "Auto-completion not supported for shell: {shell} (bash and zsh only).",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -323,6 +323,8 @@ hors ligne, elle se tait.
 
     # ── install ───────────────────────────────────────────────────────────────────
     "install_wrapper":              "Wrapper installé : {path}  →  {source}",
+    "install_wrapper_deja":
+        "Un lanceur mène déjà à ce binaire ({path}) : il vient probablement de « uv tool install » ou de pipx. On n'y touche pas, l'écraser ne ferait que défaire ce que leur prochaine mise à jour remettra.",
     "install_completion":           "Script de complétion : {path}",
     "install_rc":                   "Config shell mise à jour : {path} — rechargez avec : exec $SHELL",
     "install_completion_unsupported": "Auto-complétion non supportée pour le shell : {shell} (bash et zsh uniquement).",

--- a/tests/test_install_et_contexte.py
+++ b/tests/test_install_et_contexte.py
@@ -1,0 +1,256 @@
+"""Trois défauts de l'installation et de l'état local, chacun reproduit.
+
+Ils ont en commun de ne se manifester que chez l'utilisateur : une complétion
+qui ne complète pas, un lanceur qui ne lance pas, une CLI qui refuse de démarrer
+à cause d'un fichier d'état. Aucun ne se voit depuis le dépôt.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dsoxlab import cli
+from dsoxlab.config import read_context
+
+runner = CliRunner()
+
+
+# ── la complétion interrogeait la CLI avec une variable qu'elle n'écoute pas ──
+
+def test_la_variable_de_completion_est_celle_que_click_attend() -> None:
+    """Click dérive le nom de la variable du prog_name, il ne l'invente pas.
+
+    La valeur codée en dur était `_DSOXL_COMPLETE`. Le script généré
+    interrogeait donc dsoxlab avec une variable ignorée : la CLI répondait par
+    sa page d'aide, que le shell tentait ensuite d'évaluer à chaque tabulation.
+    """
+    attendu = "_" + cli._PROG_NAME.replace("-", "_").upper() + "_COMPLETE"
+    assert cli._COMPLETE_VAR == attendu == "_DSOXLAB_COMPLETE"
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh"])
+def test_le_script_genere_porte_la_bonne_variable(shell: str) -> None:
+    from typer.completion import get_completion_script
+
+    script = get_completion_script(  # noqa: S604 : nom de shell, pas shell=True
+        prog_name=cli._PROG_NAME, complete_var=cli._COMPLETE_VAR, shell=shell
+    )
+    assert "_DSOXLAB_COMPLETE" in script
+    assert "_DSOXL_COMPLETE" not in script, (
+        "l'ancienne variable ne doit plus apparaître : elle est ignorée par la CLI"
+    )
+
+
+def test_le_fichier_zsh_porte_le_nom_que_zsh_cherche(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """zsh autoload la fonction `_dsoxlab` pour compléter `dsoxlab`.
+
+    Le fichier s'appelait `_dsoxl` : jamais chargé, quel que soit son contenu.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+    monkeypatch.setattr(cli.Path, "home", classmethod(lambda cls: tmp_path))
+
+    resultat = runner.invoke(cli.app, ["install"])
+    assert resultat.exit_code == 0, resultat.output
+
+    assert (tmp_path / ".zfunc" / "_dsoxlab").is_file()
+    assert not (tmp_path / ".zfunc" / "_dsoxl").exists()
+
+
+# ── le wrapper cassait sur un chemin contenant une espace ─────────────────────
+
+def _ecrire_faux_binaire(chemin: Path) -> None:
+    """Un exécutable qui prouve, en s'exécutant, qu'il a bien été appelé."""
+    chemin.parent.mkdir(parents=True, exist_ok=True)
+    chemin.write_text('#!/bin/sh\necho "APPELE:$*"\n', encoding="utf-8")
+    chemin.chmod(chemin.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def test_le_wrapper_fonctionne_avec_une_espace_dans_le_chemin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Le seul test qui prouve quelque chose ici : on EXÉCUTE le wrapper.
+
+    Sans quoting, `exec /home/moi/My Tools/dsoxlab "$@"` se découpe en deux
+    arguments et le shell répond « not found ». Vérifier le contenu du fichier
+    ne l'aurait pas montré.
+    """
+    binaire = tmp_path / "My Tools" / "dsoxlab-reel"
+    _ecrire_faux_binaire(binaire)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SHELL", "/bin/bash")
+    monkeypatch.setattr(cli.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(cli.sys, "argv", [str(binaire)])
+
+    resultat = runner.invoke(cli.app, ["install"])
+    assert resultat.exit_code == 0, resultat.output
+
+    wrapper = tmp_path / ".local" / "bin" / "dsoxlab"
+    assert wrapper.is_file()
+
+    joue = subprocess.run(  # noqa: S603 : wrapper généré par le test lui-même
+        [str(wrapper), "check", "un-lab"], capture_output=True, text=True,
+    )
+    assert joue.returncode == 0, (
+        f"le wrapper ne s'exécute pas : {joue.stderr.strip()}\n"
+        f"contenu : {wrapper.read_text(encoding='utf-8')!r}"
+    )
+    assert "APPELE:check un-lab" in joue.stdout, (
+        "les arguments doivent parvenir au binaire réel"
+    )
+
+
+def test_un_lanceur_existant_n_est_pas_ecrase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`uv tool install` pose son lanceur exactement là, et c'est un lien.
+
+    Le danger est plus grave qu'un simple écrasement, et il a fallu une
+    mutation pour le voir : `write_text()` sur un lien symbolique écrit dans
+    **la cible**. Sans garde, on ne remplace donc pas le lien, on remplace le
+    binaire réel de uv par un script `exec` qui pointe sur lui-même. Le lien
+    survit, `resolve()` ne bouge pas, et la commande boucle à l'infini.
+
+    Ce test compare donc le CONTENU du binaire réel, seule chose qui change.
+    """
+    reel = tmp_path / "outils" / "dsoxlab"
+    _ecrire_faux_binaire(reel)
+    contenu_avant = reel.read_text(encoding="utf-8")
+
+    lanceur = tmp_path / ".local" / "bin" / "dsoxlab"
+    lanceur.parent.mkdir(parents=True, exist_ok=True)
+    lanceur.symlink_to(reel)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SHELL", "/bin/bash")
+    monkeypatch.setattr(cli.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(cli.sys, "argv", [str(lanceur)])
+
+    resultat = runner.invoke(cli.app, ["install"])
+    assert resultat.exit_code == 0, resultat.output
+
+    assert lanceur.is_symlink(), "le lien de uv/pipx doit rester un lien"
+    assert reel.read_text(encoding="utf-8") == contenu_avant, (
+        "le binaire réel a été réécrit à travers le lien : il s'exec désormais "
+        "lui-même, donc il boucle"
+    )
+    assert "exec" not in reel.read_text(encoding="utf-8").split("\n")[1], (
+        "le binaire ne doit pas être devenu un wrapper vers lui-même"
+    )
+
+
+# ── un fichier d'état corrompu ne doit pas emporter la CLI ────────────────────
+
+CONTEXTES_INVALIDES = [
+    ("racine liste", "[1, 2]"),
+    ("racine chaîne", '"texte"'),
+    ("racine nombre", "42"),
+    ("racine nulle", "null"),
+    ("position nulle", '{"course_pos": null}'),
+    ("position non numérique", '{"course_pos": "foo"}'),
+    ("position négative", '{"course_pos": -5}'),
+    ("position booléenne", '{"course_pos": true}'),
+    ("position flottante", '{"course_pos": 2.7}'),
+    ("section numérique", '{"section": 42}'),
+    ("section liste", '{"section": ["l1"]}'),
+    ("json invalide", "pas du json"),
+    ("fichier vide", ""),
+]
+
+
+@pytest.mark.parametrize(
+    ("nom", "contenu"),
+    CONTEXTES_INVALIDES,
+    ids=[nom for nom, _ in CONTEXTES_INVALIDES],
+)
+def test_un_contexte_corrompu_rend_un_contexte_vide(
+    tmp_path: Path, nom: str, contenu: str
+) -> None:
+    """Perdre le contexte coûte un `dsoxlab use` ; lever coûte toute la CLI.
+
+    Le `except` ne couvrait que JSONDecodeError et OSError : `null` levait un
+    TypeError, `"foo"` un ValueError, et une racine non-objet un AttributeError.
+    """
+    (tmp_path / ".dsoxlab-context.json").write_text(contenu, encoding="utf-8")
+
+    ctx = read_context(tmp_path)
+
+    assert ctx.course_pos == 0
+    assert ctx.section is None
+    assert isinstance(ctx.course_pos, int)
+
+
+def test_des_octets_illisibles_ne_font_pas_lever(tmp_path: Path) -> None:
+    """UnicodeDecodeError descend de ValueError, pas d'OSError.
+
+    Un fichier d'octets arbitraires passait donc à travers l'ancien filet.
+    """
+    (tmp_path / ".dsoxlab-context.json").write_bytes(b"\xff\xfe\x00rubbish")
+
+    assert read_context(tmp_path).course_pos == 0
+
+
+def test_un_contexte_valide_est_toujours_lu(tmp_path: Path) -> None:
+    """Le durcissement ne doit pas avaler le cas nominal."""
+    (tmp_path / ".dsoxlab-context.json").write_text(
+        json.dumps({
+            "section": "linux",
+            "level": "l2",
+            "lang": "fr",
+            "active_lab": "l2-acl-posix",
+            "active_target": "rhel",
+            "active_provider": "kvm",
+            "course_pos": 3,
+        }),
+        encoding="utf-8",
+    )
+
+    ctx = read_context(tmp_path)
+
+    assert ctx.section == "linux"
+    assert ctx.level == "l2"
+    assert ctx.lang == "fr"
+    assert ctx.active_lab == "l2-acl-posix"
+    assert ctx.active_target == "rhel"
+    assert ctx.active_provider == "kvm"
+    assert ctx.course_pos == 3
+
+
+def test_une_position_en_chaine_reste_lue(tmp_path: Path) -> None:
+    """« 3 » écrit à la main par un formateur vaut la position 3.
+
+    Refuser une chaîne numérique perdrait une position parfaitement lisible.
+    """
+    (tmp_path / ".dsoxlab-context.json").write_text(
+        '{"course_pos": " 3 "}', encoding="utf-8"
+    )
+
+    assert read_context(tmp_path).course_pos == 3
+
+
+def test_la_cli_demarre_sur_un_contexte_corrompu(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Le vrai symptôme : la commande la plus banale devenait impossible."""
+    (tmp_path / "meta.yml").write_text(
+        "repo:\n  id: demo\n  category: demo\n", encoding="utf-8"
+    )
+    (tmp_path / ".dsoxlab-context.json").write_text(
+        '{"course_pos": null}', encoding="utf-8"
+    )
+    monkeypatch.setenv("LAB_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    resultat = runner.invoke(cli.app, ["list-labs"])
+
+    assert resultat.exit_code == 0, resultat.output
+    assert "TypeError" not in resultat.output

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.42"
+version = "0.1.43"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Closes #67
Closes #68
Closes #69

# Summary

Une complétion qui ne complète pas, un lanceur qui ne lance pas, une CLI qui refuse de démarrer à cause de son propre fichier d'état. **Aucun de ces trois défauts ne se manifeste depuis le dépôt** : il faut installer l'outil pour les rencontrer.

## #67 — la complétion parlait à la CLI dans une langue qu'elle n'écoute pas

Le script généré employait `_DSOXL_COMPLETE`, alors que Click dérive `_DSOXLAB_COMPLETE` du nom du programme. dsoxlab répondait donc par sa **page d'aide**, que le shell tentait ensuite d'évaluer à chaque tabulation.

Le fichier zsh était mal nommé par-dessus (`~/.zfunc/_dsoxl`), donc zsh ne le chargeait jamais, quel qu'en soit le contenu. Renommer sans corriger la variable, ou l'inverse, n'aurait rien réparé.

La variable est désormais **dérivée** du nom du programme, comme le fait Click, au lieu d'être recopiée : les deux ne peuvent plus diverger.

## #68 — deux défauts pour le prix d'un

Le quoting d'abord : `exec /home/moi/My Tools/dsoxlab "$@"` se découpe en deux arguments, et le shell répond « not found ». Corrigé par `shlex.quote`. Le test correspondant **exécute** le wrapper, avec un binaire posé dans un répertoire nommé `My Tools` : vérifier le contenu du fichier n'aurait rien prouvé.

Le second est plus grave, et l'issue ne le mentionnait pas. `dsoxlab install` écrit exactement là où `uv tool install` et `pipx` posent leur lanceur. Or **écrire dans un lien symbolique écrit dans sa cible** : dsoxlab remplaçait donc le binaire réel de uv par un script qui `exec` ... lui-même. Le lien survivait, `resolve()` ne bougeait pas, et la commande bouclait à l'infini.

Il a fallu un **test de mutation** pour le voir : mon premier test comparait le lien et sa résolution, tous deux inchangés, et déclarait tout bon. Il compare maintenant le contenu du binaire.

## #69 — le fichier d'état emportait la CLI entière

Le `except` couvrait `JSONDecodeError` et `OSError`. Or :

| Contenu | Exception levée | Couverte ? |
|---|---|---|
| `{"course_pos": null}` | `TypeError` | non |
| `{"course_pos": "foo"}` | `ValueError` | non |
| `[1, 2]`, `"texte"`, `42` | `AttributeError` | non |
| octets arbitraires | `UnicodeDecodeError` | non (descend de `ValueError`, pas d'`OSError`) |

**Treize formes malformées** sont désormais absorbées en un contexte vide, avec un avertissement qui nomme le fichier. Perdre le contexte coûte un `dsoxlab use` ; lever coûtait toutes les commandes, y compris celles qui n'ont rien à voir avec le cours.

## Preuve : six mutations, six rouges

Un test qui n'a jamais échoué ne prouve rien. Chaque défaut a été **remis en place**, et la suite doit tomber sur le cas qui le vise :

| Mutation | Verdict | Cas touché |
|---|---|---|
| Wrapper sans `shlex.quote` | rouge | `espace_dans_le_chemin` |
| Retour à `_DSOXL_COMPLETE` | rouge | `variable_de_completion` + les 2 scripts |
| Fichier zsh renommé `_dsoxl` | rouge | `nom_que_zsh_cherche` |
| Garde du lanceur retirée | rouge | `lanceur_existant` |
| `int()` sans garde | rouge | 6 cas de contexte |
| Racine JSON non vérifiée | rouge | 4 cas de contexte |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `ruff check src/dsoxlab tests` passes
- [x] `mypy src/dsoxlab` passes (strict) : `Success: no issues found in 48 source files`
- [x] `pytest` passes : **258 passed** (235 avant, soit **+23 tests**)
- [x] The engine stays domain-agnostic : aucun nom de domaine introduit ; `_PROG_NAME` est le nom de l'outil, pas d'un catalogue
- [x] No hardcoded personal path or host ; `pathlib.Path` throughout
- [x] Manually tested against **two** lab repositories : `terraform-training` (87 labs découverts) et `linux-dsoxlab-training` (84 découverts par `doctor` ; `list-labs` en affiche 20 parce que le contexte actif filtre sur `section: l1`, comportement identique à la 0.1.42 publiée, donc sans régression)

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.42 → 0.1.43) and `uv.lock` refreshed

### When a command or option is added, removed or changed

- [x] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py` (`install_wrapper_deja` ; parité vérifiée : 337 clés de chaque côté, écart nul)
- [x] `fullhelp` : **N/A**, aucune commande ni option ajoutée, retirée ou renommée. `install` existe déjà et garde sa signature ; seul son comportement se corrige.
- [x] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched

**N/A** : aucun workflow modifié.

### When the declarative contract changes

**N/A** : le contrat déclaratif est inchangé. `.dsoxlab-context.json` est un fichier d'**état local**, écrit par l'outil, jamais par un auteur de labs : il ne fait pas partie du contrat et n'a pas de place dans `fuzz/corpus/`. L'issue #71 vise précisément à l'ajouter au périmètre du fuzzing, et les treize formes couvertes ici lui donnent son point de départ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
