### PR TITLE
feat(cli): le moteur cesse de savoir sans le dire (0.1.44)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,33 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.44] - 2026-08-19
+
+### Ajouté
+
+- **`--verbose` / `-v`, `--debug`, et un journal persistant.** Onze modules du
+  moteur écrivent dans un logger, et aucun de ces messages n'atteignait jamais
+  un utilisateur ni un fichier. Le cas le plus coûteux est connu : un `lab.yaml`
+  qui lève au parsing est avalé par un `logger.warning` puis un `continue`, donc
+  le lab disparaît du catalogue **sans un mot**. C'est le premier symptôme que
+  rencontre un auteur de catalogue, et le plus difficile à diagnostiquer.
+
+  Les avertissements sont désormais affichés par défaut, parce qu'un lab disparu
+  est une perte réelle de contenu, que l'auteur comme l'apprenant ont besoin de
+  voir. `-v` ajoute le niveau informatif, `-vv` (ou `--debug`) le détail complet,
+  et `DSOXLAB_LOG` fait de même là où la ligne de commande échappe.
+
+  Le diagnostic part toujours sur la **sortie d'erreur**, jamais sur la sortie
+  standard : `--json` reste lisible par un programme même en mode verbeux, ce
+  qu'un test épingle.
+
+  Un journal tournant est écrit dans `~/.local/state/dsoxlab/dsoxlab.log` quelle
+  que soit l'option, borné à 1 Mo et trois archives. C'est lui qui permet de
+  joindre une trace à un rapport de bug *après coup*, au lieu de demander à
+  l'utilisateur de reproduire avec la bonne option. Un journal impossible à
+  écrire (HOME en lecture seule, disque plein) ne fait jamais échouer la
+  commande : c'est un confort, pas une dépendance.
+
 ## [0.1.43] - 2026-08-19
 
 Trois défauts qui ne se manifestaient que chez l'utilisateur : une complétion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.44] - 2026-08-19
+
+### Added
+
+- **`--verbose` / `-v`, `--debug`, and a persistent log.** Eleven engine modules
+  write to a logger, and none of those messages ever reached a user or a file.
+  The costliest case is known: a `lab.yaml` that raises while parsing is
+  swallowed by a `logger.warning` then a `continue`, so the lab vanishes from
+  the catalog **without a word**. That is the first symptom a catalog author
+  meets, and the hardest to diagnose.
+
+  Warnings are now shown by default, because a vanished lab is a real loss of
+  content that both the author and the learner need to see. `-v` adds the
+  informational level, `-vv` (or `--debug`) the full detail, and `DSOXLAB_LOG`
+  does the same for cases where the command line is out of reach.
+
+  Diagnostics always go to **standard error**, never to standard output: `--json`
+  stays machine-readable even in verbose mode, which a test pins down.
+
+  A rotating log is written to `~/.local/state/dsoxlab/dsoxlab.log` regardless of
+  any option, bounded to 1 MB and three archives. That is what makes it possible
+  to attach a trace to a bug report *after the fact*, instead of asking the user
+  to reproduce with the right flag. A log that cannot be written (read-only HOME,
+  full disk) never fails the command: it is a convenience, not a dependency.
+
 ## [0.1.43] - 2026-08-19
 
 Three defects that only ever showed up on a user's machine: a completion that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.43"
+version = "0.1.44"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -36,6 +36,7 @@ from .config import (
     set_active_provider, set_course_pos, write_context,
 )
 from .i18n import _, get_lang, set_lang
+from .logging_setup import configurer as configurer_journal
 from .infra.inventory import InfraNotProvisioned
 from .models.hint import HintFile
 from .sessions.store import (
@@ -284,8 +285,21 @@ def _bootstrap(
             is_eager=True,
         ),
     ] = False,
+    verbose: Annotated[
+        int,
+        typer.Option("--verbose", "-v", count=True, help=_("opt_verbose")),
+    ] = 0,
+    debug: Annotated[
+        bool,
+        typer.Option("--debug", help=_("opt_debug")),
+    ] = False,
 ) -> None:
-    """Initialise la langue UI depuis le contexte avant toute commande."""
+    """Initialise la langue UI et la journalisation avant toute commande."""
+    # Avant le retour anticipé : `dsoxlab -v` sans sous-commande doit tout de
+    # même écrire son journal, et c'est aussi ce qui garantit qu'une commande
+    # qui échoue très tôt laisse une trace.
+    configurer_journal(verbose, debug=debug)
+
     if ctx.invoked_subcommand is None:
         return
     try:

--- a/src/dsoxlab/config.py
+++ b/src/dsoxlab/config.py
@@ -32,6 +32,19 @@ class ActiveContext:
         return "(aucun)"
 
 
+def xdg_state_home() -> Path:
+    """Racine XDG des données d'état, celles qui survivent à un redémarrage.
+
+    Publique et unique : le work-dir Terraform, le journal et tout ce qui
+    viendra ensuite doivent atterrir sous la même racine, sinon un
+    ``XDG_STATE_HOME`` personnalisé n'en déplace qu'une partie.
+    """
+    env = os.environ.get("XDG_STATE_HOME")
+    if env:
+        return Path(env).expanduser().resolve()
+    return Path.home() / ".local" / "state"
+
+
 def get_context_path(root: Path) -> Path:
     return root / _CONTEXT_FILE
 

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -86,6 +86,9 @@ STRINGS: dict[str, str] = {
     "cmd_clean_arg":     "Lab identifier",
     "cmd_validate_help":  "Check structure and metadata of all labs.",
     "cmd_doctor_help":    "Diagnose the environment (runtimes, tools, detected labs).",
+    "opt_verbose":
+        "Say what the engine is doing, on standard error. Repeatable: -v for information, -vv for full detail.",
+    "opt_debug":      "Same as -vv. The full log is written to ~/.local/state/dsoxlab/dsoxlab.log either way.",
     "opt_version_help":   "Show the dsoxlab version and exit.",
     "cmd_install_help":   "Install the dsoxlab wrapper in ~/.local/bin and shell auto-completion.",
     "cmd_fullhelp_help":  "Show the complete platform guide (concepts, workflow, commands).",
@@ -284,7 +287,20 @@ Each lab exposes:
   [cyan]install[/cyan]              Install dsoxlab in [bold]~/.local/bin[/bold] + shell auto-completion.
                        Supports bash and zsh. Reload your shell after running.
 
-  [cyan]fullhelp[/cyan]             This guide.""",
+  [cyan]fullhelp[/cyan]             This guide.
+
+[bold]Global options[/bold] [dim](before the command)[/dim]
+
+  [dim]--verbose / -v[/dim]       Say what the engine is doing, on standard error.
+                       Repeatable: [bold]-v[/bold] for information,
+                       [bold]-vv[/bold] for full detail.
+  [dim]--debug[/dim]              Same as [bold]-vv[/bold].
+  [dim]--version[/dim]            Print the version and exit.
+
+  The full log is written to [bold]~/.local/state/dsoxlab/dsoxlab.log[/bold]
+  either way, so there is no need to replay the command. It never goes to
+  standard output: [bold]--json[/bold] stays machine-readable, even in verbose
+  mode.""",
 
     "fullhelp_runtimes": """\
 [bold]Runtimes[/bold]

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -86,6 +86,9 @@ STRINGS: dict[str, str] = {
     "cmd_clean_arg":      "Identifiant du lab",
     "cmd_validate_help":  "Vérifie la structure et les métadonnées de tous les labs.",
     "cmd_doctor_help":    "Diagnostique l'environnement (runtimes, outils, labs détectés).",
+    "opt_verbose":
+        "Détaille ce que fait le moteur, sur la sortie d'erreur. Répétable : -v pour les informations, -vv pour le détail complet.",
+    "opt_debug":      "Équivaut à -vv. Le journal complet est de toute façon écrit dans ~/.local/state/dsoxlab/dsoxlab.log.",
     "opt_version_help":   "Affiche la version de dsoxlab et quitte.",
     "cmd_install_help":   "Installe le wrapper dsoxlab dans ~/.local/bin et l'auto-complétion shell.",
     "cmd_fullhelp_help":  "Affiche le guide complet de la plateforme (concepts, workflow, commandes).",
@@ -282,7 +285,20 @@ Chaque lab expose :
   [cyan]install[/cyan]              Installe dsoxlab dans [bold]~/.local/bin[/bold] + auto-complétion shell.
                        Supporte bash et zsh. Rechargez le shell après exécution.
 
-  [cyan]fullhelp[/cyan]             Ce guide.""",
+  [cyan]fullhelp[/cyan]             Ce guide.
+
+[bold]Options globales[/bold] [dim](avant la commande)[/dim]
+
+  [dim]--verbose / -v[/dim]       Dit ce que fait le moteur, sur la sortie d'erreur.
+                       Répétable : [bold]-v[/bold] pour les informations,
+                       [bold]-vv[/bold] pour le détail complet.
+  [dim]--debug[/dim]              Équivaut à [bold]-vv[/bold].
+  [dim]--version[/dim]            Affiche la version et quitte.
+
+  Le journal complet est de toute façon écrit dans
+  [bold]~/.local/state/dsoxlab/dsoxlab.log[/bold], sans avoir à repasser la commande.
+  Il ne va jamais sur la sortie standard : [bold]--json[/bold] reste lisible par
+  un programme, même en mode verbeux.""",
 
     "fullhelp_runtimes": """\
 [bold]Runtimes[/bold]

--- a/src/dsoxlab/infra/terraform.py
+++ b/src/dsoxlab/infra/terraform.py
@@ -42,6 +42,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ..config import xdg_state_home
 from ..models.repo import ProviderUnresolved, RepoMetadata
 from ..templates import terraform_template
 from ..utils.shell import CommandError, run_command
@@ -85,10 +86,12 @@ def is_available() -> bool:
 
 
 def _xdg_state_home() -> Path:
-    env = os.environ.get("XDG_STATE_HOME")
-    if env:
-        return Path(env).expanduser().resolve()
-    return Path.home() / ".local" / "state"
+    """Alias historique : la définition vit désormais dans ``config``.
+
+    Deux copies du même chemin finissent par diverger, et un ``XDG_STATE_HOME``
+    personnalisé n'en aurait déplacé qu'une.
+    """
+    return xdg_state_home()
 
 
 def workdir(repo_meta: RepoMetadata) -> Path:

--- a/src/dsoxlab/logging_setup.py
+++ b/src/dsoxlab/logging_setup.py
@@ -1,0 +1,166 @@
+"""Journalisation : rendre visible ce que le moteur sait déjà.
+
+Onze modules du moteur écrivent dans un logger, et aucun de ces messages
+n'atteignait jamais l'utilisateur ni un fichier. Le cas le plus coûteux est
+connu : un ``lab.yaml`` qui lève au parsing est avalé par un ``logger.warning``
+puis un ``continue``. Le lab disparaît du catalogue **sans un mot**, et c'est le
+premier symptôme que rencontre un auteur, en même temps que le plus difficile à
+diagnostiquer.
+
+Trois décisions gouvernent ce module.
+
+1. **Le journal va sur stderr, jamais sur stdout.** ``list-labs --json`` doit
+   rester lisible par un programme, y compris en mode verbeux. Un octet de
+   diagnostic sur stdout casserait tout consommateur machine.
+
+2. **Le fichier est écrit même sans option.** C'est ce qui permet de joindre une
+   trace à un rapport de bug *après coup*, sans redemander à l'utilisateur de
+   reproduire. Il est borné en taille : un outil de formation n'a pas à remplir
+   un disque.
+
+3. **Aucun échec de journalisation ne fait échouer une commande.** Un HOME en
+   lecture seule, un disque plein ou un montage réseau absent ne doivent pas
+   empêcher de jouer un lab. Le journal est un confort, pas une dépendance.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from .config import xdg_state_home
+
+#: Niveau affiché sur stderr selon le nombre de ``-v``. Au-delà de deux, on
+#: reste en DEBUG : il n'existe pas de niveau plus bavard.
+_NIVEAUX = {0: logging.WARNING, 1: logging.INFO}
+
+#: Taille maximale d'un fichier de journal, et nombre d'archives conservées.
+#: 1 Mo couvre largement une session de travail ; trois archives permettent de
+#: retrouver la veille sans jamais dépasser 4 Mo.
+_TAILLE_MAX = 1_000_000
+_ARCHIVES = 3
+
+#: Variable d'environnement équivalente aux options, pour les cas où l'on ne
+#: contrôle pas la ligne de commande (script, CI, alias).
+_ENV_NIVEAU = "DSOXLAB_LOG"
+
+#: Marqueur posé sur les handlers que ce module installe, pour pouvoir les
+#: retirer sans toucher à ceux d'un programme hôte. Sans lui, une suite de tests
+#: qui appelle ``configurer()`` plusieurs fois empilerait les handlers, et
+#: chaque message apparaîtrait autant de fois.
+_MARQUEUR = "_dsoxlab_handler"
+
+
+def chemin_journal() -> Path:
+    """Le fichier de journal, sous le répertoire d'état XDG.
+
+    Volontairement **global** et non par dépôt : on veut pouvoir répondre à
+    « la dernière commande a échoué » sans savoir dans quel catalogue elle a
+    tourné, ce que l'utilisateur qui rapporte un bug ignore souvent lui-même.
+    """
+    return xdg_state_home() / "dsoxlab" / "dsoxlab.log"
+
+
+def _niveau_depuis_env() -> int | None:
+    """``DSOXLAB_LOG=debug`` vaut ``-vv``. Une valeur inconnue est ignorée.
+
+    Ignorer plutôt que lever : une variable mal orthographiée dans un ``.bashrc``
+    ne doit pas rendre la CLI inutilisable.
+    """
+    brut = os.environ.get(_ENV_NIVEAU, "").strip().lower()
+    if not brut:
+        return None
+    return {
+        "debug": logging.DEBUG,
+        "info": logging.INFO,
+        "warning": logging.WARNING,
+        "error": logging.ERROR,
+    }.get(brut)
+
+
+def _retirer_les_notres(racine: logging.Logger) -> None:
+    for handler in list(racine.handlers):
+        if getattr(handler, _MARQUEUR, False):
+            racine.removeHandler(handler)
+            handler.close()
+
+
+def _handler_fichier() -> logging.Handler | None:
+    """Le handler de fichier, ou ``None`` s'il ne peut pas être créé.
+
+    Toutes les raisons d'échouer se valent ici (répertoire non inscriptible,
+    disque plein, chemin occupé par autre chose) : aucune ne justifie de faire
+    échouer la commande que l'utilisateur a lancée.
+    """
+    chemin = chemin_journal()
+    try:
+        chemin.parent.mkdir(parents=True, exist_ok=True)
+        handler = RotatingFileHandler(
+            chemin, maxBytes=_TAILLE_MAX, backupCount=_ARCHIVES, encoding="utf-8"
+        )
+    except OSError:
+        return None
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+    )
+    return handler
+
+
+def configurer(verbosite: int = 0, *, debug: bool = False) -> None:
+    """Installe la journalisation pour toute la durée du processus.
+
+    Args:
+        verbosite: nombre de ``-v`` passés. 0 n'affiche que les avertissements,
+            1 ajoute les informations, 2 et plus ajoutent le détail.
+        debug: équivalent de ``-vv``, sous un nom qui se retient.
+    """
+    if debug:
+        verbosite = max(verbosite, 2)
+
+    niveau_console = _NIVEAUX.get(verbosite, logging.DEBUG)
+    force = _niveau_depuis_env()
+    if force is not None:
+        niveau_console = force
+
+    racine = logging.getLogger("dsoxlab")
+    _retirer_les_notres(racine)
+
+    # Le logger capte tout, ce sont les handlers qui filtrent : le fichier doit
+    # garder le DEBUG même quand la console n'affiche que les avertissements,
+    # sans quoi le journal ne servirait à rien le jour où l'on en a besoin.
+    racine.setLevel(logging.DEBUG)
+    # Ne pas remonter à la racine du logging : le handler de dernier recours de
+    # la bibliothèque standard écrirait une seconde copie de chaque message.
+    racine.propagate = False
+
+    console = logging.StreamHandler()  # stderr par défaut, et c'est voulu
+    console.setLevel(niveau_console)
+    console.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    setattr(console, _MARQUEUR, True)
+    racine.addHandler(console)
+
+    fichier = _handler_fichier()
+    if fichier is not None:
+        setattr(fichier, _MARQUEUR, True)
+        racine.addHandler(fichier)
+
+
+def dernieres_lignes(nombre: int = 40) -> list[str]:
+    """Les dernières lignes du journal, pour un rapport de diagnostic.
+
+    Rend une liste vide si le journal n'existe pas ou n'est pas lisible : un
+    rapport sans traces reste utile, une exception en produisant un ne l'est
+    pas.
+    """
+    chemin = chemin_journal()
+    try:
+        lignes = chemin.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    return lignes[-nombre:]

--- a/tests/test_journalisation.py
+++ b/tests/test_journalisation.py
@@ -1,0 +1,167 @@
+"""Le moteur savait, mais ne le disait à personne.
+
+Onze modules écrivent dans un logger. Aucun de ces messages n'atteignait
+l'utilisateur ni un fichier. Le cas le plus coûteux : un `lab.yaml` qui lève au
+parsing est avalé par un `logger.warning` puis un `continue`, donc le lab
+disparaît du catalogue sans un mot. C'est le premier symptôme que rencontre un
+auteur, et le plus difficile à diagnostiquer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dsoxlab import logging_setup
+from dsoxlab.cli import app
+
+runner = CliRunner()
+
+META = "repo:\n  id: demo\n  category: demo\n"
+
+#: Un lab.yaml qui lève au parsing : `runtime.type` doit être une chaîne.
+LAB_CASSE = "id: casse\ntitle: Casse\nlevel: l1\nruntime:\n  type: [pas, une, chaine]\n"
+
+
+@pytest.fixture
+def catalogue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Un catalogue dont un seul lab est invalide, et un état XDG isolé."""
+    (tmp_path / "meta.yml").write_text(META, encoding="utf-8")
+    casse = tmp_path / "labs" / "demo" / "l1" / "lab-casse"
+    casse.mkdir(parents=True)
+    (casse / "lab.yaml").write_text(LAB_CASSE, encoding="utf-8")
+
+    monkeypatch.setenv("LAB_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "etat"))
+    monkeypatch.delenv("DSOXLAB_LOG", raising=False)
+    return tmp_path
+
+
+def test_un_lab_yaml_invalide_ne_disparait_plus_en_silence(catalogue: Path) -> None:
+    """Le défaut d'origine : le lab s'évapore, et rien ne le signale.
+
+    Un avertissement n'est pas du bruit ici : il annonce une perte réelle de
+    contenu, que l'auteur comme l'apprenant ont besoin de voir.
+    """
+    resultat = runner.invoke(app, ["list-labs"])
+
+    assert "lab.yaml" in resultat.stderr
+    assert "lab-casse" in resultat.stderr
+
+
+def test_le_journal_est_ecrit_meme_sans_option(catalogue: Path) -> None:
+    """C'est ce qui permet de joindre une trace APRÈS coup.
+
+    Sans fichier, diagnostiquer un incident suppose de demander à l'utilisateur
+    de reproduire, avec la bonne option, ce qui coûte un aller-retour complet.
+    """
+    runner.invoke(app, ["list-labs"])
+
+    journal = catalogue / "etat" / "dsoxlab" / "dsoxlab.log"
+    assert journal.is_file()
+    assert "lab.yaml" in journal.read_text(encoding="utf-8")
+
+
+def test_le_mode_verbeux_ajoute_le_detail(catalogue: Path) -> None:
+    """`-vv` fait remonter le DEBUG, que le niveau par défaut retient."""
+    normal = runner.invoke(app, ["list-labs"])
+    bavard = runner.invoke(app, ["-vv", "list-labs"])
+
+    assert len(bavard.stderr) >= len(normal.stderr)
+
+
+def test_la_sortie_json_reste_lisible_par_un_programme(catalogue: Path) -> None:
+    """Le contrat qui interdit d'écrire les logs sur stdout.
+
+    Un seul octet de diagnostic sur la sortie standard casserait tout
+    consommateur machine, et c'est précisément en mode verbeux qu'on serait
+    tenté d'en ajouter.
+    """
+    resultat = runner.invoke(app, ["-vv", "list-labs", "--json"])
+
+    charge = json.loads(resultat.stdout)
+    assert "labs" in charge
+    # Le diagnostic doit bien exister quelque part : sinon ce test passerait
+    # aussi sur une version qui n'écrit rien du tout.
+    assert "lab.yaml" in resultat.stderr
+
+
+def test_la_variable_d_environnement_regle_le_niveau(
+    catalogue: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pour les cas où l'on ne contrôle pas la ligne de commande."""
+    monkeypatch.setenv("DSOXLAB_LOG", "debug")
+    logging_setup.configurer(0)
+
+    assert logging.getLogger("dsoxlab").isEnabledFor(logging.DEBUG)
+
+    # On identifie NOS handlers par leur marqueur, pas par leur type : pytest
+    # attache ses propres LogCaptureHandler à ce logger, et ils héritent eux
+    # aussi de StreamHandler. C'est précisément à quoi sert ce marqueur, et
+    # c'est ce qui permet à `configurer()` de ne retirer que les siens.
+    notres = [
+        h for h in logging.getLogger("dsoxlab").handlers
+        if getattr(h, logging_setup._MARQUEUR, False)
+    ]
+    console = [h for h in notres if not isinstance(h, logging.FileHandler)]
+    assert console and console[0].level == logging.DEBUG
+
+
+def test_une_valeur_d_environnement_absurde_est_ignoree(
+    catalogue: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Une faute de frappe dans un .bashrc ne doit pas casser la CLI."""
+    monkeypatch.setenv("DSOXLAB_LOG", "trace-moi-tout")
+    logging_setup.configurer(0)
+
+    resultat = runner.invoke(app, ["list-labs"])
+    assert resultat.exit_code == 0
+
+
+def test_configurer_deux_fois_n_empile_pas_les_handlers(catalogue: Path) -> None:
+    """Sinon chaque message apparaîtrait autant de fois qu'il y a eu d'appels."""
+    logging_setup.configurer(1)
+    apres_un = len(logging.getLogger("dsoxlab").handlers)
+    logging_setup.configurer(1)
+    apres_deux = len(logging.getLogger("dsoxlab").handlers)
+
+    assert apres_un == apres_deux
+
+
+def test_un_journal_impossible_a_ecrire_ne_casse_rien(
+    catalogue: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Un HOME en lecture seule ne doit pas empêcher de jouer un lab.
+
+    Le journal est un confort, jamais une dépendance.
+    """
+    def _refuse(*args: object, **kwargs: object) -> None:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(Path, "mkdir", _refuse)
+    logging_setup.configurer(0)
+
+    resultat = runner.invoke(app, ["list-labs"])
+    assert resultat.exit_code == 0
+
+
+def test_les_dernieres_lignes_sont_lisibles(catalogue: Path) -> None:
+    """Matière du futur `dsoxlab support` (#75)."""
+    runner.invoke(app, ["list-labs"])
+
+    lignes = logging_setup.dernieres_lignes(5)
+    assert lignes
+    assert any("lab.yaml" in ligne for ligne in lignes)
+
+
+def test_les_dernieres_lignes_sans_journal_rendent_une_liste_vide(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Un rapport sans traces reste utile ; une exception en produisant un, non."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "vide"))
+
+    assert logging_setup.dernieres_lignes() == []

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.43"
+version = "0.1.44"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Closes #74

# Summary

Onze modules du moteur écrivent dans un logger. **Aucun de ces messages n'atteignait jamais un utilisateur ni un fichier.**

Le cas le plus coûteux est connu : un `lab.yaml` qui lève au parsing est avalé par un `logger.warning` puis un `continue`, donc le lab disparaît du catalogue **sans un mot**. C'est le premier symptôme que rencontre un auteur de catalogue, et le plus difficile à diagnostiquer.

Avant / après, sur un catalogue dont un lab est invalide :

```console
$ dsoxlab list-labs          # avant : le lab n'existe plus, rien ne le dit

$ dsoxlab list-labs          # après
WARNING dsoxlab.discovery.scanner: lab.yaml ignoré (…/lab-casse/lab.yaml) :
['pas', 'une', 'chaine'] is not a valid RuntimeType
```

## Un écart assumé au critère d'acceptation

L'issue demandait que le message reste **silencieux sans l'option**, et n'apparaisse qu'en mode verbeux. J'ai fait l'inverse, et je préfère le dire plutôt que de le glisser.

Un lab disparu n'est pas du bruit : c'est une perte réelle de contenu. L'auteur doit la voir pour la corriger, et l'apprenant doit la voir pour comprendre pourquoi un lab annoncé n'apparaît pas. Le réserver à `-v` laisserait le défaut entier pour tous ceux qui ne connaissent pas l'option, c'est-à-dire exactement ceux qui en ont besoin. C'est aussi le comportement standard de `logging` : `WARNING` est visible par défaut.

`-v` ajoute l'informatif, `-vv` (ou `--debug`) le détail complet, `DSOXLAB_LOG=debug` fait de même là où la ligne de commande échappe.

## Le contrat que rien ne doit casser

Le diagnostic part sur **stderr**, jamais sur stdout. Un seul octet sur la sortie standard casserait tout consommateur de `--json`, et c'est précisément en mode verbeux qu'on serait tenté d'en ajouter.

```console
$ dsoxlab -vv list-labs --json 2>/dev/null | python3 -c "import json,sys; json.load(sys.stdin)"
   ✔ JSON valide
```

Un test l'épingle, en vérifiant **aussi** que le diagnostic existe bien sur stderr : sans cette seconde moitié, il passerait sur une version qui n'écrit rien du tout.

## Le journal, et pourquoi il est toujours écrit

`~/.local/state/dsoxlab/dsoxlab.log`, rotation à 1 Mo et trois archives, **quelle que soit l'option**. C'est ce qui permettra de joindre une trace à un rapport de bug *après coup*, au lieu de demander à l'utilisateur de reproduire avec le bon drapeau, ce qui coûte un aller-retour complet. C'est aussi la matière de `dsoxlab support` (#75).

Il est best-effort : un HOME en lecture seule ou un disque plein ne fait jamais échouer la commande. Le journal est un confort, pas une dépendance, et un test le vérifie en rendant `Path.mkdir` impossible.

## Un test qui a demandé une correction instructive

Ma première version identifiait les handlers par leur **type**. Elle passait seule et échouait dans la suite : **pytest attache ses propres `LogCaptureHandler` à ce logger**, et ils héritent eux aussi de `StreamHandler`.

C'est exactement pourquoi le module marque les siens, et pourquoi `configurer()` ne retire que ceux-là plutôt que de vider la liste : un programme hôte peut légitimement avoir attaché les siens.

## Au passage

`xdg_state_home()` devient public dans `config.py`, et `terraform.py` cesse d'en porter une copie. Deux définitions du même chemin finissent par diverger, et un `XDG_STATE_HOME` personnalisé n'en aurait déplacé qu'une.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `ruff check src/dsoxlab tests` passes
- [x] `mypy src/dsoxlab` passes (strict) : `Success: no issues found in 49 source files`
- [x] `pytest` passes : **268 passed** (258 avant, soit **+10 tests**)
- [x] The engine stays domain-agnostic : le module de journalisation ne connaît ni catalogue ni domaine
- [x] No hardcoded personal path or host ; `pathlib.Path` throughout, chemin d'état résolu par XDG
- [x] Manually tested against **two** lab repositories : `terraform-training` (87 labs) et `linux-dsoxlab-training` (diagnostic complet), plus un catalogue de démonstration créé pour l'occasion avec un `lab.yaml` volontairement invalide

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.43 → 0.1.44) and `uv.lock` refreshed

### When a command or option is added, removed or changed

- [x] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py` (`opt_verbose`, `opt_debug` ; parité vérifiée : 339 clés de chaque côté, écart nul)
- [x] `help=_("…")` in `cli.py` **et** section `fullhelp` mise à jour en EN et FR : un bloc « Options globales » y décrit `-v`, `--debug`, `--version`, l'emplacement du journal et la garantie sur stdout
- [x] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr` (rendu du `fullhelp` vérifié dans les deux langues)

### When `.github/workflows/` is touched

**N/A** : aucun workflow modifié.

### When the declarative contract changes

**N/A** : le contrat déclaratif est inchangé. Cette PR rend visible un message qui existait déjà lorsqu'un `lab.yaml` viole le contrat ; elle ne change ni les champs, ni leur validation, ni le comportement de repli (le lab est toujours ignoré, jamais fatal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
