### PR TITLE
feat(cli): dsoxlab support, le rapport que l'on ne redemande plus

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,12 +27,26 @@ body:
         3. ...
     validations:
       required: true
-  - type: input
-    id: version
+  - type: textarea
+    id: support
     attributes:
-      label: dsoxlab version
-      description: Output of `dsoxlab --version`.
-      placeholder: dsoxlab 0.1.0
+      label: Diagnostic report
+      description: >-
+        Output of `dsoxlab support`. It gathers the version, the system, the
+        external tools, the catalog and the latest log lines in one block, and
+        it is anonymised by default: no personal path, no public address, no
+        machine name. If dsoxlab does not even start, paste `dsoxlab --version`
+        and your OS instead, and say what happened.
+      render: markdown
+      placeholder: |
+        ## dsoxlab support
+
+        ### Environnement
+
+        | | |
+        |---|---|
+        | dsoxlab | 0.1.44 |
+        ...
     validations:
       required: true
   - type: input

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -13,6 +13,24 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- **`dsoxlab support` : un rapport de diagnostic prêt à coller dans une issue.**
+  Répondre à « ça ne marche pas » supposait de redemander la version, le
+  système, le provider, le catalogue, l'état de chaque dépendance. Chaque
+  aller-retour coûte une journée, et l'outil connaissait déjà toutes les
+  réponses. La commande les rassemble d'un bloc en Markdown, avec `--json` pour
+  le même contenu en document machine.
+
+  **Anonymisé par défaut, et testé comme tel**, parce que ce rapport est fait
+  pour être collé publiquement : le répertoire personnel devient `~`, le nom
+  d'utilisateur devient `<user>`, les adresses IPv4 publiques deviennent `<ip>`,
+  et le nom de machine n'est tout simplement jamais collecté. Les adresses
+  privées restent lisibles délibérément : `10.10.30.11` est une VM de lab, elle
+  ne désigne personne hors du réseau local, et la masquer rendrait inexploitable
+  tout rapport portant sur l'infrastructure.
+
+  Le gabarit d'issue et les deux `CONTRIBUTING` demandent désormais ce rapport
+  plutôt que trois champs à recopier à la main.
+
 - **`--verbose` / `-v`, `--debug`, et un journal persistant.** Onze modules du
   moteur écrivent dans un logger, et aucun de ces messages n'atteignait jamais
   un utilisateur ni un fichier. Le cas le plus coûteux est connu : un `lab.yaml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`dsoxlab support`: a diagnostic report ready to paste into an issue.**
+  Answering "it does not work" meant asking back for the version, the system,
+  the provider, the catalog, the state of every dependency. Each round trip
+  costs a day, and the tool already knew all of it. The command gathers it in
+  one Markdown block, with `--json` for the same content as a machine document.
+
+  **Anonymised by default, and tested as such**, because this report is meant to
+  be pasted publicly: the home directory becomes `~`, the user name becomes
+  `<user>`, public IPv4 addresses become `<ip>`, and the machine name is simply
+  never collected. Private addresses stay readable on purpose: `10.10.30.11` is
+  a lab VM, it identifies nobody outside the local network, and hiding it would
+  make every infrastructure report useless.
+
+  The bug report template and both `CONTRIBUTING` files now ask for this report
+  instead of three fields to copy by hand.
+
 - **`--verbose` / `-v`, `--debug`, and a persistent log.** Eleven engine modules
   write to a logger, and none of those messages ever reached a user or a file.
   The costliest case is known: a `lab.yaml` that raises while parsing is

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -207,7 +207,14 @@ consultez `git log --oneline -5` pour coller au style.
 
 ## Signaler un bug ou demander une fonctionnalité
 
-Utilisez les gabarits d'issue GitHub. Pour un bug, indiquez la sortie de
-`dsoxlab --version`, votre OS, la commande exacte, et l'écart entre le
-comportement attendu et observé. Pour un problème de sécurité, suivez plutôt
+Utilisez les gabarits d'issue GitHub. Pour un bug, lancez `dsoxlab support` et
+collez sa sortie : elle rassemble d'un bloc la version, le système, les outils
+externes, le catalogue et les dernières lignes de journal, ce qui évite un
+aller-retour qui coûte sinon une journée. Le rapport est anonymisé par défaut,
+il ne porte donc ni chemin personnel, ni adresse publique, ni nom de machine ;
+`dsoxlab support --json` rend le même contenu pour un programme.
+
+Ajoutez la commande exacte jouée, et l'écart entre le comportement attendu et
+observé. Si dsoxlab ne démarre pas du tout, `dsoxlab --version` et votre OS
+suffisent. Pour un problème de sécurité, suivez plutôt
 [SECURITY.md](./SECURITY.md) au lieu d'ouvrir une issue publique.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,14 @@ Keep commits focused and the history readable. Before a grouped commit, check
 
 ## Reporting bugs and requesting features
 
-Use the GitHub issue templates. For bugs, include the `dsoxlab --version`
-output, your OS, the exact command, and what you expected versus what happened.
+Use the GitHub issue templates. For bugs, run `dsoxlab support` and paste its
+output: it gathers the version, the system, the external tools, the catalog and
+the latest log lines in one block, which saves a round trip that otherwise costs
+a day. The report is anonymised by default, so it carries no personal path, no
+public address and no machine name; `dsoxlab support --json` produces the same
+content for a program.
+
+Add the exact command you ran, and what you expected versus what happened. If
+dsoxlab does not start at all, `dsoxlab --version` and your OS are enough.
 For security issues, follow [SECURITY.md](./SECURITY.md) instead of opening a
 public issue.

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -2209,6 +2209,31 @@ def instructor_bootstrap(
         raise typer.Exit(1)
 
 
+# ── support ───────────────────────────────────────────────────────────────────
+
+@app.command("support", help=_("cmd_support_help"))
+def support(
+    as_json: Annotated[bool, typer.Option("--json", help=_("opt_json"))] = False,
+    lignes: Annotated[
+        int, typer.Option("--log-lines", help=_("opt_support_log_lines"))
+    ] = 30,
+) -> None:
+    """Rapport de diagnostic anonymisé, prêt à coller dans une issue."""
+    from .services.support import collecter, en_markdown
+
+    rapport = collecter(lignes_journal=max(0, lignes))
+
+    if as_json:
+        machine.emit(rapport)
+        return
+
+    # `print` et non la console Rich : ce texte est fait pour être copié dans
+    # une issue. Rich l'habillerait de couleurs et le couperait à la largeur du
+    # terminal, ce qui casserait les tableaux Markdown une fois collés.
+    print(en_markdown(rapport))
+    info(_("support_hint"))
+
+
 # ── fullhelp ──────────────────────────────────────────────────────────────────
 
 @app.command("fullhelp", help=_("cmd_fullhelp_help"))

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -91,6 +91,13 @@ STRINGS: dict[str, str] = {
     "opt_debug":      "Same as -vv. The full log is written to ~/.local/state/dsoxlab/dsoxlab.log either way.",
     "opt_version_help":   "Show the dsoxlab version and exit.",
     "cmd_install_help":   "Install the dsoxlab wrapper in ~/.local/bin and shell auto-completion.",
+    "cmd_support_help":
+        "Produce an anonymised diagnostic report, ready to paste into an issue.",
+    "opt_support_log_lines":
+        "How many log lines to include (0 to include none).",
+    "support_hint":
+        "Paste this report into your issue. It carries no personal path, no "
+        "public address and no machine name.",
     "cmd_fullhelp_help":  "Show the complete platform guide (concepts, workflow, commands).",
     "cmd_provision_help": "Provision the lab infrastructure (terraform apply on the current provider).",
     "cmd_destroy_help":   "Destroy the lab infrastructure (terraform destroy).",
@@ -286,6 +293,12 @@ Each lab exposes:
 
   [cyan]install[/cyan]              Install dsoxlab in [bold]~/.local/bin[/bold] + shell auto-completion.
                        Supports bash and zsh. Reload your shell after running.
+
+  [cyan]support[/cyan]              Diagnostic report to paste into an issue:
+                       versions, tools, catalog, latest traces. Anonymised by
+                       default (no personal path, no public address).
+    [dim]--json[/dim]               The same content, as a machine document.
+    [dim]--log-lines <n>[/dim]      How many log lines to include (0 for none).
 
   [cyan]fullhelp[/cyan]             This guide.
 

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -91,6 +91,13 @@ STRINGS: dict[str, str] = {
     "opt_debug":      "Équivaut à -vv. Le journal complet est de toute façon écrit dans ~/.local/state/dsoxlab/dsoxlab.log.",
     "opt_version_help":   "Affiche la version de dsoxlab et quitte.",
     "cmd_install_help":   "Installe le wrapper dsoxlab dans ~/.local/bin et l'auto-complétion shell.",
+    "cmd_support_help":
+        "Produit un rapport de diagnostic anonymisé, à coller dans une issue.",
+    "opt_support_log_lines":
+        "Nombre de lignes de journal à joindre (0 pour n'en joindre aucune).",
+    "support_hint":
+        "Collez ce rapport dans votre issue. Il ne contient ni chemin personnel, "
+        "ni adresse publique, ni nom de machine.",
     "cmd_fullhelp_help":  "Affiche le guide complet de la plateforme (concepts, workflow, commandes).",
     "cmd_provision_help": "Provisionne l'infrastructure du lab (terraform apply sur le provider courant).",
     "cmd_destroy_help":   "Détruit l'infrastructure du lab (terraform destroy).",
@@ -284,6 +291,12 @@ Chaque lab expose :
 
   [cyan]install[/cyan]              Installe dsoxlab dans [bold]~/.local/bin[/bold] + auto-complétion shell.
                        Supporte bash et zsh. Rechargez le shell après exécution.
+
+  [cyan]support[/cyan]              Rapport de diagnostic à coller dans une issue :
+                       versions, outils, catalogue, dernières traces. Anonymisé
+                       par défaut (ni chemin personnel, ni adresse publique).
+    [dim]--json[/dim]               Le même contenu, en document machine.
+    [dim]--log-lines <n>[/dim]      Nombre de lignes de journal jointes (0 pour aucune).
 
   [cyan]fullhelp[/cyan]             Ce guide.
 

--- a/src/dsoxlab/services/support.py
+++ b/src/dsoxlab/services/support.py
@@ -1,0 +1,201 @@
+"""Le rapport de diagnostic à coller dans une issue.
+
+Quand quelqu'un écrit « ça ne marche pas », il faut lui redemander sa version,
+son système, son provider, son catalogue, l'état de ses dépendances. Chaque
+aller-retour coûte une journée, et l'outil connaît déjà toutes ces réponses.
+
+**Ce rapport est destiné à être collé publiquement.** L'anonymisation n'est donc
+pas une option de confort : elle est appliquée par défaut et testée. Un chemin
+absolu suffit à publier le nom de famille de quelqu'un, un nom d'hôte à
+identifier une machine d'entreprise.
+
+Ce qui n'est PAS anonymisé, et pourquoi : les adresses privées (10.x, 192.168.x,
+172.16-31.x) restent lisibles. Ce sont celles des VM de lab, elles ne désignent
+personne hors du réseau local, et les masquer rendrait inexploitable tout
+rapport portant sur l'infrastructure, c'est-à-dire la moitié d'entre eux.
+"""
+
+from __future__ import annotations
+
+import getpass
+import ipaddress
+import os
+import platform
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .. import __version__
+from ..config import get_lab_home, read_context, xdg_state_home
+from ..discovery.repo import read_repo_metadata
+from ..logging_setup import chemin_journal, dernieres_lignes
+from .lab_service import get_all_labs
+
+#: Outils externes dont la présence et la version changent le diagnostic.
+#: L'ordre est celui du parcours : provisionner, configurer, se connecter.
+_OUTILS = (
+    ("terraform", ("terraform", "version")),
+    ("ansible-playbook", ("ansible-playbook", "--version")),
+    ("virsh", ("virsh", "--version")),
+    ("incus", ("incus", "--version")),
+    ("docker", ("docker", "--version")),
+    ("ssh", ("ssh", "-V")),
+    ("git", ("git", "--version")),
+    ("uv", ("uv", "--version")),
+)
+
+_IPV4 = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+
+
+def _est_privee(brut: str) -> bool:
+    try:
+        adresse = ipaddress.ip_address(brut)
+    except ValueError:
+        return False
+    return adresse.is_private or adresse.is_loopback or adresse.is_link_local
+
+
+def anonymiser(texte: str) -> str:
+    """Retire d'un texte ce qui désigne une personne ou une machine.
+
+    Trois substitutions, dans cet ordre : le répertoire personnel devient ``~``,
+    le nom d'utilisateur devient ``<user>``, et toute adresse IPv4 **publique**
+    devient ``<ip>``. Le nom d'hôte est traité par l'appelant, qui ne le collecte
+    tout simplement pas.
+    """
+    if not texte:
+        return texte
+
+    maison = str(Path.home())
+    if maison and maison != "/":
+        texte = texte.replace(maison, "~")
+
+    try:
+        utilisateur = getpass.getuser()
+    except (KeyError, OSError):
+        utilisateur = ""
+    if utilisateur and len(utilisateur) > 2:
+        # Un nom très court produirait des remplacements au milieu de mots
+        # ordinaires, et rendrait le rapport illisible sans rien protéger.
+        texte = re.sub(rf"\b{re.escape(utilisateur)}\b", "<user>", texte)
+
+    return _IPV4.sub(
+        lambda m: m.group(0) if _est_privee(m.group(0)) else "<ip>", texte
+    )
+
+
+def _version_outil(commande: tuple[str, ...]) -> str | None:
+    """Première ligne utile de la sortie de version, ou None si absent.
+
+    ``ssh -V`` écrit sur stderr, ``docker --version`` sur stdout : on lit les
+    deux plutôt que de tenir une table des exceptions.
+    """
+    if shutil.which(commande[0]) is None:
+        return None
+    try:
+        proc = subprocess.run(
+            list(commande), capture_output=True, text=True, timeout=5, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "présent, version illisible"
+    sortie = (proc.stdout or "") + (proc.stderr or "")
+    lignes = [ligne.strip() for ligne in sortie.splitlines() if ligne.strip()]
+    return lignes[0][:120] if lignes else "présent, version illisible"
+
+
+def _distribution() -> str:
+    """La distribution, lue dans os-release. Le nom d'hôte n'y figure pas."""
+    try:
+        contenu = Path("/etc/os-release").read_text(encoding="utf-8")
+    except OSError:
+        return platform.platform(terse=True)
+    for ligne in contenu.splitlines():
+        if ligne.startswith("PRETTY_NAME="):
+            return ligne.split("=", 1)[1].strip().strip('"')
+    return platform.platform(terse=True)
+
+
+def collecter(*, lignes_journal: int = 30) -> dict[str, Any]:
+    """Rassemble le rapport. Aucune section ne peut faire échouer les autres.
+
+    Un diagnostic qui lève en cherchant à diagnostiquer est le pire des cas :
+    il survient justement quand l'environnement est cassé, c'est-à-dire quand
+    on en a le plus besoin.
+    """
+    rapport: dict[str, Any] = {
+        "dsoxlab": __version__,
+        "python": f"{platform.python_version()} ({platform.python_implementation()})",
+        "systeme": f"{platform.system()} {platform.release()}",
+        "distribution": _distribution(),
+        "architecture": platform.machine(),
+        "shell": Path(os.environ.get("SHELL", "")).name or "inconnu",
+    }
+
+    rapport["outils"] = {
+        nom: _version_outil(cmd) or "absent" for nom, cmd in _OUTILS
+    }
+
+    catalogue: dict[str, Any] = {}
+    try:
+        racine = get_lab_home()
+        catalogue["racine"] = anonymiser(str(racine))
+        contexte = read_context(racine)
+        catalogue["section_active"] = contexte.section
+        catalogue["lab_actif"] = contexte.active_lab
+        meta = read_repo_metadata(racine)
+        if meta is not None:
+            catalogue["id"] = meta.id
+            catalogue["categorie"] = meta.category
+            catalogue["provider_actif"] = meta.infra.provider or None
+            catalogue["providers_declares"] = list(meta.infra.providers_available)
+            catalogue["hotes_declares"] = len(meta.infra.hosts)
+        labs = get_all_labs(racine)
+        catalogue["labs_decouverts"] = len(labs)
+        catalogue["labs_vm"] = sum(
+            1 for lab in labs if lab.runtime.type.value in ("vm", "kvm", "incus")
+        )
+    except Exception as exc:  # noqa: BLE001 : un rapport partiel vaut mieux que rien
+        catalogue["erreur"] = anonymiser(f"{type(exc).__name__}: {exc}")
+    rapport["catalogue"] = catalogue
+
+    rapport["etat"] = {
+        "xdg_state": anonymiser(str(xdg_state_home() / "dsoxlab")),
+        "journal": anonymiser(str(chemin_journal())),
+    }
+    rapport["journal"] = [anonymiser(ligne) for ligne in dernieres_lignes(lignes_journal)]
+    return rapport
+
+
+def _tableau(titre: str, valeurs: dict[str, Any]) -> list[str]:
+    lignes = [f"### {titre}", "", "| | |", "|---|---|"]
+    for cle, valeur in valeurs.items():
+        rendu = "aucun" if valeur is None else valeur
+        if isinstance(rendu, list):
+            rendu = ", ".join(str(x) for x in rendu) or "aucun"
+        lignes.append(f"| {cle} | {rendu} |")
+    lignes.append("")
+    return lignes
+
+
+def en_markdown(rapport: dict[str, Any]) -> str:
+    """Le rapport prêt à coller dans une issue, sans retouche."""
+    general = {
+        cle: rapport[cle]
+        for cle in ("dsoxlab", "python", "systeme", "distribution",
+                    "architecture", "shell")
+    }
+    lignes = ["## dsoxlab support", ""]
+    lignes += _tableau("Environnement", general)
+    lignes += _tableau("Outils externes", rapport["outils"])
+    lignes += _tableau("Catalogue", rapport["catalogue"])
+    lignes += _tableau("Emplacements", rapport["etat"])
+
+    journal = rapport.get("journal") or []
+    lignes += ["### Dernières lignes du journal", ""]
+    if journal:
+        lignes += ["```", *journal, "```", ""]
+    else:
+        lignes += ["_Aucune trace enregistrée._", ""]
+    return "\n".join(lignes)

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -1,0 +1,175 @@
+"""Le rapport de diagnostic, et surtout ce qu'il ne doit jamais contenir.
+
+Ce rapport est fait pour être collé publiquement dans une issue. L'anonymisation
+n'est donc pas un confort : un chemin absolu suffit à publier le nom de famille
+de quelqu'un, un nom d'hôte à identifier une machine d'entreprise.
+
+Les tests qui comptent ici sont ceux qui vérifient une ABSENCE.
+"""
+
+from __future__ import annotations
+
+import getpass
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dsoxlab.cli import app
+from dsoxlab.services import support
+
+runner = CliRunner()
+
+META = "repo:\n  id: demo\n  category: demo\n"
+
+
+@pytest.fixture
+def catalogue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    (tmp_path / "meta.yml").write_text(META, encoding="utf-8")
+    monkeypatch.setenv("LAB_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "etat"))
+    return tmp_path
+
+
+# ── anonymisation : ce que le rapport ne doit jamais porter ───────────────────
+
+def test_le_repertoire_personnel_devient_un_tilde() -> None:
+    texte = f"le lab est dans {Path.home()}/Projets/mon-catalogue"
+
+    assert str(Path.home()) not in support.anonymiser(texte)
+    assert "~/Projets/mon-catalogue" in support.anonymiser(texte)
+
+
+def test_le_nom_d_utilisateur_disparait() -> None:
+    """Un chemin ne portant pas le HOME peut tout de même porter le nom.
+
+    Le cas courant : /srv/formations/<user>/labs, ou une trace de commande.
+    """
+    utilisateur = getpass.getuser()
+    if len(utilisateur) <= 2:
+        pytest.skip("nom trop court pour être substitué sans casser le texte")
+
+    texte = f"/srv/formations/{utilisateur}/labs et sudo -u {utilisateur} virsh"
+    anonyme = support.anonymiser(texte)
+
+    assert utilisateur not in anonyme
+    assert anonyme.count("<user>") == 2
+
+
+def test_les_adresses_publiques_sont_masquees() -> None:
+    texte = "connexion vers 93.184.216.34 puis vers 8.8.8.8"
+    anonyme = support.anonymiser(texte)
+
+    assert "93.184.216.34" not in anonyme
+    assert "8.8.8.8" not in anonyme
+    assert anonyme.count("<ip>") == 2
+
+
+def test_les_adresses_privees_restent_lisibles() -> None:
+    """Masquer les IP de lab rendrait inexploitable tout rapport d'infra.
+
+    10.10.30.11 ne désigne personne hors du réseau local, et c'est précisément
+    l'information dont on a besoin pour diagnostiquer un provisionnement.
+    """
+    texte = "alma-rhcsa-1 a pris 10.10.30.11, bridge en 192.168.122.1, boucle 127.0.0.1"
+    anonyme = support.anonymiser(texte)
+
+    assert "10.10.30.11" in anonyme
+    assert "192.168.122.1" in anonyme
+    assert "127.0.0.1" in anonyme
+    assert "<ip>" not in anonyme
+
+
+def test_une_chaine_vide_ne_leve_pas() -> None:
+    assert support.anonymiser("") == ""
+
+
+# ── le rapport complet ────────────────────────────────────────────────────────
+
+def test_le_rapport_ne_porte_aucun_chemin_personnel(catalogue: Path) -> None:
+    """Le contrôle qui vaut pour tout le reste : on relit le rapport entier."""
+    rapport = support.collecter()
+    rendu = support.en_markdown(rapport) + json.dumps(rapport, ensure_ascii=False)
+
+    assert str(Path.home()) not in rendu, (
+        "un chemin absolu dans un rapport destiné à une issue publie le HOME"
+    )
+
+    utilisateur = getpass.getuser()
+    if len(utilisateur) > 2:
+        assert utilisateur not in rendu
+
+
+def test_le_rapport_nomme_les_outils_manquants_sans_en_faire_une_erreur(
+    catalogue: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Une absence normale reste une absence, pas un échec.
+
+    Un catalogue entièrement `shell` n'a besoin ni de terraform ni d'incus :
+    les afficher comme des erreurs reproduirait le défaut que `doctor` a mis
+    des versions à corriger.
+    """
+    monkeypatch.setattr(support.shutil, "which", lambda nom: None)
+
+    rapport = support.collecter()
+
+    assert set(rapport["outils"].values()) == {"absent"}
+    assert "erreur" not in rapport["outils"]
+
+
+def test_le_rapport_survit_a_un_catalogue_illisible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Un diagnostic qui lève en diagnostiquant est le pire des cas.
+
+    Il survient justement quand l'environnement est cassé, c'est-à-dire quand
+    on en a le plus besoin.
+    """
+    (tmp_path / "meta.yml").write_text("repo: [ceci nest pas: un mapping\n", encoding="utf-8")
+    monkeypatch.setenv("LAB_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "etat"))
+
+    rapport = support.collecter()
+
+    assert rapport["dsoxlab"]
+    assert "catalogue" in rapport
+
+
+def test_le_journal_est_joint_et_bornable(catalogue: Path) -> None:
+    runner.invoke(app, ["list-labs"])
+
+    avec = support.collecter(lignes_journal=5)
+    sans = support.collecter(lignes_journal=0)
+
+    assert len(avec["journal"]) <= 5
+    assert sans["journal"] == []
+
+
+# ── les deux sorties de la commande ───────────────────────────────────────────
+
+def test_la_commande_rend_du_markdown_collable(catalogue: Path) -> None:
+    resultat = runner.invoke(app, ["support"])
+
+    assert resultat.exit_code == 0
+    assert "## dsoxlab support" in resultat.stdout
+    assert "| dsoxlab |" in resultat.stdout
+
+
+def test_la_sortie_json_ne_contient_que_du_json(catalogue: Path) -> None:
+    """Un « ℹ » en tête de flux rendrait le document illisible pour l'appelant."""
+    resultat = runner.invoke(app, ["support", "--json"])
+
+    charge = json.loads(resultat.stdout)
+    assert charge["schema"] == 1
+    assert charge["dsoxlab"]
+    assert "outils" in charge and "catalogue" in charge
+
+
+def test_les_deux_sorties_portent_le_meme_contenu(catalogue: Path) -> None:
+    """Sinon l'une des deux finirait par mentir, et ce serait la moins lue."""
+    markdown = runner.invoke(app, ["support"]).stdout
+    charge = json.loads(runner.invoke(app, ["support", "--json"]).stdout)
+
+    assert charge["dsoxlab"] in markdown
+    assert charge["architecture"] in markdown


### PR DESCRIPTION
Closes #75

# Summary

Répondre à « ça ne marche pas » suppose de redemander la version, le système, le provider, le catalogue, l'état de chaque dépendance. Chaque aller-retour coûte une journée, **et l'outil connaissait déjà toutes les réponses**.

```console
$ dsoxlab support
## dsoxlab support

### Environnement
| dsoxlab | 0.1.44 |
| distribution | Ubuntu 24.04.2 LTS |
| shell | zsh |

### Outils externes
| terraform | Terraform v1.15.4 |
| ansible-playbook | ansible-playbook [core 2.21.3] |
| virsh | 10.0.0 |
| docker | Docker version 29.1.3 |

### Catalogue
| racine | ~/Projets/linux-dsoxlab-training |
| provider_actif | kvm |
| labs_decouverts | 84 |
| labs_vm | 64 |
```

Plus les dernières lignes du journal, que la 0.1.44 conserve déjà : c'est ce qui permet de joindre une trace **sans demander de reproduire**.

## L'anonymisation n'est pas un confort

Ce rapport est fait pour être collé publiquement. Un chemin absolu suffit à publier le nom de famille de quelqu'un, un nom d'hôte à identifier une machine d'entreprise.

| Donnée | Traitement |
|---|---|
| Répertoire personnel | devient `~` |
| Nom d'utilisateur | devient `<user>` |
| Adresse IPv4 **publique** | devient `<ip>` |
| Nom de machine | jamais collecté |

**Ce qui reste lisible, et pourquoi** : les adresses privées. `10.10.30.11` est une VM de lab, elle ne désigne personne hors du réseau local, et la masquer rendrait inexploitable tout rapport portant sur l'infrastructure, c'est-à-dire la moitié d'entre eux.

Quatre tests le vérifient, dont un qui relit le rapport entier, Markdown et JSON confondus. **Mutation jouée** : en neutralisant `anonymiser()`, quatre tests tombent, dont celui-là.

## Deux règles de robustesse

**Aucune section ne peut faire échouer les autres.** Un `meta.yml` illisible produit un rapport partiel avec la cause, jamais une exception. Un diagnostic qui lève en cherchant à diagnostiquer survient justement quand l'environnement est cassé, c'est-à-dire quand on en a le plus besoin.

**Une absence normale reste une absence.** Un outil manquant est noté `absent`, pas signalé en erreur : c'est la règle que `doctor` a mis des versions à établir, et il n'y a pas de raison de la défaire ici.

## Là où on en a besoin

Le gabarit d'issue demandait trois champs à recopier à la main (version, OS, runtime). Le champ `version` est remplacé par un champ `Diagnostic report` qui accueille la sortie de la commande, avec un repli explicite pour qui ne peut pas la lancer. Les deux `CONTRIBUTING` suivent.

## Vérification, sur les **trois** catalogues

Vous m'avez fait remarquer que je ne validais que sur deux. `ansible-training` n'entrait dans aucune validation jusqu'ici, alors que c'est le plus gros catalogue et le seul à mêler massivement labs `vm` et `shell`.

| Catalogue | `lab.yaml` sur disque | Découverts | `validate-structure` | `support --json` |
|---|---|---|---|---|
| `linux-dsoxlab-training` | 84 | **84** | vert | 84 labs, id correct |
| `ansible-training` | 113 | **113** | vert | 113 labs, id correct |
| `terraform-training` | 87 | **87** | vert | 87 labs, id correct |

L'égalité disque/découverts est le contrôle qui compte : un `lab.yaml` qui lève au parsing disparaît sans un mot.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `ruff check src/dsoxlab tests` passes
- [x] `mypy src/dsoxlab` passes (strict) : `Success: no issues found in 50 source files`
- [x] `pytest` passes : **276 passed, 4 skipped** (268 avant, soit **+12 tests**)
- [x] The engine stays domain-agnostic : le rapport lit le contrat (`meta.yml`), il ne connaît ni Linux, ni Ansible, ni Terraform
- [x] No hardcoded personal path or host ; `pathlib.Path` throughout, et c'est même l'objet du module que d'en retirer
- [x] Manually tested against **three** lab repositories (tableau ci-dessus)

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated (l'entrée 0.1.44 accueille cette commande aux côtés du journal, les deux étant indissociables)
- [x] Version : **déjà portée à 0.1.44** par la PR #115, non encore publiée. `uv.lock` est aligné. Publier `support` sans le journal n'aurait aucun sens, ils sortiront ensemble.

### When a command or option is added, removed or changed

- [x] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py` (`cmd_support_help`, `opt_support_log_lines`, `support_hint` ; parité vérifiée : 342 clés de chaque côté, écart nul)
- [x] `help=_("…")` in `cli.py` **et** section `fullhelp` mise à jour en EN et FR, rendu vérifié dans les deux langues
- [x] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched

**N/A** : `.github/ISSUE_TEMPLATE/bug_report.yml` n'est pas un workflow. Aucun fichier de `.github/workflows/` n'est modifié, donc ni `actionlint`, ni `zizmor`, ni `poutine`, ni l'épinglage par SHA ne sont concernés. Le gabarit reste un YAML valide, vérifié par chargement.

### When the declarative contract changes

**N/A** : le contrat est inchangé. `support` lit `meta.yml` par `read_repo_metadata`, la même porte que les autres commandes, et n'introduit aucun champ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
