### PR TITLE
feat(cli): dsoxlab demo, un premier lab sans rien cloner (0.1.45)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,41 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.45] - 2026-08-19
+
+### Ajouté
+
+- **`dsoxlab demo` : un premier lab jouable juste après l'installation, sans
+  rien cloner ni provisionner.** Entre `uv tool install dsoxlab` et le premier
+  lab joué, il y avait une connaissance implicite : savoir que les labs vivent
+  dans d'autres dépôts, savoir lesquels, savoir qu'il faut se placer dedans. Qui
+  installait l'outil et le lançait là où il se trouvait n'obtenait rien, avec un
+  code de retour `0` pour dire que tout allait bien.
+
+  Le catalogue de démonstration porte un seul lab `shell`, et **son sujet est
+  dsoxlab lui-même** : la boucle run / course / challenge / hint / check, rien
+  d'autre. C'est ce qui l'écarte de l'anti-pattern que le projet s'interdit,
+  embarquer des templates de labs pour un domaine technique. Le parcourir prend
+  cinq minutes et finit sur 100/100, un chemin qu'un test de bout en bout joue
+  en entier.
+
+  Une installation existante n'est jamais écrasée : ce répertoire porte la
+  progression et les réponses de l'apprenant, et `--force` est exigé pour
+  repartir de zéro.
+
+- **La documentation ne peut plus mentir sur la CLI.** Un test ferme les deux
+  sens : toute commande citée dans la documentation existe, et toute commande de
+  la CLI est décrite dans `fullhelp`, en anglais comme en français. Il a
+  immédiatement trouvé que `provision`, `destroy`, `ssh` et `status` n'étaient
+  décrites **nulle part** dans le guide, alors que ce sont les quatre commandes
+  d'infrastructure. Elles le sont désormais.
+
+### Corrigé
+
+- **Cinq commandes manquaient au `fullhelp`**, dont quatre de longue date :
+  `provision`, `status`, `ssh`, `destroy`, et la nouvelle `demo`. Une commande
+  absente du guide n'existe pas pour qui le lit.
+
 ## [0.1.44] - 2026-08-19
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.45] - 2026-08-19
+
+### Added
+
+- **`dsoxlab demo`: a first lab you can play right after installing, with
+  nothing to clone and nothing to provision.** Between `uv tool install dsoxlab`
+  and the first lab played, there was an implicit piece of knowledge: that labs
+  live in other repositories, which ones, and that you have to stand inside one.
+  Whoever installed the tool and ran it where they were got nothing, with a `0`
+  exit code saying all was well.
+
+  The demonstration catalog holds a single `shell` lab, and **its subject is
+  dsoxlab itself**: the run / course / challenge / hint / check loop, nothing
+  else. That is what keeps it clear of the anti-pattern this project forbids,
+  which is shipping lab templates for a technical domain. Playing it takes about
+  five minutes and ends on 100/100, a path an end-to-end test walks in full.
+
+  An existing installation is never overwritten: that directory holds the
+  learner's progress and answers, and `--force` is required to start over.
+
+- **Documentation can no longer lie about the CLI.** A new test closes both
+  directions: every command quoted in the docs exists, and every command of the
+  CLI is described in `fullhelp`, in English and French alike. It immediately
+  found that `provision`, `destroy`, `ssh` and `status` were described **nowhere**
+  in the guide, though they are the four infrastructure commands. They are now.
+
+### Fixed
+
+- **`fullhelp` was missing five commands**, four of them long-standing:
+  `provision`, `status`, `ssh`, `destroy`, and the new `demo`. A command absent
+  from the guide does not exist for whoever reads it.
+
 ## [0.1.44] - 2026-08-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.44"
+version = "0.1.45"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -2209,6 +2209,34 @@ def instructor_bootstrap(
         raise typer.Exit(1)
 
 
+# ── demo ──────────────────────────────────────────────────────────────────────
+
+@app.command("demo", help=_("cmd_demo_help"))
+def demo(
+    force: Annotated[bool, typer.Option("--force", help=_("opt_demo_force"))] = False,
+) -> None:
+    """Installe le catalogue de démonstration et dit quoi faire ensuite."""
+    from .services.demo import DemoExistante, installer
+
+    try:
+        installation = installer(force=force)
+    except DemoExistante as exc:
+        # Ne pas écraser : ce répertoire porte la progression et les réponses.
+        error(_("demo_deja_installee", path=str(exc)))
+        info(_("demo_deja_installee_suite", path=str(exc)))
+        raise typer.Exit(1) from None
+    except OSError as exc:
+        error(_("demo_echec", error=str(exc)))
+        raise typer.Exit(1) from None
+
+    success(_("demo_installee", path=str(installation.racine)))
+
+    # La marche à suivre est construite depuis le catalogue réellement
+    # installé : elle ne peut donc pas décrire un lab qui n'y serait plus.
+    premier = installation.labs[0] if installation.labs else ""
+    info(_("demo_suite", path=str(installation.racine), lab=premier))
+
+
 # ── support ───────────────────────────────────────────────────────────────────
 
 @app.command("support", help=_("cmd_support_help"))

--- a/src/dsoxlab/config.py
+++ b/src/dsoxlab/config.py
@@ -45,6 +45,19 @@ def xdg_state_home() -> Path:
     return Path.home() / ".local" / "state"
 
 
+def xdg_data_home() -> Path:
+    """Racine XDG des données de l'utilisateur.
+
+    Distincte de ``xdg_state_home()`` à dessein : le catalogue de démonstration
+    est un contenu que l'utilisateur peut modifier et dont il attend qu'il
+    survive, pas un cache ni un état recalculable.
+    """
+    env = os.environ.get("XDG_DATA_HOME")
+    if env:
+        return Path(env).expanduser().resolve()
+    return Path.home() / ".local" / "share"
+
+
 def get_context_path(root: Path) -> Path:
     return root / _CONTEXT_FILE
 

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -91,6 +91,26 @@ STRINGS: dict[str, str] = {
     "opt_debug":      "Same as -vv. The full log is written to ~/.local/state/dsoxlab/dsoxlab.log either way.",
     "opt_version_help":   "Show the dsoxlab version and exit.",
     "cmd_install_help":   "Install the dsoxlab wrapper in ~/.local/bin and shell auto-completion.",
+    "cmd_demo_help":
+        "Install a demonstration catalog and play a first lab, with nothing to "
+        "clone and nothing to provision.",
+    "opt_demo_force":
+        "Reinstall over the existing one, losing the progress and answers "
+        "already there.",
+    "demo_installee":  "Demonstration catalog installed in {path}",
+    "demo_deja_installee":
+        "The demonstration catalog is already installed in {path}.",
+    "demo_deja_installee_suite":
+        "It may hold your progress and your answers, so nothing was touched.\n"
+        "To pick it up: cd {path} && dsoxlab list-labs\n"
+        "To start over: dsoxlab demo --force",
+    "demo_echec":      "Cannot install: {error}",
+    "demo_suite":
+        "To get started:\n"
+        "  cd {path}\n"
+        "  dsoxlab course {lab}\n"
+        "  dsoxlab run {lab}\n"
+        "Then, once the mission is done: dsoxlab check {lab}",
     "cmd_support_help":
         "Produce an anonymised diagnostic report, ready to paste into an issue.",
     "opt_support_log_lines":
@@ -290,6 +310,20 @@ Each lab exposes:
                        [bold]Informational[/bold] and never shows up as an error.
     [dim]--fix[/dim]                Remediate the missing required components.
                        Informational components are left alone.
+
+  [cyan]demo[/cyan]                 Install a demonstration catalog and a first lab you can
+                       play right away, with nothing to clone or provision.
+    [dim]--force[/dim]              Reinstall over it (loses progress).
+
+  [cyan]provision[/cyan]            Bring up the infrastructure for vm labs (terraform apply).
+    [dim]--host <fqdn>[/dim]         Target a single machine. Repeatable.
+
+  [cyan]status[/cyan]               Check SSH connectivity of the declared hosts.
+
+  [cyan]ssh <host>[/cyan]           Open an interactive session on a lab host.
+
+  [cyan]destroy[/cyan]              Tear down the infrastructure for vm labs (terraform destroy).
+    [dim]--yes[/dim]                 Do not ask for confirmation.
 
   [cyan]install[/cyan]              Install dsoxlab in [bold]~/.local/bin[/bold] + shell auto-completion.
                        Supports bash and zsh. Reload your shell after running.

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -91,6 +91,27 @@ STRINGS: dict[str, str] = {
     "opt_debug":      "Équivaut à -vv. Le journal complet est de toute façon écrit dans ~/.local/state/dsoxlab/dsoxlab.log.",
     "opt_version_help":   "Affiche la version de dsoxlab et quitte.",
     "cmd_install_help":   "Installe le wrapper dsoxlab dans ~/.local/bin et l'auto-complétion shell.",
+    "cmd_demo_help":
+        "Installe un catalogue de démonstration et joue un premier lab, sans "
+        "rien cloner ni provisionner.",
+    "opt_demo_force":
+        "Réinstalle par-dessus, en perdant la progression et les réponses déjà "
+        "présentes.",
+    "demo_installee":  "Catalogue de démonstration installé dans {path}",
+    "demo_deja_installee":
+        "Le catalogue de démonstration est déjà installé dans {path}.",
+    "demo_deja_installee_suite":
+        "Il contient peut-être votre progression et vos réponses, donc rien "
+        "n'a été touché.\n"
+        "Pour le reprendre : cd {path} && dsoxlab list-labs\n"
+        "Pour repartir de zéro : dsoxlab demo --force",
+    "demo_echec":      "Installation impossible : {error}",
+    "demo_suite":
+        "Pour commencer :\n"
+        "  cd {path}\n"
+        "  dsoxlab course {lab}\n"
+        "  dsoxlab run {lab}\n"
+        "Puis, une fois la mission remplie : dsoxlab check {lab}",
     "cmd_support_help":
         "Produit un rapport de diagnostic anonymisé, à coller dans une issue.",
     "opt_support_log_lines":
@@ -288,6 +309,20 @@ Chaque lab expose :
                        [bold]Informatif[/bold] et ne s'affiche jamais en erreur.
     [dim]--fix[/dim]                Applique la remédiation des composants requis manquants.
                        Les composants informatifs ne sont pas touchés.
+
+  [cyan]demo[/cyan]                 Installe un catalogue de démonstration et un premier lab
+                       jouable immédiatement, sans rien cloner ni provisionner.
+    [dim]--force[/dim]              Réinstalle par-dessus (perd la progression).
+
+  [cyan]provision[/cyan]            Monte l'infrastructure des labs vm (terraform apply).
+    [dim]--host <fqdn>[/dim]         Ne cible qu'une machine. Répétable.
+
+  [cyan]status[/cyan]               Vérifie la connectivité SSH des hôtes déclarés.
+
+  [cyan]ssh <hote>[/cyan]           Ouvre une session interactive sur un hôte du lab.
+
+  [cyan]destroy[/cyan]              Détruit l'infrastructure des labs vm (terraform destroy).
+    [dim]--yes[/dim]                 Ne demande pas confirmation.
 
   [cyan]install[/cyan]              Installe dsoxlab dans [bold]~/.local/bin[/bold] + auto-complétion shell.
                        Supporte bash et zsh. Rechargez le shell après exécution.

--- a/src/dsoxlab/services/demo.py
+++ b/src/dsoxlab/services/demo.py
@@ -1,0 +1,93 @@
+"""Installer le catalogue de démonstration, et rien de plus.
+
+Entre `uv tool install dsoxlab` et le premier lab joué, il y avait une
+connaissance implicite : savoir que les labs vivent dans d'autres dépôts, savoir
+lesquels, savoir qu'il faut se placer dedans. Qui installait l'outil et le
+lançait là où il se trouvait n'obtenait rien, avec un code de retour 0 pour dire
+que tout allait bien.
+
+Ce module copie un catalogue d'un seul lab dans le répertoire de données de
+l'utilisateur. Deux principes :
+
+1. **On n'écrase jamais un travail en cours.** Le catalogue installé contient la
+   progression de l'apprenant (`.dsoxlab.db`) et ses réponses. Une réinstallation
+   silencieuse effacerait un lab en cours de résolution, ce qui est exactement ce
+   qu'on ne pardonne pas à un outil.
+2. **La marche à suivre vient de la CLI, pas d'un texte recopié.** Les commandes
+   affichées sont construites à partir du catalogue réellement installé, donc
+   elles ne peuvent pas dériver de ce qu'il contient.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..config import xdg_data_home
+from ..templates import demo_catalog
+
+
+class DemoExistante(RuntimeError):
+    """Le catalogue est déjà installé, et il porte peut-être du travail."""
+
+
+@dataclass(frozen=True)
+class Installation:
+    """Ce qu'une installation a produit, pour que la CLI le raconte."""
+
+    racine: Path
+    labs: list[str]
+    reinstallee: bool
+
+
+def destination() -> Path:
+    """Où le catalogue de démonstration est installé."""
+    return xdg_data_home() / "dsoxlab" / "demo"
+
+
+def _labs_du_catalogue(racine: Path) -> list[str]:
+    """Identifiants des labs installés, lus sur le disque.
+
+    On lit le catalogue plutôt que de coder la liste en dur : le jour où le
+    catalogue de démonstration gagne un second lab, ce qui s'affiche suit.
+    """
+    ids: list[str] = []
+    for lab_yaml in sorted((racine / "labs").rglob("lab.yaml")):
+        for ligne in lab_yaml.read_text(encoding="utf-8").splitlines():
+            if ligne.startswith("id:"):
+                ids.append(ligne.split(":", 1)[1].strip())
+                break
+    return ids
+
+
+def installer(*, force: bool = False) -> Installation:
+    """Copie le catalogue packagé vers le répertoire de données.
+
+    Args:
+        force: réinstalle par-dessus une installation existante. Sans lui, une
+            installation déjà en place lève : elle peut contenir la progression
+            et les réponses de l'apprenant.
+
+    Raises:
+        DemoExistante: si le catalogue est déjà là et que ``force`` est faux.
+        OSError: si la copie échoue (disque plein, droits).
+    """
+    cible = destination()
+    existait = cible.exists()
+
+    if existait and not force:
+        raise DemoExistante(str(cible))
+
+    if existait:
+        shutil.rmtree(cible)
+
+    cible.parent.mkdir(parents=True, exist_ok=True)
+    # `dirs_exist_ok` n'est pas utilisé : on vient de supprimer la cible, et
+    # fusionner deux catalogues laisserait des fichiers d'une version
+    # antérieure au milieu de la nouvelle.
+    shutil.copytree(demo_catalog(), cible)
+
+    return Installation(
+        racine=cible, labs=_labs_du_catalogue(cible), reinstallee=existait
+    )

--- a/src/dsoxlab/templates/__init__.py
+++ b/src/dsoxlab/templates/__init__.py
@@ -38,6 +38,22 @@ def template_root() -> Path:
     return Path(__file__).parent.resolve()
 
 
+def demo_catalog() -> Path:
+    """Le catalogue de démonstration packagé avec l'outil.
+
+    C'est la seule exception à l'anti-pattern « ne pas embarquer de templates de
+    labs », et elle est bornée : son unique lab porte sur dsoxlab lui-même, la
+    boucle run / course / challenge / hint / check. Un lab Linux ou Terraform
+    ici serait le début du couplage que le projet s'interdit.
+
+    Il existe pour que l'outil se démontre sans rien cloner, sans hyperviseur et
+    sans Docker : entre l'installation et le premier lab joué, il n'y avait
+    sinon qu'une connaissance implicite, celle de savoir que les labs vivent
+    ailleurs.
+    """
+    return template_root() / "demo"
+
+
 def terraform_template(provider: str) -> Path:
     """Retourne le chemin du template Terraform pour un provider.
 

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/README.fr.md
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/README.fr.md
@@ -1,0 +1,11 @@
+# premiers-pas
+
+Le lab de démonstration livré avec dsoxlab. Son sujet est dsoxlab lui-même :
+vous parcourez une fois toute la boucle, sur quelque chose qui n'exige aucune
+infrastructure.
+
+- Le cours : [scenario.fr.md](./scenario.fr.md)
+- La mission : [challenge/README.fr.md](./challenge/README.fr.md)
+
+Runtime `shell` : ni VM, ni conteneur, ni Docker. Il tourne partout où dsoxlab
+tourne.

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/README.md
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/README.md
@@ -1,0 +1,9 @@
+# premiers-pas
+
+The demonstration lab shipped with dsoxlab. Its subject is dsoxlab itself: you
+walk the whole loop once, on something that needs no infrastructure.
+
+- Lesson: [scenario.md](./scenario.md)
+- Mission: [challenge/README.md](./challenge/README.md)
+
+Runtime `shell`: no VM, no container, no Docker. It runs anywhere dsoxlab runs.

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/README.fr.md
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/README.fr.md
@@ -1,0 +1,30 @@
+# Challenge — premiers-pas
+
+## Mission
+
+Prouvez que vous avez fait le tour de la boucle, en produisant trois fichiers
+dans `reponses/`.
+
+1. `reponses/cours.txt` : le mot donné à la fin du cours
+   (`dsoxlab course premiers-pas`).
+2. `reponses/mission.txt` : le mot donné juste en dessous, dans cette mission.
+3. `reponses/indice.txt` : le mot révélé par `dsoxlab hint premiers-pas`.
+
+Le mot de cette mission est :
+
+    challenge
+
+## Ce qui est vérifié
+
+Les fichiers, et rien d'autre. Ni votre historique, ni les commandes tapées.
+Toute façon de les créer compte.
+
+Notez que `dsoxlab hint` coûte des points, et vous le dit avant. Prenez-le : ce
+lab est fait pour être terminé, et `dsoxlab scores` vous montrera ce que coûte
+un indice.
+
+## Validation
+
+```bash
+dsoxlab check premiers-pas
+```

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/README.md
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/README.md
@@ -1,0 +1,28 @@
+# Challenge — premiers-pas
+
+## Mission
+
+Prove you went round the loop, by producing three files in `reponses/`.
+
+1. `reponses/cours.txt` — the word given at the end of the lesson
+   (`dsoxlab course premiers-pas`).
+2. `reponses/mission.txt` — the word given right below, in this mission.
+3. `reponses/indice.txt` — the word revealed by `dsoxlab hint premiers-pas`.
+
+The word of this mission is:
+
+    challenge
+
+## What is checked
+
+The files, and nothing else. Not your shell history, not the commands you typed.
+Any way of creating them counts.
+
+Note that `dsoxlab hint` costs points and tells you so first. Take it: this lab
+exists to be finished, and `dsoxlab scores` will show you what a hint costs.
+
+## Validation
+
+```bash
+dsoxlab check premiers-pas
+```

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/hints.yaml
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/hints.yaml
@@ -1,0 +1,10 @@
+# Indices du lab de démonstration.
+#
+# Le texte est encodé en base64, comme dans tous les catalogues : ce n'est pas
+# du chiffrement, seulement de quoi éviter qu'un indice se lise par accident en
+# ouvrant le fichier.
+points: 100
+hints:
+  - text_en: "VGhlIHdvcmQgdGhpcyBoaW50IHJldmVhbHMgaXM6IHByb2dyZXNzaW9uLiBXcml0ZSBpdCB0byByZXBvbnNlcy9pbmRpY2UudHh0LiBOb3RpY2UgdGhhdCBkc294bGFiIHNjb3JlcyBub3cgc2hvd3Mgd2hhdCB0aGlzIGhpbnQgY29zdCB5b3U6IHRoYXQgaXMgdGhlIHdob2xlIHBvaW50IG9mIHRha2luZyBvbmUgZGVsaWJlcmF0ZWx5Lg=="
+    text_fr: "TGUgbW90IHF1ZSBjZXQgaW5kaWNlIHLDqXbDqGxlIGVzdCA6IHByb2dyZXNzaW9uLiDDiWNyaXZlei1sZSBkYW5zIHJlcG9uc2VzL2luZGljZS50eHQuIFJlbWFycXVleiBxdWUgZHNveGxhYiBzY29yZXMgYWZmaWNoZSBkw6lzb3JtYWlzIGNlIHF1ZSBjZXQgaW5kaWNlIHZvdXMgYSBjb8O7dMOpIDogYydlc3QgdG91dCBsJ2ludMOpcsOqdCBkJ2VuIHByZW5kcmUgdW4gc2NpZW1tZW50Lg=="
+    cost: 20

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/tests/conftest.py
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/tests/conftest.py
@@ -1,0 +1,24 @@
+"""conftest.py — premiers-pas
+
+`dsoxlab check` lance pytest depuis la RACINE du catalogue, pas depuis le
+répertoire de travail du lab. Sans cette fixture, un test qui écrit
+`pathlib.Path(".")` regarderait la racine du catalogue et ne trouverait jamais
+les réponses de l'apprenant : trois tests rouges sur un travail pourtant juste.
+
+C'est la convention de tous les labs `shell` du contrat, reprise telle quelle.
+"""
+import os
+import pathlib
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def set_workdir() -> Iterator[None]:
+    work_dir = pathlib.Path(__file__).parent.parent / "work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    original = os.getcwd()
+    os.chdir(work_dir)
+    yield
+    os.chdir(original)

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/tests/test_functional.py
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/tests/test_functional.py
@@ -1,0 +1,60 @@
+"""test_functional.py — premiers-pas
+
+Prouve l'ÉTAT produit, jamais les commandes tapées : ce sont les trois fichiers
+de `reponses/` qui sont lus. C'est la règle de tous les labs dsoxlab, et ce lab
+existe justement pour la faire comprendre.
+
+Le barème est réparti à parts égales entre les trois étapes de la boucle : lire
+le cours, lire la mission, demander un indice.
+"""
+from __future__ import annotations
+
+import pathlib
+
+WORK = pathlib.Path(".")
+REPONSES = WORK / "reponses"
+
+#: Le mot attendu dans chaque fichier, et où l'apprenant le trouve.
+ATTENDUS = {
+    "cours.txt": ("catalogue", "dsoxlab course premiers-pas"),
+    "mission.txt": ("challenge", "dsoxlab challenge premiers-pas"),
+    "indice.txt": ("progression", "dsoxlab hint premiers-pas"),
+}
+
+
+def _verifier(nom: str) -> None:
+    mot, ou = ATTENDUS[nom]
+    fichier = REPONSES / nom
+
+    assert fichier.exists(), (
+        f"{fichier} manquant. Le mot attendu se lit dans : {ou}\n"
+        f"Crée le fichier, par exemple : mkdir -p reponses && "
+        f"echo <le mot> > reponses/{nom}"
+    )
+
+    contenu = fichier.read_text(encoding="utf-8", errors="replace").strip().lower()
+    assert contenu, f"{fichier} est vide. Le mot attendu se lit dans : {ou}"
+    assert mot in contenu, (
+        f"{fichier} ne contient pas le mot attendu.\n"
+        f"Il se lit dans : {ou}\n"
+        f"Obtenu : {contenu[:60]!r}"
+    )
+
+
+def test_le_mot_du_cours() -> None:
+    """Première étape de la boucle : lire le cours."""
+    _verifier("cours.txt")
+
+
+def test_le_mot_de_la_mission() -> None:
+    """Deuxième étape : lire la mission, qui dit ce qu'il faut produire."""
+    _verifier("mission.txt")
+
+
+def test_le_mot_de_l_indice() -> None:
+    """Troisième étape : demander un indice, et voir ce qu'il coûte.
+
+    Ce test est là pour que l'apprenant fasse le geste au moins une fois, sur
+    un lab où la dépense est sans conséquence.
+    """
+    _verifier("indice.txt")

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/lab.fr.yaml
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/lab.fr.yaml
@@ -1,0 +1,2 @@
+title: Premiers pas avec dsoxlab
+description: Parcourir une fois toute la boucle dsoxlab, sur un lab qui parle de dsoxlab.

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/lab.yaml
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/lab.yaml
@@ -1,0 +1,17 @@
+id: premiers-pas
+title: First steps with dsoxlab
+level: demo
+section: demo
+description: Walk the whole dsoxlab loop once, on a lab about dsoxlab itself.
+skills:
+  - dsoxlab-workflow
+distros:
+  - any
+doc_url: https://github.com/stephrobert/dsoxlab
+lab_type: lab
+estimated_time: 5m
+runtime:
+  type: shell
+  workdir: challenge/work
+validation:
+  functional: true

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/scenario.fr.md
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/scenario.fr.md
@@ -1,0 +1,42 @@
+# Premiers pas avec dsoxlab
+
+Ce lab ne parle ni de Linux, ni de Terraform, ni d'Ansible. **Son sujet est
+dsoxlab lui-même** : la boucle que vous répéterez sur tous les autres labs,
+quel que soit le catalogue.
+
+## La boucle
+
+Un lab passe toujours par les cinq mêmes gestes.
+
+| Geste | Ce qu'il fait |
+|---|---|
+| `dsoxlab run <id>` | Prépare le lab et vous dépose dans son répertoire de travail |
+| `dsoxlab course <id>` | Affiche le cours, cette page même |
+| `dsoxlab challenge <id>` | Affiche la mission : ce que vous devez produire |
+| `dsoxlab hint <id>` | Révèle un indice de plus, à un coût sur votre score |
+| `dsoxlab check <id>` | Joue les tests et enregistre le score |
+
+Deux d'entre eux méritent un mot.
+
+**`check` lit l'état que vous avez produit, jamais les commandes que vous avez
+tapées.** Il n'y a donc pas d'historique à satisfaire ni de formulation exacte à
+deviner : les tests regardent les fichiers. C'est ce qui vous laisse arriver au
+résultat comme vous l'entendez.
+
+**`hint` coûte des points, et le dit avant de les dépenser.** Ce n'est pas une
+punition : un indice pris sciemment coûte moins cher qu'une heure perdue.
+`dsoxlab scores` montre ce qu'un lab a finalement rapporté.
+
+## Où vous travaillez
+
+`dsoxlab run` vous place dans le répertoire de travail du lab. Tout ce que vous
+y créez est ce qui sera validé. Rien d'autre sur votre machine n'est touché.
+
+## Le mot du cours
+
+La mission ci-dessous vous demande un mot qui figure ici, et uniquement ici.
+Le voici :
+
+    catalogue
+
+Lisez maintenant la mission : `dsoxlab challenge premiers-pas`.

--- a/src/dsoxlab/templates/demo/labs/demo/premiers-pas/scenario.md
+++ b/src/dsoxlab/templates/demo/labs/demo/premiers-pas/scenario.md
@@ -1,0 +1,39 @@
+# First steps with dsoxlab
+
+This lab is not about Linux, Terraform or Ansible. **Its subject is dsoxlab
+itself**: the loop you will repeat on every other lab, whatever the catalog.
+
+## The loop
+
+A lab always goes through the same five moves.
+
+| Move | What it does |
+|---|---|
+| `dsoxlab run <id>` | Prepares the lab and drops you in its work directory |
+| `dsoxlab course <id>` | Shows the lesson, this very page |
+| `dsoxlab challenge <id>` | Shows the mission: what you have to produce |
+| `dsoxlab hint <id>` | Reveals one more hint, at a cost on your score |
+| `dsoxlab check <id>` | Runs the tests and records the score |
+
+Two of them deserve a comment.
+
+**`check` reads the state you produced, never the commands you typed.** There is
+no history to please and no exact wording to guess: the tests look at the files.
+That is why you can reach the answer any way you like.
+
+**`hint` costs points, and says so before spending them.** It is not a
+punishment: a hint used deliberately is cheaper than an hour lost. `dsoxlab
+scores` shows what a lab finally earned.
+
+## Where you work
+
+`dsoxlab run` places you in the lab's work directory. Everything you create
+there is what gets validated. Nothing else on your machine is touched.
+
+## The word of the lesson
+
+The mission below asks you for a word that appears here, and only here. It is:
+
+    catalogue
+
+Now read the mission: `dsoxlab challenge premiers-pas`.

--- a/src/dsoxlab/templates/demo/meta.yml
+++ b/src/dsoxlab/templates/demo/meta.yml
@@ -1,0 +1,24 @@
+# Catalogue de démonstration, packagé avec dsoxlab.
+#
+# Il existe pour une seule raison : qu'un utilisateur qui vient d'installer
+# l'outil puisse jouer un lab dans la minute, sans cloner de dépôt, sans
+# hyperviseur et sans Docker.
+#
+# Son unique lab porte sur dsoxlab lui-même, pas sur un domaine technique.
+# C'est ce qui le distingue d'un catalogue Linux ou Terraform embarqué, ce que
+# le projet s'interdit : ici, le sujet EST la boucle run / course / challenge /
+# hint / check.
+repo:
+  id: dsoxlab-demo
+  category: demo
+  title: Démonstration dsoxlab
+  description: |
+    Un lab unique pour prendre en main la boucle de travail de dsoxlab.
+    Aucune infrastructure requise.
+
+sections:
+  - id: demo
+    title: Prise en main
+    description: La boucle de travail, de bout en bout.
+    labs:
+      - demo/premiers-pas

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,175 @@
+"""Le catalogue de démonstration, et le parcours qu'il doit rendre possible.
+
+Entre `uv tool install dsoxlab` et le premier lab joué, il y avait une
+connaissance implicite : savoir que les labs vivent dans d'autres dépôts, savoir
+lesquels, savoir qu'il faut se placer dedans. Qui lançait l'outil là où il se
+trouvait n'obtenait rien, avec un code de retour 0 pour dire que tout allait
+bien.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dsoxlab.cli import app
+from dsoxlab.services import demo
+from dsoxlab.templates import demo_catalog
+
+runner = CliRunner()
+
+#: Les réponses attendues, et où l'apprenant lit chaque mot.
+REPONSES = {
+    "cours.txt": "catalogue",
+    "mission.txt": "challenge",
+    "indice.txt": "progression",
+}
+
+
+@pytest.fixture
+def maison(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "etat"))
+    monkeypatch.delenv("LAB_HOME", raising=False)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# ── le catalogue packagé respecte le contrat qu'il enseigne ───────────────────
+
+def test_le_catalogue_est_bien_empaquete() -> None:
+    """Livré avec l'outil : il doit exister dans l'arbre du paquet."""
+    racine = demo_catalog()
+
+    assert (racine / "meta.yml").is_file()
+    labs = list((racine / "labs").rglob("lab.yaml"))
+    assert labs, "le catalogue de démonstration doit contenir au moins un lab"
+
+
+def test_le_lab_porte_les_fichiers_exiges_par_le_contrat() -> None:
+    """Un lab de démonstration qui violerait le contrat serait le pire exemple.
+
+    C'est le tout premier lab que voit un utilisateur : il doit être conforme,
+    et il doit rester jouable sans infrastructure.
+    """
+    lab = next((demo_catalog() / "labs").rglob("lab.yaml")).parent
+
+    for exige in (
+        "lab.yaml", "README.md", "scenario.md",
+        "challenge/tests/test_functional.py",
+    ):
+        assert (lab / exige).is_file(), f"{exige} manquant"
+
+    # Le conftest est ce qui place pytest dans le répertoire de travail :
+    # sans lui, les tests cherchent les réponses à la racine du catalogue et
+    # trois cas rouges sanctionnent un travail pourtant juste.
+    assert (lab / "challenge" / "tests" / "conftest.py").is_file()
+
+    contenu = (lab / "lab.yaml").read_text(encoding="utf-8")
+    assert "type: shell" in contenu, "le lab de démonstration ne doit exiger aucune VM"
+
+
+def test_la_parite_de_langue_est_tenue() -> None:
+    """Un document traduit d'un seul côté est signalé par le validator."""
+    lab = next((demo_catalog() / "labs").rglob("lab.yaml")).parent
+
+    for base in ("README", "scenario", "challenge/README"):
+        assert (lab / f"{base}.md").is_file()
+        assert (lab / f"{base}.fr.md").is_file(), f"{base}.fr.md manquant"
+
+
+# ── l'installation ────────────────────────────────────────────────────────────
+
+def test_l_installation_pose_un_catalogue_jouable(maison: Path) -> None:
+    resultat = runner.invoke(app, ["demo"])
+
+    assert resultat.exit_code == 0, resultat.output
+    cible = demo.destination()
+    assert (cible / "meta.yml").is_file()
+    assert list((cible / "labs").rglob("lab.yaml"))
+
+
+def test_une_installation_existante_n_est_jamais_ecrasee(maison: Path) -> None:
+    """Ce répertoire porte la progression et les réponses de l'apprenant.
+
+    Une réinstallation silencieuse effacerait un lab en cours de résolution,
+    ce qu'on ne pardonne pas à un outil.
+    """
+    runner.invoke(app, ["demo"])
+    temoin = demo.destination() / "labs" / "temoin.txt"
+    temoin.write_text("le travail de l'apprenant", encoding="utf-8")
+
+    resultat = runner.invoke(app, ["demo"])
+
+    assert resultat.exit_code == 1
+    assert temoin.is_file(), "le travail en place a été détruit"
+    assert temoin.read_text(encoding="utf-8") == "le travail de l'apprenant"
+
+
+def test_force_reinstalle_vraiment(maison: Path) -> None:
+    runner.invoke(app, ["demo"])
+    temoin = demo.destination() / "labs" / "temoin.txt"
+    temoin.write_text("ancien", encoding="utf-8")
+
+    resultat = runner.invoke(app, ["demo", "--force"])
+
+    assert resultat.exit_code == 0
+    assert not temoin.exists(), "--force doit repartir d'un catalogue propre"
+
+
+def test_la_marche_a_suivre_nomme_le_lab_reellement_installe(maison: Path) -> None:
+    """Elle est construite depuis le catalogue posé, pas recopiée à la main.
+
+    Le jour où le catalogue de démonstration change de lab, ce qui s'affiche
+    suit tout seul.
+    """
+    resultat = runner.invoke(app, ["demo"])
+
+    # Rich replie les longues lignes : on compare sur une sortie recollée,
+    # sinon le test échoue sur un retour à la ligne et non sur le fond.
+    sortie = resultat.output.replace("\n", "")
+    lab = next((demo.destination() / "labs").rglob("lab.yaml")).parent.name
+
+    assert lab in sortie
+    assert str(demo.destination()).replace("\n", "") in sortie
+
+
+# ── le parcours complet, joué pour de vrai ────────────────────────────────────
+
+def test_de_l_installation_au_100_sur_100(maison: Path) -> None:
+    """Le test qui justifie tout le reste : l'outil se démontre lui-même.
+
+    On joue le parcours d'un débutant en entier, dans un sous-processus, avec
+    la CLI réelle : installer, échouer à froid, répondre, réussir.
+    """
+    assert runner.invoke(app, ["demo"]).exit_code == 0
+    catalogue = demo.destination()
+
+    binaire = Path(sys.executable).parent / "dsoxlab"
+    if not binaire.exists():
+        pytest.skip("script console dsoxlab absent de cet environnement")
+
+    def dsoxlab(*args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603 : c'est notre propre CLI
+            [str(binaire), *args],
+            cwd=catalogue, capture_output=True, text=True, timeout=120,
+        )
+
+    avant = dsoxlab("check", "premiers-pas")
+    assert "0 / 100" in avant.stdout or "0/100" in avant.stdout, (
+        f"un lab non résolu doit valoir 0 : {avant.stdout[-300:]}"
+    )
+
+    work = next((catalogue / "labs").rglob("lab.yaml")).parent / "challenge" / "work"
+    (work / "reponses").mkdir(parents=True, exist_ok=True)
+    for fichier, mot in REPONSES.items():
+        (work / "reponses" / fichier).write_text(mot + "\n", encoding="utf-8")
+
+    apres = dsoxlab("check", "premiers-pas")
+    assert "100 / 100" in apres.stdout or "100/100" in apres.stdout, (
+        f"le parcours complet doit valoir 100 : {apres.stdout[-300:]}"
+    )

--- a/tests/test_documentation_synchrone.py
+++ b/tests/test_documentation_synchrone.py
@@ -1,0 +1,146 @@
+"""La documentation ne peut plus mentir sur la CLI.
+
+Tout ce qu'un binaire peut affirmer de lui-même ne doit pas être recopié à la
+main : une commande renommée, retirée ou ajoutée laisse sinon derrière elle une
+documentation qui décrit un outil qui n'existe plus. Personne ne s'en aperçoit,
+parce que rien ne lit la documentation en même temps que le code.
+
+Ce module ferme les deux sens :
+
+1. **Toute commande citée dans la documentation existe** dans la CLI.
+2. **Toute commande de la CLI est décrite** dans `fullhelp`, en anglais comme en
+   français. C'est la règle que le projet s'était donnée sans pouvoir la tenir :
+   « ne jamais laisser le fullhelp décrire une commande qui n'existe plus ».
+
+Il attrape donc aussi bien la commande oubliée que la commande fantôme.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from dsoxlab.cli import app
+from dsoxlab.i18n.strings.en import STRINGS as EN
+from dsoxlab.i18n.strings.fr import STRINGS as FR
+
+RACINE = Path(__file__).resolve().parent.parent
+
+#: Documents qui s'adressent à un utilisateur ou à un contributeur, et qui
+#: peuvent donc citer des commandes. Le CHANGELOG en est exclu : il raconte le
+#: passé, où une commande retirée a toute sa place.
+DOCUMENTS = [
+    "README.md",
+    "README.fr.md",
+    "CONTRIBUTING.md",
+    "CONTRIBUTING.fr.md",
+    "RELEASING.md",
+]
+
+#: `dsoxlab <mot>` dans un texte. On ignore ce qui suit un tiret : `dsoxlab
+#: --version` est une option, pas une commande.
+_APPEL = re.compile(r"(?<![\w/.-])dsoxlab[ \t]+(?!-)([a-z][a-z0-9-]*)")
+
+#: Bloc de code clôturé, et code en ligne entre accents graves.
+_BLOC = re.compile(r"```.*?```", re.DOTALL)
+_EN_LIGNE = re.compile(r"`([^`\n]+)`")
+
+
+def _appels_de_commande(texte: str) -> set[str]:
+    """Les commandes appelées dans un document, et elles seules.
+
+    On ne lit QUE le code : blocs clôturés et accents graves. La prose emploie
+    le même mot sans l'appeler (« dsoxlab lui-même », « dsoxlab itself »,
+    « dsoxlab tourne »), et une extraction naïve prenait ces mots pour des
+    commandes inexistantes. Un contrôle qui crie au loup sur de la grammaire
+    finit désactivé, ce qui est pire que son absence.
+    """
+    fragments = _BLOC.findall(texte)
+    fragments += _EN_LIGNE.findall(_BLOC.sub("", texte))
+    return {m.group(1) for fragment in fragments for m in _APPEL.finditer(fragment)}
+
+
+def _commandes_cli() -> set[str]:
+    """Les noms de commandes réellement enregistrés sur l'application Typer."""
+    noms = {c.name for c in app.registered_commands if c.name}
+    for groupe in app.registered_groups:
+        if groupe.name:
+            noms.add(groupe.name)
+    return noms
+
+
+COMMANDES = _commandes_cli()
+
+
+def test_la_cli_declare_bien_des_commandes() -> None:
+    """Garde-fou : une extraction cassée rendrait tout ce module vert à vide."""
+    assert len(COMMANDES) >= 20, f"seulement {len(COMMANDES)} commandes trouvées"
+    assert "check" in COMMANDES and "doctor" in COMMANDES
+
+
+@pytest.mark.parametrize("document", DOCUMENTS)
+def test_les_commandes_citees_existent(document: str) -> None:
+    """Une commande renommée laisse une documentation qui envoie dans le mur."""
+    chemin = RACINE / document
+    if not chemin.is_file():
+        pytest.skip(f"{document} absent de ce dépôt")
+
+    citees = _appels_de_commande(chemin.read_text(encoding="utf-8"))
+    inconnues = sorted(citees - COMMANDES)
+    assert not inconnues, (
+        f"{document} cite des commandes qui n'existent pas : {inconnues}\n"
+        f"Commandes réelles : {sorted(COMMANDES)}"
+    )
+
+
+@pytest.mark.parametrize("langue", ["en", "fr"])
+def test_toute_commande_est_decrite_dans_le_fullhelp(langue: str) -> None:
+    """L'inverse, et le plus utile : la commande ajoutée sans sa documentation.
+
+    C'est ce contrôle qui aurait attrapé `support` et `demo` si j'avais oublié
+    de les décrire, au lieu de le découvrir chez un utilisateur.
+    """
+    catalogue = EN if langue == "en" else FR
+    fullhelp = catalogue["fullhelp_commands"]
+
+    # `instructor` est un groupe : le fullhelp le décrit par sa sous-commande.
+    attendues = COMMANDES - {"instructor"}
+    manquantes = sorted(cmd for cmd in attendues if cmd not in fullhelp)
+
+    assert not manquantes, (
+        f"fullhelp ({langue}) ne décrit pas : {manquantes}\n"
+        "Une commande absente du guide n'existe pas pour qui le lit."
+    )
+
+
+def test_le_fullhelp_ne_decrit_aucune_commande_fantome() -> None:
+    """L'autre sens : une commande retirée qui survit dans le guide.
+
+    On ne lit que les lignes en `[cyan]…[/cyan]`, qui sont la liste des
+    commandes du guide, pour ne pas confondre avec la prose autour.
+    """
+    for langue, catalogue in (("en", EN), ("fr", FR)):
+        citees = set(
+            re.findall(r"\[cyan\]([a-z][a-z0-9-]*)", catalogue["fullhelp_commands"])
+        )
+        fantomes = sorted(citees - COMMANDES)
+        assert not fantomes, (
+            f"fullhelp ({langue}) décrit des commandes inexistantes : {fantomes}"
+        )
+
+
+def test_le_catalogue_de_demonstration_ne_cite_que_des_commandes_reelles() -> None:
+    """Le lab de démonstration ENSEIGNE la boucle : s'il la nomme mal, il
+    apprend une erreur, et c'est le tout premier contact avec l'outil."""
+    from dsoxlab.templates import demo_catalog
+
+    inconnues: dict[str, list[str]] = {}
+    for markdown in sorted(demo_catalog().rglob("*.md")):
+        citees = _appels_de_commande(markdown.read_text(encoding="utf-8"))
+        manquantes = sorted(citees - COMMANDES)
+        if manquantes:
+            inconnues[markdown.name] = manquantes
+
+    assert not inconnues, f"commandes inexistantes citées : {inconnues}"

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.44"
+version = "0.1.45"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Closes #72

# Summary

Entre `uv tool install dsoxlab` et le premier lab joué, il y avait une **connaissance implicite** : savoir que les labs vivent dans d'autres dépôts, savoir lesquels, savoir qu'il faut se placer dedans. Qui installait l'outil et le lançait là où il se trouvait n'obtenait rien, avec un code de retour `0` pour dire que tout allait bien.

```console
$ dsoxlab demo
✔ Catalogue de démonstration installé dans ~/.local/share/dsoxlab/demo
ℹ Pour commencer :
    cd ~/.local/share/dsoxlab/demo
    dsoxlab course premiers-pas
    dsoxlab run premiers-pas
  Puis, une fois la mission remplie : dsoxlab check premiers-pas
```

## Comment le lab reste hors de l'anti-pattern

Le projet s'interdit d'embarquer des templates de labs. Ce catalogue en est la seule exception, et elle est bornée : **son sujet est dsoxlab lui-même**, la boucle `run` / `course` / `challenge` / `hint` / `check`, rien d'autre. Un lab Linux ou Terraform ici serait le début du couplage que le projet refuse.

L'exercice consiste à recopier trois mots : l'un lu dans le cours, l'autre dans la mission, le dernier révélé par un indice. L'apprenant fait donc le tour complet de la boucle, et **voit ce qu'un indice coûte** sur un lab où la dépense est sans conséquence. Cinq minutes, aucune infrastructure.

## Le test qui interdit à la documentation de mentir

Vous avez demandé que tout ce qui peut être automatisé avec le binaire le soit. `tests/test_documentation_synchrone.py` ferme les deux sens :

1. toute commande citée dans la documentation **existe** dans la CLI ;
2. toute commande de la CLI est **décrite** dans `fullhelp`, en anglais comme en français.

Il a immédiatement trouvé que **`provision`, `destroy`, `ssh` et `status` n'étaient décrites nulle part dans le guide**, alors que ce sont les quatre commandes d'infrastructure, indispensables à tout lab `vm`. Le `CLAUDE.md` posait la règle (« ne jamais laisser le fullhelp décrire une commande qui n'existe plus ») sans que rien ne la tienne. Elles y sont désormais, avec `demo`.

## Trois corrections que mes propres tests m'ont imposées

**Le `conftest.py` du lab manquait.** `dsoxlab check` lance pytest depuis la **racine du catalogue**, pas depuis le répertoire de travail. Sans lui, les trois cas cherchaient les réponses au mauvais endroit : `0/100` sur un travail pourtant juste. C'est la convention de tous les labs `shell`, et je l'avais oubliée.

**L'extracteur de commandes prenait la prose pour du code.** « dsoxlab lui-même », « dsoxlab itself » étaient signalés comme commandes inexistantes. Puis, une fois restreint aux blocs de code, `src/dsoxlab tests` passé à ruff l'était aussi. Un contrôle qui crie au loup sur de la grammaire finit désactivé, ce qui est pire que son absence.

**Rich replie les longues lignes**, donc comparer un chemin entier à la sortie échouait sur un retour à la ligne, pas sur le fond.

## Preuve

Le parcours est joué **en entier** par un test de bout en bout qui appelle la CLI réelle en sous-processus : installation, `check` à froid qui doit valoir **0/100**, écriture des trois réponses, `check` qui doit valoir **100/100**.

| Vérification | Résultat |
|---|---|
| Suite complète | **298 passed** (268 avant, soit **+30 tests**) |
| `ruff`, `mypy` strict | verts (53 fichiers) |
| Parité i18n | 349 clés de chaque côté, écart nul |
| Catalogue dans le wheel | 12 fichiers, `meta.yml` et `conftest.py` compris |
| `validate-structure` sur le lab démo | vert |

Et sur les **trois** catalogues fournisseurs :

| Catalogue | Sur disque | Découverts | `validate-structure` |
|---|---|---|---|
| `linux-dsoxlab-training` | 84 | 84 | vert |
| `ansible-training` | 113 | 113 | vert |
| `terraform-training` | 87 | 87 | vert |

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `ruff check src/dsoxlab tests` passes
- [x] `mypy src/dsoxlab` passes (strict) : 53 fichiers, dont le `conftest.py` du template, annoté pour cela plutôt qu'exclu
- [x] `pytest` passes : **298 passed**
- [x] The engine stays domain-agnostic : le lab de démonstration parle de dsoxlab, jamais d'un domaine technique ; c'est la condition qui rend cette exception acceptable, et un test vérifie qu'il reste `shell`
- [x] No hardcoded personal path or host ; destination résolue par `XDG_DATA_HOME`
- [x] Manually tested against **three** lab repositories (tableau ci-dessus)

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.44 → 0.1.45) and `uv.lock` refreshed

### When a command or option is added, removed or changed

- [x] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py` (parité vérifiée : 349 clés de chaque côté)
- [x] `help=_("…")` in `cli.py` **et** `fullhelp` mis à jour en EN et FR, désormais tenu par un test plutôt que par la vigilance
- [x] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched

**N/A** : aucun workflow modifié.

### When the declarative contract changes

**N/A** : le contrat est inchangé. Le catalogue de démonstration en est un **consommateur** de plus, pas une extension : il déclare un `meta.yml` et un `lab.yaml` ordinaires, et `dsoxlab validate-structure` le valide comme n'importe quel autre. C'est d'ailleurs un contrôle utile en soi, puisqu'un lab de démonstration non conforme serait le pire premier exemple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
