### PR TITLE
docs(readme): l'installation de l'utilisateur, et une table qui se génère

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,17 @@ repos:
         language: system
         files: '^\.github/dependabot\.yml$'
 
+      # Une table de commandes écrite à la main dérive sans que personne
+      # ne s'en aperçoive : celle du README annonçait encore un `cleanup.sh`
+      # que le zéro-bash interdit, et il y manquait deux commandes. Elle est
+      # désormais produite par la CLI, et ce hook refuse une version périmée.
+      - id: doc-a-jour
+        name: la documentation décrit la CLI réelle
+        entry: python3 scripts/generer-doc.py --verifier
+        language: system
+        pass_filenames: false
+        files: '^(src/dsoxlab/(cli\.py|i18n/)|README(\.fr)?\.md|scripts/generer-doc\.py)'
+
       # Full test suite runs on push (kept off the per-commit path for speed).
       - id: pytest
         name: pytest

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -38,7 +38,28 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
   décrites **nulle part** dans le guide, alors que ce sont les quatre commandes
   d'infrastructure. Elles le sont désormais.
 
+- **Le README ouvre sur l'installation de l'utilisateur, pas du contributeur.**
+  Il commençait par `git clone` puis `uv tool install --editable .`, une
+  procédure de développement, alors que le paquet est publié sur PyPI et que
+  `doctor` recommandait déjà l'installation par PyPI. Qui suivait le README se
+  retrouvait avec une copie éditable dont il n'avait aucune raison de vouloir.
+  Le parcours devient : installer, jouer un lab, puis choisir un catalogue.
+
+- **La table des commandes est générée depuis la CLI**
+  (`scripts/generer-doc.py`), entre marqueurs, dans les deux langues. Écrite à
+  la main, elle avait dérivé sans bruit : elle décrivait encore `dsoxlab clean`
+  exécutant un `cleanup.sh`, que le zéro-bash interdit, et il y manquait `demo`
+  et `support`. Un hook pre-commit et un test refusent une version périmée.
+
 ### Corrigé
+
+- **La section Persistance était fausse sur ses trois points.** Elle annonçait
+  `~/.local/share/dsoxlab/progress.db`, un `~/.config/dsoxlab/config.yaml` et
+  une surcharge par `XDG_CONFIG_HOME`. Vérifié dans le code : la base est
+  `<catalogue>/.dsoxlab.db`, aucun fichier de configuration n'est lu nulle part,
+  et les variables réellement honorées sont `XDG_DATA_HOME`, `XDG_STATE_HOME` et
+  `XDG_CACHE_HOME`. La progression est **par catalogue**, ce que la section dit
+  désormais.
 
 - **Cinq commandes manquaient au `fullhelp`**, dont quatre de longue date :
   `provision`, `status`, `ssh`, `destroy`, et la nouvelle `demo`. Une commande

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   found that `provision`, `destroy`, `ssh` and `status` were described **nowhere**
   in the guide, though they are the four infrastructure commands. They are now.
 
+- **The README now opens on the user's installation, not the contributor's.**
+  It started with `git clone` and `uv tool install --editable .`, a development
+  setup, while the package is published on PyPI and `doctor` already recommended
+  the PyPI install. A reader following it ended up with an editable checkout they
+  had no reason to want. The path is now: install, play a lab, then pick a
+  catalog.
+
+- **The command table is generated from the CLI** (`scripts/generer-doc.py`),
+  between markers, in both languages. Written by hand it had drifted without a
+  sound: it still described `dsoxlab clean` running a `cleanup.sh`, which the
+  zero-bash rule forbids, and it was missing `demo` and `support`. A pre-commit
+  hook and a test refuse a stale version.
+
 ### Fixed
+
+- **The Persistence section was wrong on all three counts.** It announced
+  `~/.local/share/dsoxlab/progress.db`, a `~/.config/dsoxlab/config.yaml` and an
+  `XDG_CONFIG_HOME` override. Checked against the code: the database is
+  `<catalog>/.dsoxlab.db`, no configuration file is read anywhere, and the
+  variables actually honoured are `XDG_DATA_HOME`, `XDG_STATE_HOME` and
+  `XDG_CACHE_HOME`. Progress is **per catalog**, which the section now says.
 
 - **`fullhelp` was missing five commands**, four of them long-standing:
   `provision`, `status`, `ssh`, `destroy`, and the new `demo`. A command absent

--- a/README.fr.md
+++ b/README.fr.md
@@ -48,41 +48,63 @@ domaine ne vit dans le moteur.
 
 ## Installation
 
-Nécessite **Python 3.11+** et [uv](https://docs.astral.sh/uv/).
+Nécessite **Python 3.11+**.
 
 ```bash
-# Depuis le dépôt Git (mode développement / editable)
-git clone https://github.com/stephrobert/dsoxlab.git
-cd dsoxlab
-uv tool install --editable .
-
-# Vérifier
+uv tool install dsoxlab      # ou : pipx install dsoxlab
 dsoxlab --version
-dsoxlab doctor
 ```
 
-`dsoxlab doctor --fix` diagnostique (et répare si possible) la boîte à outils
-locale attendue par les runtimes : SSH, Terraform, libvirt/Incus et la pile
-`pytest` embarquée.
+C'est toute l'installation. Rien à cloner, rien à compiler.
 
 ---
 
-## Prise en main
+## Votre premier lab, en cinq minutes
 
-Les labs vivent dans leurs propres dépôts, publiés séparément du moteur.
-Clonez-en un d'abord, puis lancez `dsoxlab` depuis l'intérieur :
+Nul besoin d'un catalogue pour commencer. `dsoxlab demo` installe un catalogue
+de démonstration d'un seul lab, dont le sujet est dsoxlab lui-même : la boucle
+que vous répéterez sur tous les autres labs.
 
 ```bash
-# 1. Cloner un catalogue de labs (ex. linux-dsoxlab-training)
+dsoxlab demo                    # l'installe et affiche la suite
+cd ~/.local/share/dsoxlab/demo
+
+dsoxlab course premiers-pas     # le cours
+dsoxlab run premiers-pas        # vous dépose dans le répertoire de travail
+dsoxlab challenge premiers-pas  # la mission
+dsoxlab check premiers-pas      # les tests, et le score
+```
+
+Ni VM, ni conteneur, ni Docker : cela tourne partout où dsoxlab tourne.
+
+---
+
+## Ensuite, un vrai catalogue
+
+Les labs vivent dans leurs propres dépôts, publiés séparément du moteur.
+Clonez-en un, puis lancez `dsoxlab` depuis l'intérieur :
+
+```bash
 git clone https://github.com/stephrobert/linux-dsoxlab-training.git
 cd linux-dsoxlab-training
 
-# 2. Le contexte actif est détecté automatiquement via le meta.yml du dépôt
+dsoxlab doctor                  # ce que ce catalogue exige, et ce qui manque
 dsoxlab list-labs
-dsoxlab show linux.depanner.service-crash-loop
-dsoxlab guide linux.depanner.service-crash-loop   # lire le cours dans le navigateur
-dsoxlab run linux.depanner.service-crash-loop
-dsoxlab check linux.depanner.service-crash-loop
+dsoxlab run <identifiant>
+dsoxlab check <identifiant>
+```
+
+`dsoxlab doctor` ne signale que ce dont *ce* catalogue a besoin : un catalogue
+entièrement `shell` ne réclame jamais d'hyperviseur. `dsoxlab doctor --fix`
+répare ce qui peut l'être sans risque. En cas de problème, `dsoxlab support`
+produit un rapport de diagnostic anonymisé, prêt à coller dans une issue.
+
+### Installer depuis les sources (contributeurs)
+
+```bash
+git clone https://github.com/stephrobert/dsoxlab.git
+cd dsoxlab
+uv tool install --editable .
 ```
 
 ### Lire le cours
@@ -123,6 +145,21 @@ DSOXLAB_PAGER='bat --plain' dsoxlab course   # choisir son pager (défaut : less
 dsoxlab course --no-pager                    # tout déverser d'un bloc
 dsoxlab course > cours.txt                   # jamais paginé : texte brut
 ```
+
+---
+
+## Runtimes
+
+| Runtime | Backend | Usage typique |
+| --- | --- | --- |
+| `shell` | Shell local | Exercices rapides mono-hôte, sans surcoût de VM |
+| `incus` | Conteneurs Incus | Environnements Linux isolés, à démarrage rapide |
+| `kvm` | Terraform + libvirt | VM complètes avec test de reboot/persistance |
+
+Chaque runtime est opt-in et auto-descriptif (`is_available()`), le moteur ne
+dépend jamais en dur d'un backend non installé. Les templates de provisioning
+(HCL Terraform, cloud-init) vivent sous `dsoxlab.templates` et couvrent Incus,
+KVM/libvirt et Outscale.
 
 ---
 
@@ -194,44 +231,38 @@ test référencés sont présents.
 
 ## Référence des commandes
 
-| Commande | Effet |
+<!-- BEGIN COMMANDES : généré par scripts/generer-doc.py, ne pas éditer -->
+
+| Commande | Rôle |
 | --- | --- |
-| `dsoxlab use [section[/level]]` | Définit le contexte actif ; `--reset` l'efface, `--provider` choisit le provider d'infra |
-| `dsoxlab list-labs` | Liste les labs du dépôt courant (filtre `--section`/`--level`/`--type`/`--bloc`) |
-| `dsoxlab show <id>` | Détail d'un lab |
-| `dsoxlab course [section]` | Affiche une section de cours ou la table des matières |
-| `dsoxlab guide [id]` | Ouvre le guide en ligne du lab dans le navigateur (`--print` affiche l'URL) |
-| `dsoxlab run <id>` | Prépare et démarre l'environnement du lab |
-| `dsoxlab challenge <id>` | Affiche la mission de challenge d'un lab |
-| `dsoxlab hint <id>` | Révèle un indice (déduit du score) |
-| `dsoxlab check <id>` | Lance la validation `pytest` et enregistre le score |
-| `dsoxlab submit <id>` | Soumission finale : tests, score, fermeture de session |
-| `dsoxlab scores` | Historique des runs (SQLite local) |
-| `dsoxlab progress` | Progression par bloc (labs faits, score moyen, challenges) |
-| `dsoxlab next` | Recommande le prochain lab ou challenge à traiter |
-| `dsoxlab reset <id>` | Remet le lab à son état initial |
-| `dsoxlab clean <id>` | Exécute le `cleanup.sh` du lab |
-| `dsoxlab provision` | Provisionne l'infrastructure (`terraform apply`) |
-| `dsoxlab destroy` | Détruit l'infrastructure (`terraform destroy`) |
-| `dsoxlab status` | Vérifie la connectivité SSH de tous les hôtes du `meta.yml` |
-| `dsoxlab ssh <host>` | Ouvre une session SSH interactive sur un hôte |
-| `dsoxlab validate-structure` | Valide le contrat (`meta.yml` + chaque `lab.yaml`) |
-| `dsoxlab doctor [--fix]` | Diagnostique (et répare) l'environnement local |
-| `dsoxlab install` | Installe le wrapper shell et l'auto-complétion |
-| `dsoxlab instructor bootstrap` | Outillage formateur (génération de la clé SSH du lab) |
-| `dsoxlab fullhelp` | Guide complet multilingue (EN/FR) |
+| `dsoxlab challenge` | Affiche la mission du challenge (challenge/README.md). |
+| `dsoxlab check` | Exécute les tests, calcule le score (hints déduits) et enregistre le résultat. |
+| `dsoxlab clean` | Supprime toutes les ressources créées par le lab. |
+| `dsoxlab course` | Affiche une section du cours, ou le sommaire si aucune section n'est précisée. |
+| `dsoxlab demo` | Installe un catalogue de démonstration et joue un premier lab, sans rien cloner ni provisionner. |
+| `dsoxlab destroy` | Détruit l'infrastructure du lab (terraform destroy). |
+| `dsoxlab doctor` | Diagnostique l'environnement (runtimes, outils, labs détectés). |
+| `dsoxlab fullhelp` | Affiche le guide complet de la plateforme (concepts, workflow, commandes). |
+| `dsoxlab guide` | Ouvre le guide en ligne du lab dans le navigateur. |
+| `dsoxlab hint` | Affiche le prochain indice du challenge (déduit des points au score final). |
+| `dsoxlab install` | Installe le wrapper dsoxlab dans ~/.local/bin et l'auto-complétion shell. |
+| `dsoxlab instructor bootstrap` | Génère la clé SSH du lab (si absente) et vérifie que terraform/ansible-runner sont installés. |
+| `dsoxlab list-labs` | Liste tous les labs disponibles (filtrés par contexte actif si défini). |
+| `dsoxlab next` | Recommande le prochain lab ou challenge à compléter dans le contexte actif. |
+| `dsoxlab progress` | Affiche la progression par bloc (labs complétés, score moyen, challenges et capstones). |
+| `dsoxlab provision` | Provisionne l'infrastructure du lab (terraform apply sur le provider courant). |
+| `dsoxlab reset` | Remet le lab à l'état initial (clean + redémarrage). |
+| `dsoxlab run` | Prépare et démarre l'environnement du lab. |
+| `dsoxlab scores` | Affiche l'historique des scores enregistrés. |
+| `dsoxlab show` | Affiche le détail et le statut d'un lab. |
+| `dsoxlab ssh` | Ouvre une session SSH interactive sur un hôte du lab. |
+| `dsoxlab status` | Vérifie la connectivité SSH des hôtes déclarés dans meta.yml. |
+| `dsoxlab submit` | Soumission finale : lance les tests, enregistre le score, puis tapez 'exit' pour quitter la session. |
+| `dsoxlab support` | Produit un rapport de diagnostic anonymisé, à coller dans une issue. |
+| `dsoxlab use` | Définit le contexte actif (section et/ou niveau par défaut). Utilisez --reset pour l'effacer. |
+| `dsoxlab validate-structure` | Vérifie la structure et les métadonnées de tous les labs. |
 
-Lancer `dsoxlab <commande> --help` pour les options de chaque commande.
-
----
-
-## Runtimes
-
-| Runtime | Backend | Usage typique |
-| --- | --- | --- |
-| `shell` | Shell local | Exercices rapides mono-hôte, sans surcoût de VM |
-| `incus` | Conteneurs Incus | Environnements Linux isolés, à démarrage rapide |
-| `kvm` | Terraform + libvirt | VM complètes avec test de reboot/persistance |
+<!-- END COMMANDES -->
 
 Chaque runtime est opt-in et auto-descriptif (`is_available()`), le moteur ne
 dépend jamais en dur d'un backend non installé. Les templates de provisioning
@@ -266,14 +297,24 @@ fonctionne sur n'importe quel arbre déclaré par le `meta.yml`.
 
 ## Persistance
 
-- **Sessions locales :** `.dsoxlab-context.json` dans le dépôt courant
-  (gitignored par chaque dépôt de labs).
-- **Scores et indices :** `~/.local/share/dsoxlab/progress.db` (XDG). L'id
-  global d'un lab est `<category>.<section>.<lab>`, le schéma reste universel.
-- **Config utilisateur :** `~/.config/dsoxlab/config.yaml` (optionnelle).
+Tout ce que dsoxlab conserve tient dans quatre emplacements, et **la
+progression est par catalogue**, jamais globale : deux catalogues côte à côte
+ont chacun leur historique.
 
-On surcharge ces emplacements avec les variables standard `XDG_DATA_HOME` /
-`XDG_CONFIG_HOME`.
+| Quoi | Où | Surcharge |
+| --- | --- | --- |
+| Scores et indices | `<catalogue>/.dsoxlab.db` (SQLite) | aucune, c'est le dépôt |
+| Contexte de session | `<catalogue>/.dsoxlab-context.json` | aucune, c'est le dépôt |
+| Journal, état Terraform | `~/.local/state/dsoxlab/` | `XDG_STATE_HOME` |
+| Catalogue de démonstration | `~/.local/share/dsoxlab/demo/` | `XDG_DATA_HOME` |
+
+Les deux premiers sont à ignorer dans le `.gitignore` de chaque catalogue.
+
+Il n'existe **aucun fichier de configuration utilisateur** : rien n'est lu dans
+`~/.config/dsoxlab/`. Ce que l'on règle passe par le contrat (`meta.yml`), par
+le contexte actif (`dsoxlab use`) ou par une variable d'environnement
+(`DSOXLAB_PROVIDER`, `DSOXLAB_LANG`, `DSOXLAB_LOG`,
+`DSOXLAB_HOST_READY_TIMEOUT`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,41 +48,63 @@ about a specific domain lives in the engine.
 
 ## Installation
 
-Requires **Python 3.11+** and [uv](https://docs.astral.sh/uv/).
+Requires **Python 3.11+**.
 
 ```bash
-# From the Git repository (development / editable mode)
-git clone https://github.com/stephrobert/dsoxlab.git
-cd dsoxlab
-uv tool install --editable .
-
-# Verify
+uv tool install dsoxlab      # or: pipx install dsoxlab
 dsoxlab --version
-dsoxlab doctor
 ```
 
-`dsoxlab doctor --fix` diagnoses (and repairs where possible) the local
-toolchain expected by the runtimes: SSH, Terraform, libvirt/Incus, and the
-embedded `pytest` stack.
+That is the whole installation. Nothing to clone, nothing to build.
 
 ---
 
-## Quickstart
+## Your first lab, in five minutes
 
-Labs live in their own repositories, published separately from the engine.
-Clone one first, then run `dsoxlab` from inside it:
+You do not need a catalog to start. `dsoxlab demo` installs a one-lab
+demonstration catalog whose subject is dsoxlab itself: the loop you will repeat
+on every other lab.
 
 ```bash
-# 1. Clone a lab catalog (e.g. linux-dsoxlab-training)
+dsoxlab demo                    # installs it and prints what to do next
+cd ~/.local/share/dsoxlab/demo
+
+dsoxlab course premiers-pas     # the lesson
+dsoxlab run premiers-pas        # drops you in the lab's work directory
+dsoxlab challenge premiers-pas  # the mission
+dsoxlab check premiers-pas      # the tests, and the score
+```
+
+No VM, no container, no Docker: it runs anywhere dsoxlab runs.
+
+---
+
+## Then, a real catalog
+
+Labs live in their own repositories, published separately from the engine.
+Clone one, then run `dsoxlab` from inside it:
+
+```bash
 git clone https://github.com/stephrobert/linux-dsoxlab-training.git
 cd linux-dsoxlab-training
 
-# 2. The active context is detected automatically from the repo's meta.yml
+dsoxlab doctor                  # what this catalog needs, and what is missing
 dsoxlab list-labs
-dsoxlab show linux.depanner.service-crash-loop
-dsoxlab guide linux.depanner.service-crash-loop   # read the course in your browser
-dsoxlab run linux.depanner.service-crash-loop
-dsoxlab check linux.depanner.service-crash-loop
+dsoxlab run <lab-id>
+dsoxlab check <lab-id>
+```
+
+`dsoxlab doctor` only reports what *this* catalog needs: a shell-only catalog
+never asks for a hypervisor. `dsoxlab doctor --fix` repairs what can be repaired
+safely. If something goes wrong, `dsoxlab support` produces an anonymised
+diagnostic report ready to paste into an issue.
+
+### Installing from source (contributors)
+
+```bash
+git clone https://github.com/stephrobert/dsoxlab.git
+cd dsoxlab
+uv tool install --editable .
 ```
 
 ### Reading the course
@@ -253,44 +275,38 @@ scripts and test files are present.
 
 ## Command reference
 
+<!-- BEGIN COMMANDES : généré par scripts/generer-doc.py, ne pas éditer -->
+
 | Command | Purpose |
 | --- | --- |
-| `dsoxlab use [section[/level]]` | Set the active context; `--reset` clears it, `--provider` selects the infra provider |
-| `dsoxlab list-labs` | List labs of the current repo (filter by `--section`/`--level`/`--type`/`--bloc`) |
-| `dsoxlab show <id>` | Show a lab's details |
-| `dsoxlab course [section]` | Display a course section, or the table of contents |
-| `dsoxlab guide [id]` | Open the lab's online guide in a browser (`--print` shows the URL) |
-| `dsoxlab run <id>` | Prepare and start the lab environment |
-| `dsoxlab challenge <id>` | Show the challenge mission for a lab |
-| `dsoxlab hint <id>` | Reveal a hint (deducted from the score) |
-| `dsoxlab check <id>` | Run the `pytest` validation and record the score |
-| `dsoxlab submit <id>` | Final submission: run tests, record score, close the session |
-| `dsoxlab scores` | Show run history (local SQLite) |
-| `dsoxlab progress` | Progression by bloc (labs done, average score, challenges) |
-| `dsoxlab next` | Recommend the next lab or challenge to tackle |
-| `dsoxlab reset <id>` | Reset the lab to its initial state |
-| `dsoxlab clean <id>` | Run the lab's `cleanup.sh` |
-| `dsoxlab provision` | Provision the lab infrastructure (`terraform apply`) |
-| `dsoxlab destroy` | Destroy the lab infrastructure (`terraform destroy`) |
-| `dsoxlab status` | Check SSH connectivity to all hosts in `meta.yml` |
-| `dsoxlab ssh <host>` | Open an interactive SSH session on a lab host |
-| `dsoxlab validate-structure` | Validate the contract (`meta.yml` + every `lab.yaml`) |
-| `dsoxlab doctor [--fix]` | Diagnose (and repair) the local environment |
-| `dsoxlab install` | Install the shell wrapper and auto-completion |
-| `dsoxlab instructor bootstrap` | Instructor tooling (e.g. generate the lab SSH key) |
-| `dsoxlab fullhelp` | Full multilingual guide (EN/FR) |
+| `dsoxlab challenge` | Display the challenge mission for this lab (challenge/README.md). |
+| `dsoxlab check` | Run tests, calculate score (hints deducted) and record result. |
+| `dsoxlab clean` | Remove all resources created by the lab. |
+| `dsoxlab course` | Display a course section, or the table of contents if no section is given. |
+| `dsoxlab demo` | Install a demonstration catalog and play a first lab, with nothing to clone and nothing to provision. |
+| `dsoxlab destroy` | Destroy the lab infrastructure (terraform destroy). |
+| `dsoxlab doctor` | Diagnose the environment (runtimes, tools, detected labs). |
+| `dsoxlab fullhelp` | Show the complete platform guide (concepts, workflow, commands). |
+| `dsoxlab guide` | Open the lab's online guide in your web browser. |
+| `dsoxlab hint` | Show the next challenge hint (deducts points from final score). |
+| `dsoxlab install` | Install the dsoxlab wrapper in ~/.local/bin and shell auto-completion. |
+| `dsoxlab instructor bootstrap` | Generate the lab SSH key (if missing) and check that terraform/ansible-runner are installed. |
+| `dsoxlab list-labs` | List all available labs (filtered by active context if set). |
+| `dsoxlab next` | Recommend the next lab or challenge to complete in the active context. |
+| `dsoxlab progress` | Show progression by bloc (labs completed, average score, challenges and capstones). |
+| `dsoxlab provision` | Provision the lab infrastructure (terraform apply on the current provider). |
+| `dsoxlab reset` | Reset the lab to its initial state (clean + restart). |
+| `dsoxlab run` | Prepare and start the lab environment. |
+| `dsoxlab scores` | Show recorded scores history. |
+| `dsoxlab show` | Show details and status of a lab. |
+| `dsoxlab ssh` | Open an interactive SSH session on a lab host. |
+| `dsoxlab status` | Check SSH connectivity to all hosts declared in meta.yml. |
+| `dsoxlab submit` | Final submission: run tests, record score, then type 'exit' to leave the session. |
+| `dsoxlab support` | Produce an anonymised diagnostic report, ready to paste into an issue. |
+| `dsoxlab use` | Sets the active context (section and/or default level). Use --reset to clear it. |
+| `dsoxlab validate-structure` | Check structure and metadata of all labs. |
 
-Run `dsoxlab <command> --help` for the options of any command.
-
----
-
-## Runtimes
-
-| Runtime | Backend | Typical use |
-| --- | --- | --- |
-| `shell` | Local shell | Quick, single-host exercises with no VM overhead |
-| `incus` | Incus containers | Isolated, fast-booting Linux environments |
-| `kvm` | Terraform + libvirt | Full VMs with reboot/persistence testing |
+<!-- END COMMANDES -->
 
 Each runtime is opt-in and self-describing (`is_available()`), so the engine
 never hard-depends on a backend the user has not installed. Provisioning
@@ -325,14 +341,23 @@ works on whatever tree the `meta.yml` declares.
 
 ## Persistence
 
-- **Local sessions:** `.dsoxlab-context.json` in the current repo (gitignored
-  by each lab repository).
-- **Scores and hints:** `~/.local/share/dsoxlab/progress.db` (XDG). The global
-  lab id is `<category>.<section>.<lab>`, so the schema stays universal.
-- **User config:** `~/.config/dsoxlab/config.yaml` (optional).
+Everything dsoxlab keeps lives in four places, and **progress is per
+catalog**, never global: two catalogs side by side each keep their own history.
 
-Override the locations with the standard `XDG_DATA_HOME` / `XDG_CONFIG_HOME`
-environment variables.
+| What | Where | Override |
+| --- | --- | --- |
+| Scores and hints | `<catalog>/.dsoxlab.db` (SQLite) | none, it is the repo |
+| Session context | `<catalog>/.dsoxlab-context.json` | none, it is the repo |
+| Log, Terraform state | `~/.local/state/dsoxlab/` | `XDG_STATE_HOME` |
+| Demonstration catalog | `~/.local/share/dsoxlab/demo/` | `XDG_DATA_HOME` |
+
+The first two belong in each catalog's `.gitignore`.
+
+There is **no user configuration file**: nothing is read from
+`~/.config/dsoxlab/`. What can be set goes through the contract (`meta.yml`),
+the active context (`dsoxlab use`) or an environment variable
+(`DSOXLAB_PROVIDER`, `DSOXLAB_LANG`, `DSOXLAB_LOG`,
+`DSOXLAB_HOST_READY_TIMEOUT`).
 
 ---
 

--- a/scripts/generer-doc.py
+++ b/scripts/generer-doc.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Génère depuis la CLI ce que la documentation ne doit plus recopier.
+
+Une table de commandes écrite à la main dérive, et personne ne s'en aperçoit :
+celle du README annonçait encore `dsoxlab clean` exécutant un `cleanup.sh`,
+alors que le zéro-bash est un invariant du contrat depuis longtemps, et il y
+manquait `demo` et `support`. Rien ne lit la documentation en même temps que le
+code.
+
+Le principe : la section vit entre deux marqueurs, elle est produite par
+l'application elle-même, et un mode `--verifier` la compare à ce qu'elle devrait
+être. La CI refuse alors une documentation périmée, exactement comme elle
+refuserait un test rouge.
+
+Usage :
+    python3 scripts/generer-doc.py             # réécrit les sections générées
+    python3 scripts/generer-doc.py --verifier   # sort 1 si une section a dérivé
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+RACINE = Path(__file__).resolve().parent.parent
+
+DEBUT = "<!-- BEGIN COMMANDES : généré par scripts/generer-doc.py, ne pas éditer -->"
+FIN = "<!-- END COMMANDES -->"
+
+#: Fichier de documentation et langue dans laquelle le remplir.
+CIBLES = {
+    "README.md": "en",
+    "README.fr.md": "fr",
+}
+
+TITRES = {
+    "en": ("| Command | Purpose |", "| --- | --- |"),
+    "fr": ("| Commande | Rôle |", "| --- | --- |"),
+}
+
+#: Programme joué dans un sous-processus par langue. L'aide des commandes est
+#: résolue par `_()` au moment de l'import : changer la langue APRÈS n'aurait
+#: aucun effet, d'où un interpréteur neuf par langue.
+_EXTRACTION = """
+import json
+from dsoxlab.cli import app
+
+commandes = []
+for info in app.registered_commands:
+    if info.name:
+        commandes.append((info.name, (info.help or "").strip()))
+for groupe in app.registered_groups:
+    sous = getattr(groupe, "typer_instance", None)
+    if groupe.name and sous is not None:
+        for info in sous.registered_commands:
+            if info.name:
+                commandes.append(
+                    (f"{groupe.name} {info.name}", (info.help or "").strip())
+                )
+print(json.dumps(sorted(commandes)))
+"""
+
+
+def commandes(langue: str) -> list[tuple[str, str]]:
+    """Les commandes de la CLI et leur aide, dans une langue donnée."""
+    env = dict(os.environ, DSOXLAB_LANG=langue, PYTHONPATH=str(RACINE / "src"))
+    proc = subprocess.run(
+        [sys.executable, "-c", _EXTRACTION],
+        capture_output=True, text=True, env=env, cwd=RACINE, check=True,
+    )
+    return [(nom, aide) for nom, aide in json.loads(proc.stdout)]
+
+
+def table(langue: str) -> str:
+    entete, separateur = TITRES[langue]
+    lignes = [DEBUT, "", entete, separateur]
+    for nom, aide in commandes(langue):
+        # L'aide peut contenir des barres verticales, qui casseraient la table.
+        lignes.append(f"| `dsoxlab {nom}` | {aide.replace('|', '/')} |")
+    lignes += ["", FIN]
+    return "\n".join(lignes)
+
+
+def remplacer(document: Path, contenu: str) -> str | None:
+    """Rend le texte mis à jour, ou None si les marqueurs sont absents."""
+    texte = document.read_text(encoding="utf-8")
+    if DEBUT not in texte or FIN not in texte:
+        return None
+    avant = texte[: texte.index(DEBUT)]
+    apres = texte[texte.index(FIN) + len(FIN) :]
+    return avant + contenu + apres
+
+
+def main() -> int:
+    verifier = "--verifier" in sys.argv
+    perimes: list[str] = []
+
+    for nom, langue in CIBLES.items():
+        document = RACINE / nom
+        if not document.is_file():
+            print(f"  ! {nom} absent, ignoré")
+            continue
+
+        attendu = remplacer(document, table(langue))
+        if attendu is None:
+            print(
+                f"  ! {nom} ne porte pas les marqueurs de section générée.\n"
+                f"    Ajoute-les autour de la table des commandes :\n"
+                f"    {DEBUT}\n    {FIN}"
+            )
+            perimes.append(nom)
+            continue
+
+        if attendu == document.read_text(encoding="utf-8"):
+            print(f"  ✔ {nom} à jour")
+            continue
+
+        if verifier:
+            print(f"  ✘ {nom} a dérivé de la CLI")
+            perimes.append(nom)
+        else:
+            document.write_text(attendu, encoding="utf-8")
+            print(f"  ✔ {nom} régénéré")
+
+    if perimes and verifier:
+        print(
+            "\nLa documentation ne décrit plus la CLI. Régénère-la :\n"
+            "    python3 scripts/generer-doc.py\n"
+        )
+        return 1
+    return 1 if perimes else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_documentation_synchrone.py
+++ b/tests/test_documentation_synchrone.py
@@ -144,3 +144,31 @@ def test_le_catalogue_de_demonstration_ne_cite_que_des_commandes_reelles() -> No
             inconnues[markdown.name] = manquantes
 
     assert not inconnues, f"commandes inexistantes citées : {inconnues}"
+
+
+def test_la_table_des_commandes_du_readme_est_a_jour() -> None:
+    """La table du README est produite par la CLI, et doit le rester.
+
+    Écrite à la main, elle dérivait sans bruit : elle annonçait encore
+    `dsoxlab clean` exécutant un `cleanup.sh`, alors que le zéro-bash est un
+    invariant du contrat, et il y manquait `demo` et `support`.
+
+    Ce test joue le générateur en mode vérification. Il échoue si quelqu'un
+    ajoute une commande sans régénérer, ce qui est précisément le moment où la
+    documentation se met à mentir.
+    """
+    import subprocess
+    import sys
+
+    generateur = RACINE / "scripts" / "generer-doc.py"
+    if not generateur.is_file():
+        pytest.skip("générateur absent de ce dépôt")
+
+    proc = subprocess.run(  # noqa: S603 : notre propre script
+        [sys.executable, str(generateur), "--verifier"],
+        capture_output=True, text=True, cwd=RACINE,
+    )
+    assert proc.returncode == 0, (
+        f"la documentation a dérivé de la CLI :\n{proc.stdout}\n"
+        "Régénère-la : python3 scripts/generer-doc.py"
+    )


### PR DESCRIPTION
Closes #70
Refs #86

# Summary

Le README ouvrait sur la procédure d'un **contributeur** :

```bash
git clone https://github.com/stephrobert/dsoxlab.git
cd dsoxlab
uv tool install --editable .
```

Alors que le paquet est publié sur PyPI, et que `doctor` recommandait déjà l'installation par PyPI. Qui suivait le README repartait avec une copie éditable dont il n'avait aucune raison de vouloir.

Désormais :

```bash
uv tool install dsoxlab      # ou : pipx install dsoxlab
dsoxlab --version
```

Puis, immédiatement, un premier lab sans rien cloner grâce à `dsoxlab demo`, et **seulement ensuite** un vrai catalogue. L'installation depuis les sources reste, reléguée en sous-section pour contributeurs.

## La table des commandes est générée, plus recopiée

Vous avez demandé que tout ce qui peut être automatisé avec le binaire le soit. `scripts/generer-doc.py` produit la table depuis l'application Typer, entre marqueurs, **dans les deux langues** (un interpréteur par langue, puisque `help=_("…")` est résolu à l'import).

Ce que la table écrite à la main disait encore :

| Ce qui était écrit | La réalité |
|---|---|
| `dsoxlab clean` → « Run the lab's `cleanup.sh` » | le zéro-bash interdit les `.sh` ; c'est `cleanup.yaml` |
| `demo` et `support` | absents |

Le contrôle est câblé à deux endroits : un hook pre-commit déclenché quand `cli.py`, l'i18n ou les README changent, et un test. **Vérifié par mutation** : ajouter une commande sans régénérer rend trois tests rouges (fullhelp EN, fullhelp FR, README).

## La section « Persistance » était fausse sur ses trois points

Vérifié dans le code plutôt que supposé :

| Ce qu'annonçait le README | Ce que dit le code |
|---|---|
| `~/.local/share/dsoxlab/progress.db` | `<catalogue>/.dsoxlab.db` (`sessions/store.py:10`) |
| `~/.config/dsoxlab/config.yaml` | aucune occurrence dans `src/` |
| surcharge par `XDG_CONFIG_HOME` | jamais lue ; les trois variables honorées sont `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME` |

Le `CLAUDE.md` du projet avait relevé ce point pour lui-même ; le README ne l'avait jamais suivi. La conséquence pratique manquait aussi : **la progression est par catalogue**, jamais globale.

C'est la moitié documentaire de #86, d'où un `Refs` et non un `Closes` : la séparation par publics et le site de documentation dédié restent à faire.

## Deux erreurs que la relecture du diff m'a rendues

Mon découpage du README français a **avalé la section `## Runtimes`**. Puis, en la restaurant, je l'ai tronquée : je cherchais `---` et j'ai trouvé la ligne de séparation d'un tableau Markdown (`| --- | --- |`) avant la règle horizontale. Les deux sont corrigées, et le diff des titres le confirme.

## Vérifications

| Contrôle | Résultat |
|---|---|
| Suite complète | **295 passed, 4 skipped** |
| `ruff` (dont `scripts/`), `mypy` strict | verts |
| `generer-doc.py --verifier` | les deux README à jour |
| Trois catalogues fournisseurs | 84, 113, 87 labs, aucun écart disque/découverts |

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `ruff check src/dsoxlab tests scripts` passes
- [x] `mypy src/dsoxlab` passes (strict)
- [x] `pytest` passes : **295 passed**
- [x] The engine stays domain-agnostic : le générateur lit l'application Typer, il ne connaît aucun domaine
- [x] No hardcoded personal path or host
- [x] Manually tested against **three** lab repositories

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated (entrée 0.1.45, aux côtés de `demo`)
- [x] Version : **déjà portée à 0.1.45** par la PR #117, non encore publiée ; `uv.lock` aligné. Le README documente `demo`, les deux sortiront ensemble.

### When a command or option is added, removed or changed

**N/A** : aucune commande ni option n'est ajoutée, retirée ou modifiée. Cette PR ne fait que décrire celles qui existent, et rend cette description automatique.

### When `.github/workflows/` is touched

**N/A** : aucun workflow modifié. `.pre-commit-config.yaml` gagne un hook local, sans action tierce, donc ni `zizmor`, ni `poutine`, ni l'épinglage par SHA ne sont concernés.

### When the declarative contract changes

**N/A** : contrat inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
