### PR TITLE
fix(cli): migrer la complétion vers autocompletion, et la mettre enfin sous test (0.1.50)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,40 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.50] - 2026-08-20
+
+### Modifié
+
+- **La complétion shell ne repose plus sur `shell_complete`, que typer
+  déprécie.** Les dix arguments `lab_id` (`show`, `run`, `course`, `challenge`,
+  `guide`, `hint`, `check`, `submit`, `reset`, `clean`) passaient par le
+  `shell_complete=` de click, un mot-clé dont typer 0.27 avertit et dont il
+  annonce la suppression. Le passage à `autocompletion=` n'est pas un
+  renommage : la fonction ne reçoit plus les trois positionnels
+  `(ctx, param, incomplete)`, mais les paramètres que typer déduit de ses
+  annotations, et elle rend désormais des couples `(valeur, aide)` au lieu des
+  `CompletionItem` de click, que typer refuse. L'aide affichée à côté de chaque
+  proposition, le titre du lab, est préservée : zsh affiche toujours
+  `identifiant-du-lab -- Titre du lab`.
+
+- **La suite n'émet plus un seul `DeprecationWarning` de typer,** contre 490 par
+  exécution. Une dépréciation noyée dans 490 autres n'est plus un signal, et la
+  prochaine, celle qui comptera vraiment, serait arrivée dans ce bruit.
+
+### Ajouté
+
+- **La complétion est enfin couverte par des tests qui la déclenchent
+  vraiment.** Rien n'exerçait le mécanisme : la complétion pouvait cesser de
+  proposer quoi que ce soit sans que ruff, mypy ni la suite ne bronchent, et la
+  panne ne serait apparue que sous la forme d'un `Tab` sans effet chez
+  l'apprenant. Les nouveaux tests demandent une complétion à la CLI comme le
+  fait le shell, par la variable d'environnement que pose le script zsh généré,
+  puis lisent ce qui revient : les propositions, le filtrage par le préfixe
+  saisi, l'aide affichée, les dix commandes une par une, et les cas dégradés
+  (hors d'un dépôt de labs, avec un `meta.yml` cassé, avec un contrat trop
+  récent pour être lu) où le `except` aveugle doit rendre une liste vide plutôt
+  qu'une trace Python dans le shell.
+
 ## [0.1.49] - 2026-08-20
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.50] - 2026-08-20
+
+### Changed
+
+- **Shell completion no longer relies on `shell_complete`, which typer
+  deprecates.** The ten `lab_id` arguments (`show`, `run`, `course`,
+  `challenge`, `guide`, `hint`, `check`, `submit`, `reset`, `clean`) went
+  through click's `shell_complete=`, a keyword typer 0.27 warns about and
+  announces the removal of. Moving to `autocompletion=` is not a rename: the
+  callback no longer receives `(ctx, param, incomplete)` positionally, but the
+  parameters typer derives from its annotations, and it now returns
+  `(value, help)` pairs instead of click `CompletionItem` objects, which typer
+  refuses. The help text next to each proposal, the lab title, is preserved:
+  zsh still displays `lab-id -- Lab title`.
+
+- **The suite no longer emits a single typer `DeprecationWarning`,** down from
+  490 per run. A deprecation drowned in 490 others is no longer a signal, and
+  the next one, the one that will matter, would have arrived in that noise.
+
+### Added
+
+- **Completion is now covered by tests that actually trigger it.** Nothing
+  exercised the mechanism: the completion could have stopped proposing anything
+  at all while ruff, mypy and the whole suite stayed green, and the failure
+  would only have shown up as a `Tab` that does nothing on a learner's machine.
+  The new tests ask the CLI for a completion the way the shell does, through the
+  environment variable the generated zsh script sets, and read what comes back:
+  the proposals themselves, the prefix filtering, the help text, all ten
+  commands one by one, and the degraded cases (outside a lab repository, with a
+  broken `meta.yml`, with a contract too recent to read) where the blind
+  `except` must yield no proposal rather than a Python traceback in the shell.
+
 ## [0.1.49] - 2026-08-20
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.49"
+version = "0.1.50"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -33,7 +33,6 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Any, NoReturn
 
-import click
 import typer
 from typer.core import TyperGroup, TyperOption
 
@@ -323,16 +322,29 @@ def _lang(root: Path) -> str:
     return get_lang(ctx_lang=ctx.lang)
 
 
-def _complete_lab_id(
-    ctx: click.Context, param: click.Parameter, incomplete: str
-) -> list[Any]:
-    """Retourne la liste des lab IDs disponibles pour l'auto-complétion."""
-    from click.shell_completion import CompletionItem
+def _complete_lab_id(incomplete: str) -> list[tuple[str, str]]:
+    """Propose les lab IDs du dépôt courant, filtrés par ce qui est déjà saisi.
+
+    Contrat **typer**, pas celui de click. Deux différences, et elles ne sont
+    pas cosmétiques :
+
+    - typer construit lui-même les paramètres passés ici, d'après les
+      annotations de cette signature (``incomplete: str`` reçoit le préfixe
+      saisi). Il n'attend donc pas les trois positionnels
+      ``(ctx, param, incomplete)`` de click, et ce qu'on ne déclare pas n'est
+      pas injecté ;
+    - le retour est une liste de couples ``(valeur, aide)``. C'est typer qui en
+      fait des ``CompletionItem`` : lui rendre l'objet click directement casse
+      son adaptateur, qui exige une chaîne ou un couple.
+
+    Le second élément du couple est l'aide affichée à côté de la proposition,
+    c'est-à-dire le titre du lab. Elle survit à la migration, et zsh l'affiche.
+    """
     try:
         root = get_lab_home()
         labs = get_all_labs(root)
         return [
-            CompletionItem(lab.id, help=lab.title)
+            (lab.id, lab.title)
             for lab in labs
             if lab.id.startswith(incomplete)
         ]
@@ -666,7 +678,7 @@ def list_labs(
 
 @app.command("show", help=_("cmd_show_help"))
 def show(
-    lab_id: Annotated[str, typer.Argument(help=_("cmd_show_arg"), shell_complete=_complete_lab_id)],
+    lab_id: Annotated[str, typer.Argument(help=_("cmd_show_arg"), autocompletion=_complete_lab_id)],
     lab_home: LabHomeOption = None,
 ) -> None:
     root = _root(lab_home)
@@ -689,7 +701,7 @@ def show(
 
 @app.command("run", help=_("cmd_run_help"))
 def run(
-    lab_id: Annotated[str, typer.Argument(help=_("cmd_run_arg"), shell_complete=_complete_lab_id)],
+    lab_id: Annotated[str, typer.Argument(help=_("cmd_run_arg"), autocompletion=_complete_lab_id)],
     target: Annotated[str | None, typer.Option("--target", "-t",
         help=_("opt_run_target"))] = None,
     lab_home: LabHomeOption = None,
@@ -763,7 +775,7 @@ def run(
 
 @app.command("course", help=_("cmd_course_help"))
 def course(
-    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_course_arg"), shell_complete=_complete_lab_id)] = None,
+    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_course_arg"), autocompletion=_complete_lab_id)] = None,
     section: Annotated[str | None, typer.Option("--section", "-s", help=_("cmd_course_opt_section"))] = None,
     next_section: Annotated[bool, typer.Option("--next", "-n", help=_("cmd_course_opt_next"))] = False,
     prev_section: Annotated[bool, typer.Option("--prev", "-p", help=_("cmd_course_opt_prev"))] = False,
@@ -843,7 +855,7 @@ def _show_course_section(
 
 @app.command("challenge", help=_("cmd_challenge_help"))
 def challenge_cmd(
-    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_challenge_arg"), shell_complete=_complete_lab_id)] = None,
+    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_challenge_arg"), autocompletion=_complete_lab_id)] = None,
     no_pager: NoPagerOption = False,
     lab_home: LabHomeOption = None,
 ) -> None:
@@ -857,7 +869,7 @@ def challenge_cmd(
 
 @app.command("guide", help=_("cmd_guide_help"))
 def guide(
-    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_guide_arg"), shell_complete=_complete_lab_id)] = None,
+    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_guide_arg"), autocompletion=_complete_lab_id)] = None,
     print_only: Annotated[bool, typer.Option("--print", help=_("cmd_guide_opt_print"))] = False,
     lab_home: LabHomeOption = None,
 ) -> None:
@@ -895,7 +907,7 @@ def guide(
 
 @app.command("hint", help=_("cmd_hint_help"))
 def hint(
-    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_hint_arg"), shell_complete=_complete_lab_id)] = None,
+    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_hint_arg"), autocompletion=_complete_lab_id)] = None,
     lab_home: LabHomeOption = None,
 ) -> None:
     root = _root(lab_home)
@@ -1120,7 +1132,7 @@ def _run_check(
 
 @app.command("check", help=_("cmd_check_help"))
 def check(
-    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_check_arg"), shell_complete=_complete_lab_id)] = None,
+    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_check_arg"), autocompletion=_complete_lab_id)] = None,
     target: Annotated[str | None, typer.Option("--target", "-t",
         help=_("opt_check_target"))] = None,
     as_json: Annotated[bool, typer.Option("--json", help=_("opt_json"))] = False,
@@ -1158,7 +1170,7 @@ def check(
 
 @app.command("submit", help=_("cmd_submit_help"))
 def submit(
-    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_submit_arg"), shell_complete=_complete_lab_id)] = None,
+    lab_id: Annotated[str | None, typer.Argument(help=_("cmd_submit_arg"), autocompletion=_complete_lab_id)] = None,
     target: Annotated[str | None, typer.Option("--target", "-t",
         help=_("opt_check_target"))] = None,
     lab_home: LabHomeOption = None,
@@ -1275,7 +1287,7 @@ def next_lab(
 
 @app.command("reset", help=_("cmd_reset_help"))
 def reset(
-    lab_id: Annotated[str, typer.Argument(help=_("cmd_reset_arg"), shell_complete=_complete_lab_id)],
+    lab_id: Annotated[str, typer.Argument(help=_("cmd_reset_arg"), autocompletion=_complete_lab_id)],
     target: Annotated[str | None, typer.Option("--target", "-t",
         help=_("opt_run_target"))] = None,
     lab_home: LabHomeOption = None,
@@ -1308,7 +1320,7 @@ def reset(
 
 @app.command("clean", help=_("cmd_clean_help"))
 def clean(
-    lab_id: Annotated[str, typer.Argument(help=_("cmd_clean_arg"), shell_complete=_complete_lab_id)],
+    lab_id: Annotated[str, typer.Argument(help=_("cmd_clean_arg"), autocompletion=_complete_lab_id)],
     target: Annotated[str | None, typer.Option("--target", "-t",
         help=_("opt_run_target"))] = None,
     lab_home: LabHomeOption = None,

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,0 +1,250 @@
+"""La complétion au `Tab`, prise par la porte que le shell emprunte vraiment.
+
+Ce module existe parce que la migration de `shell_complete` (contrat click) vers
+`autocompletion` (contrat typer) ne se prouve pas en relisant le code. Les deux
+contrats diffèrent sur la signature ET sur le type de retour, et l'erreur ne se
+voit **nulle part** : ni `ruff`, ni `mypy`, ni la suite ne parlent d'un mécanisme
+qu'aucun test ne déclenchait. Une complétion débranchée ne propose simplement
+plus rien, en silence, chez l'apprenant.
+
+D'où le parti pris : ces tests n'appellent pas la fonction de complétion, ils
+**demandent une complétion à la CLI comme le fait le shell**. Le script que
+`dsoxlab install` pose dans `~/.zfunc/_dsoxlab` exécute exactement ceci ::
+
+    env _TYPER_COMPLETE_ARGS="${words[1,$CURRENT]}" _DSOXLAB_COMPLETE=complete_zsh dsoxlab
+
+Les deux variables ci-dessous sont donc celles du vrai script, et la sortie
+attendue est celle que zsh évalue : `_arguments '*: :(("id":"titre" …))'`, ou
+`_files` quand rien ne correspond.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+import typer.main
+from typer.testing import CliRunner
+
+from dsoxlab import cli
+from dsoxlab.cli import _COMPLETE_VAR, app
+
+runner = CliRunner()
+
+#: L'instruction que le script généré passe dans `_COMPLETE_VAR`. Typer garde
+#: l'ordre « instruction_shell » de click 7, là où click 8 dit « shell_source ».
+_INSTRUCTION_ZSH = "complete_zsh"
+
+#: La variable où le script zsh dépose la ligne de commande en cours de frappe.
+_ARGS_VAR = "_TYPER_COMPLETE_ARGS"
+
+#: Les dix commandes qui prennent un `lab_id`. La liste est écrite en dur, et
+#: c'est voulu : la dériver du code ferait passer au vert un site oublié.
+COMMANDES_A_LAB_ID = (
+    "show", "run", "course", "challenge", "guide",
+    "hint", "check", "submit", "reset", "clean",
+)
+
+LAB = """\
+id: {id}
+title: {titre}
+level: beginner
+skills: [demo]
+distros: [any]
+doc_url: https://example.org/docs/demo/
+runtime:
+  type: shell
+  workdir: challenge/work
+"""
+
+META = "repo:\n  id: demo-training\n  category: demo\n"
+
+#: Trois labs, dont deux partagent un préfixe : sans quoi un filtre absent
+#: passerait inaperçu, toutes les propositions étant de toute façon attendues.
+LABS = (
+    ("alpha-un", "Monter un volume"),
+    ("alpha-deux", "Étendre un volume"),
+    ("beta", "Lire un journal"),
+)
+
+
+@pytest.fixture
+def catalogue(tmp_path: Path) -> Path:
+    """Un dépôt de labs minimal, mais lisible par la découverte."""
+    (tmp_path / "meta.yml").write_text(META, encoding="utf-8")
+    for lab_id, titre in LABS:
+        dossier = tmp_path / "labs" / "demo" / lab_id
+        (dossier / "challenge" / "tests").mkdir(parents=True)
+        (dossier / "lab.yaml").write_text(
+            LAB.format(id=lab_id, titre=titre), encoding="utf-8"
+        )
+        (dossier / "README.md").write_text("# Demo\n", encoding="utf-8")
+        (dossier / "scenario.md").write_text("# Scenario\n", encoding="utf-8")
+    return tmp_path
+
+
+def _tab(racine: Path, saisie: str) -> str:
+    """Ce que le shell reçoit après un `Tab` sur ``saisie``.
+
+    ``saisie`` est la ligne de commande telle que zsh la transmet, curseur
+    compris : « dsoxlab run alph » complète le mot en cours, « dsoxlab run »
+    suivi d'une espace demande toutes les propositions.
+    """
+    resultat = runner.invoke(
+        app,
+        [],
+        env={
+            _COMPLETE_VAR: _INSTRUCTION_ZSH,
+            _ARGS_VAR: saisie,
+            "LAB_HOME": str(racine),
+        },
+    )
+    assert resultat.exit_code == 0, f"la complétion a échoué : {resultat.output}"
+    return resultat.output
+
+
+# ── ce que la complétion propose ─────────────────────────────────────────────
+
+def test_le_shell_recoit_les_labs_du_depot(catalogue: Path) -> None:
+    """Le test qui rougit si la complétion est débranchée, et lui seul suffit."""
+    propositions = _tab(catalogue, "dsoxlab run ")
+
+    for lab_id, _titre in LABS:
+        assert f'"{lab_id}"' in propositions
+
+
+def test_le_prefixe_deja_saisi_filtre(catalogue: Path) -> None:
+    """Sans filtre, zsh proposerait tout le catalogue à chaque Tab, soit une
+    centaine de labs sur les dépôts réels."""
+    propositions = _tab(catalogue, "dsoxlab run alpha")
+
+    assert '"alpha-un"' in propositions
+    assert '"alpha-deux"' in propositions
+    assert '"beta"' not in propositions
+
+
+def test_le_titre_du_lab_reste_affiche(catalogue: Path) -> None:
+    """L'aide de chaque proposition survit à la migration vers `autocompletion`.
+
+    C'est la seule chose que le contrat de typer aurait pu faire perdre : il
+    n'accepte plus l'objet `CompletionItem` de click, seulement une chaîne ou
+    un couple `(valeur, aide)`. Rendre la chaîne seule aurait été silencieux :
+    la complétion aurait continué de fonctionner, sans les titres.
+    """
+    propositions = _tab(catalogue, "dsoxlab run alpha-un")
+
+    assert '"alpha-un":"Monter un volume"' in propositions
+
+
+def test_un_prefixe_sans_correspondance_ne_propose_rien(catalogue: Path) -> None:
+    """`_files` est la façon dont zsh dit « rien pour moi, montre des fichiers »."""
+    assert _tab(catalogue, "dsoxlab run zzz").strip() == "_files"
+
+
+@pytest.mark.parametrize("commande", COMMANDES_A_LAB_ID)
+def test_chaque_commande_a_lab_id_complete(commande: str, catalogue: Path) -> None:
+    """Les dix sites, un par un : en oublier un ne se verrait pas autrement."""
+    assert '"alpha-un"' in _tab(catalogue, f"dsoxlab {commande} alpha-un")
+
+
+# ── ce qu'elle ne doit jamais faire : cracher une trace ───────────────────────
+
+def test_hors_d_un_depot_de_labs_rien_ne_casse(tmp_path: Path) -> None:
+    """L'apprenant tabule dans ~/Téléchargements : pas de proposition, pas de bruit."""
+    assert _tab(tmp_path, "dsoxlab run ").strip() == "_files"
+
+
+def test_un_meta_yml_illisible_ne_leve_pas(tmp_path: Path) -> None:
+    """YAML cassé en cours d'édition : la lecture du dépôt lève, pas la complétion."""
+    (tmp_path / "meta.yml").write_text("repo: [ceci nest pas: un mapping\n", encoding="utf-8")
+
+    assert _tab(tmp_path, "dsoxlab run ").strip() == "_files"
+
+
+def test_un_contrat_trop_recent_ne_leve_pas(tmp_path: Path) -> None:
+    """`UnsupportedSchemaVersion` est une exception ATTENDUE, et bien réelle.
+
+    Un dépôt de labs écrit pour un dsoxlab plus récent la déclenche à chaque
+    lecture du `meta.yml`. La CLI la rend en une phrase ; la complétion, elle,
+    n'a rien à dire à ce moment-là et doit se taire.
+    """
+    (tmp_path / "meta.yml").write_text(
+        "schema_version: 99\nrepo:\n  id: demo\n  category: demo\n", encoding="utf-8"
+    )
+
+    assert _tab(tmp_path, "dsoxlab run ").strip() == "_files"
+
+
+def test_toute_panne_de_lecture_est_avalee(
+    catalogue: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Le `except Exception` est délibéré : on le prouve avec une panne absurde.
+
+    Les cas ci-dessus sont des exceptions qu'on sait nommer. Celui-ci couvre
+    l'intention du filet : quoi qu'il arrive en lisant le catalogue, le shell
+    de l'apprenant ne reçoit pas de traceback Python.
+    """
+    def boum(*_args: object, **_kwargs: object) -> list[object]:
+        raise MemoryError("panne qu'aucun appelant n'anticipe")
+
+    monkeypatch.setattr(cli, "get_all_labs", boum)
+
+    assert _tab(catalogue, "dsoxlab run ").strip() == "_files"
+
+
+# ── le contrat de typer, et l'avertissement qu'il émettait ────────────────────
+
+def test_la_fonction_rend_des_couples_valeur_aide(
+    catalogue: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Typer n'accepte qu'une chaîne ou un couple, et son `assert` sur `str` casse.
+
+    Rendre un `CompletionItem` de click ferait échouer l'adaptateur de typer
+    *pendant* la complétion, donc dans le shell, donc nulle part où on le
+    verrait. Le vérifier ici est moins cher.
+    """
+    monkeypatch.setenv("LAB_HOME", str(catalogue))
+
+    propositions = cli._complete_lab_id("alpha")
+
+    assert sorted(propositions) == [
+        ("alpha-deux", "Étendre un volume"),
+        ("alpha-un", "Monter un volume"),
+    ]
+    assert all(isinstance(valeur, str) and isinstance(aide, str) for valeur, aide in propositions)
+
+
+def test_le_script_installe_pousse_ces_variables() -> None:
+    """Le harnais ci-dessus tire les mêmes leviers que le script de `install`.
+
+    Sans ce contrôle, ces tests pourraient rester verts sur un protocole que
+    plus personne n'emprunte : il suffirait que typer change de variable pour
+    que le shell de l'apprenant cesse de compléter sans qu'un test bronche.
+    """
+    from typer.completion import get_completion_script
+
+    script = get_completion_script(  # noqa: S604 (`shell` = nom du shell Typer, pas un subprocess shell=True)
+        prog_name=cli._PROG_NAME, complete_var=_COMPLETE_VAR, shell="zsh"
+    )
+
+    assert f"{_COMPLETE_VAR}={_INSTRUCTION_ZSH}" in script
+    assert _ARGS_VAR in script
+
+
+def test_construire_la_cli_n_avertit_plus() -> None:
+    """490 avertissements par exécution de la suite noyaient le prochain.
+
+    `shell_complete` est déprécié par typer, qui le dit une fois par argument
+    et par construction de la commande. Le contrôle porte sur l'absence de
+    l'avertissement, pas sur l'absence du mot-clé : un renommage partiel ne
+    passerait pas.
+    """
+    with warnings.catch_warnings(record=True) as journal:
+        warnings.simplefilter("always")
+        typer.main.get_command(app)
+
+    deprecations = [
+        str(a.message) for a in journal if issubclass(a.category, DeprecationWarning)
+    ]
+    assert deprecations == []

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.49"
+version = "0.1.50"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
# Summary

Migrates the ten `lab_id` arguments from `shell_complete=` (deprecated by typer
0.27) to `autocompletion=`, and — the part that actually matters — **puts the
completion under test for the first time**.

It was not a keyword rename. Measured in typer 0.27.1's own sources
(`typer/main.py:1849`, `typer/core.py:43`), two contract differences:

- typer does **not** inject `(ctx, param, incomplete)` positionally; it derives
  parameters from annotations, and `param` cannot be injected at all;
- its adapter does `CompletionItem(c[0], help=c[1])` on a tuple, and otherwise
  `assert isinstance(c, str)`. Returning click's `CompletionItem` — what the old
  code did — would have raised an `AssertionError` **during completion**, which
  is to say invisibly, in the learner's shell.

That last point is why this needed behavioural proof rather than a green suite.

## Why a green suite proved nothing here

No test touched the completion. The code could have stopped proposing anything
at all and `ruff`, `mypy` and all 400 tests would have stayed green. So the
verification had to run the mechanism, not read it — this repository's own rule:
*vérifier, ce n'est pas parser*.

**Real zsh, under a pseudo-terminal, with a real `Tab`**, against the generated
`_dsoxlab` file that `dsoxlab install` writes:

```
=== « dsoxlab run first-infra-v<Tab> » in terraform-training ===
first-infra-variables-outputs  -- Variables Outputs (skeleton)
first-infra-virtual-network    -- Reseau Virtuel (skeleton)
first-infra-vm-libvirt         -- Vm Libvirt (skeleton)

=== « dsoxlab run l2-s<Tab> » in linux-dsoxlab-training ===
l2-storage-performance  -- Tune a mount for performance with noatime (persistently)
l2-sudo-delegation      -- Delegate limited sudo rights with a sudoers drop-in
l2-swap-management      -- Add and manage swap space
```

The `-- title` on the right is the per-item help: it survives the migration.

Coverage against the three real catalogues, comparing files on disk to what the
`Tab` actually returns:

```
linux-dsoxlab-training :  84 lab.yaml on disk,  84 proposals (rc=0)
ansible-training       : 113 lab.yaml on disk, 113 proposals (rc=0)
terraform-training     :  87 lab.yaml on disk,  87 proposals (rc=0)
```

## The test bites

Verified independently, not taken on trust. Unwiring the completion
(`sed -i 's/, autocompletion=_complete_lab_id//g'`) turns **13 of the 21 tests
red**; restored, 21 pass. A finer unwiring — returning `lab.id` alone instead of
the `(value, help)` pair, so completion still works but loses its titles — turns
exactly 2 red.

## The noise is gone, and stays gone

| | Before | After |
|---|---|---|
| `pytest tests/ -q` | 400 passed, **490 warnings** | **421 passed, 0 warnings** |

490 deprecation warnings per run is not a signal any more; the next deprecation —
the one that will matter — would have arrived inside that noise. A test now locks
the zero.

## Type of change

- [x] Bug fix

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests fuzz scripts` passes — All checks passed!
- [x] `uv run mypy src/dsoxlab` passes (strict) — no issues in 57 source files
- [x] `uv run pytest` passes — **421 passed**, 0 warnings
- [x] The engine stays domain-agnostic
- [x] No hardcoded personal path or host; `pathlib.Path` throughout
- [x] Manually tested against **three** lab repositories, at the `Tab` itself and
      through `list-labs` / `validate-structure` (rc=0 on all three). Their
      `git status` is identical before and after.

### When behavior changes

- [x] Both `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped to 0.1.50 and `uv.lock` refreshed

### When a command or option is added, removed or changed

N/A — no command, option or displayed string changes, so no i18n key and no
`fullhelp` entry moves. `dsoxlab install` is unchanged and now has a test
asserting the generated script still drives this completion.

### When `.github/workflows/` is touched — N/A

### When the declarative contract changes — N/A

## Preserved on purpose

`_complete_lab_id` keeps its blind `except`, and its reason is still written
next to it: completion runs on every `Tab`, in any directory, and must never
push a Python traceback into a learner's shell. A missing `meta.yml`, a
`lab.yaml` that raises, a half-written catalogue — no proposal, and that is all.
Four tests now cover that degraded path instead of leaving it to good intentions.

`import click` had no remaining use in `cli.py` and is removed.

## Decisions worth reviewing

1. **0.1.50 rather than adding to 0.1.49.** 0.1.49 was on `main`, dated and
   written as a finished release, and has since been tagged — so appending to it
   would have described a change absent from the published artefact.
2. **`click>=8` stays declared in `pyproject.toml` although nothing imports it
   any more.** typer 0.27 no longer depends on click, it vendors it
   (`typer/_click/`). Removing the direct dependency changes the installed
   footprint of `uv tool install dsoxlab` and deserves its own change rather than
   a side effect of this one. Worth an issue.
3. **The callback no longer receives `param`.** Typer cannot inject it. No
   current use — the ten sites all complete the same `lab_id` — but a completion
   that ever needed to depend on its parameter would need one function per
   parameter.
4. **No bash-protocol test.** Everything above the callback belongs to typer and
   is shared by both shells; only formatting differs, and bash never shows the
   help anyway (`BashComplete.format_completion` returns the value alone).

## Pre-existing quirk found, not fixed

The **first `Tab` of a shell session is inert**. The `#compdef` script typer
generates defines `_dsoxlab_completion` and then re-registers itself, so the
first invocation proposes nothing and the second works. It is visible in the
captures above. Upstream typer, unrelated to this migration — but the learner
sees it.

## Related issues

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
