### PR TITLE
test(e2e): jouer le parcours complet sur la roue installée, sans importer le paquet (0.1.51)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,9 +19,13 @@ box reads as "forgotten", an explicit `N/A` reads as "considered".
 
 ### Always
 
-- [ ] `uv run ruff check src/dsoxlab tests fuzz` passes (lint + flake8-bandit)
+- [ ] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` passes
+      (lint + flake8-bandit)
 - [ ] `uv run mypy src/dsoxlab` passes (strict)
-- [ ] `uv run pytest` passes
+- [ ] `uv run pytest` passes (unit suite)
+- [ ] `uv run pytest tests_e2e` passes (black-box suite: it builds the wheel,
+      installs it and drives the binary — the only check that sees a packaging
+      defect)
 - [ ] The engine stays domain-agnostic — no domain-specific logic in
       `src/dsoxlab/` (no `if category == "linux"`)
 - [ ] No hardcoded personal path or host; `pathlib.Path` throughout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,13 +181,62 @@ jobs:
       # Python file, so leaving it out here made this job pass while the parity
       # job failed on the same code — the wrong order to learn it in.
       - name: Lint and security (ruff)
-        run: uv run ruff check src/dsoxlab tests fuzz scripts
+        run: uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts
 
       - name: Type-check (mypy strict)
         run: uv run mypy src/dsoxlab
 
       - name: Test (pytest)
         run: uv run pytest
+
+  # End-to-end gate — the only job that exercises the PROGRAM AS INSTALLED.
+  #
+  # The `quality` matrix above imports the package from `src/`, so it proves the
+  # functions do what they say and nothing about the distribution: a data file
+  # missing from the wheel, a broken `console_scripts` entry point or an import
+  # that only resolves in the source tree all pass it. This job builds the
+  # wheel, installs it into a throwaway venv and drives the `dsoxlab` binary by
+  # subprocess, from `demo` to a 100/100 score — the exact path a newcomer
+  # walks, and the one nobody replayed.
+  #
+  # No hypervisor, no Docker, no privilege: the packaged demonstration catalog
+  # is a `shell` lab, so this runs on a bare runner. Separate job on purpose —
+  # a red E2E and a red unit suite do not mean the same thing.
+  e2e:
+    name: End-to-end (black box, installed wheel)
+    needs: [zizmor, actionlint, poutine]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          version: "0.11.26"
+          enable-cache: true
+
+      # Warms the uv cache with exactly the dependencies the wheel declares, so
+      # the throwaway venv the suite creates is filled from disk instead of the
+      # network. It is also what provides pytest to run the suite itself.
+      - name: Sync dependencies (locked)
+        run: uv sync --frozen
+
+      # `tests_e2e/pytest.ini` is this suite's own configuration: the project's
+      # `testpaths` deliberately excludes it, so `uv run pytest` never picks it
+      # up by accident and the contribution gate keeps its measured duration.
+      - name: End-to-end suite (build the wheel, install it, drive the binary)
+        run: uv run pytest tests_e2e
 
   # Parity gate — run EVERY pre-commit hook (commit AND push stages) exactly as
   # a contributor's local pre-commit would, from this project's locked env. The

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,52 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.51] - 2026-08-21
+
+### Ajouté
+
+- **Une suite de bout en bout « boîte noire », `tests_e2e/`.** Les 421 tests
+  unitaires parlent tous au moteur depuis l'intérieur. Ils prouvent que les
+  fonctions font ce qu'elles disent ; ils ne prouvent jamais que *le programme
+  installé* se comporte comme promis. Un point d'entrée cassé, un fichier de
+  données absent de la roue, un `console_scripts` mal déclaré : rien de cela
+  n'était détectable par une suite verte. La nouvelle suite construit la roue,
+  l'installe dans un environnement virtuel jetable et pilote le binaire
+  `dsoxlab` par sous-processus, en n'assérant que sur le code de retour, la
+  sortie standard, la sortie d'erreur et les fichiers laissés sur le disque.
+
+- **Le parcours de l'inconnu est rejoué en entier :** `demo`, `list-labs`,
+  `run`, `check`, `scores`, d'une machine nue jusqu'au 100/100 sur le lab de
+  démonstration packagé. Il n'exige ni KVM, ni Incus, ni Docker, ni le moindre
+  privilège (le catalogue de démonstration est un lab `shell`), et le job dure
+  environ six secondes, construction de la roue comprise.
+
+- **La suite peut échouer, et c'est tout son intérêt.** Le même lab vaut 100/100
+  une fois résolu et 0/100 avec un code de retour non nul quand il ne l'est
+  pas ; prendre son unique indice fait tomber le même travail parfait à 80/100.
+  Exclure le catalogue de démonstration de la roue fait rougir les contrôles
+  d'empaquetage et entraîne tout le parcours avec eux : c'est la preuve que le
+  sujet du test est bien la distribution, et pas l'arborescence source.
+
+- **La règle « aucun import de `dsoxlab` » est tenue par un test,** sur le
+  modèle de `tests/test_i18n_coverage.py`. Trois portes, parce qu'une seule se
+  contourne : une analyse syntaxique de chaque fichier de la suite pour
+  `import dsoxlab`, une deuxième pour la voie dynamique
+  (`importlib.import_module("dsoxlab")`), et une troisième qui lit `sys.modules`
+  à l'exécution, qu'aucune astuce syntaxique n'esquive.
+
+### Modifié
+
+- **La CI gagne un job à elle, `End-to-end (black box, installed wheel)`.** Il
+  est séparé de la matrice unitaire à dessein : une E2E rouge et une suite
+  unitaire rouge ne disent pas la même chose, et seule la première annonce que
+  l'outil empaqueté est cassé. `tests_e2e/` porte sa propre `pytest.ini`, donc
+  `uv run pytest` continue de ne jouer que la suite unitaire et la porte de
+  contribution garde la durée qu'on lui a mesurée.
+
+- L'étape ruff lint désormais aussi `tests_e2e`, ce qui l'aligne sur le hook
+  pre-commit, qui a toujours tourné sur tous les fichiers Python de l'arbre.
+
 ## [0.1.50] - 2026-08-20
 
 ### Modifié

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.51] - 2026-08-21
+
+### Added
+
+- **A black-box end-to-end suite, `tests_e2e/`.** The 421 unit tests all speak
+  to the engine from the inside. They prove the functions do what they say; they
+  never prove that *the installed program* behaves as promised. A broken entry
+  point, a data file missing from the wheel, a mis-declared `console_scripts`:
+  none of it was detectable by a green suite. The new suite builds the wheel,
+  installs it into a throwaway virtualenv and drives the `dsoxlab` binary by
+  subprocess, asserting only on the exit code, stdout, stderr and the files left
+  on disk.
+
+- **The newcomer's path is replayed in full:** `demo`, `list-labs`, `run`,
+  `check`, `scores`, from a bare machine to 100/100 on the packaged
+  demonstration lab. It needs no KVM, no Incus, no Docker and no privilege — the
+  demonstration catalog is a `shell` lab — and the job takes about six seconds,
+  wheel build included.
+
+- **The suite can fail, and that is the whole point.** The same lab is worth
+  100/100 once solved and 0/100 with a non-zero exit code when it is not; taking
+  its single hint drops the same flawless run to 80/100. Excluding the
+  demonstration catalog from the wheel turns the packaging checks red and takes
+  the whole journey down with them, which is the proof that what is under test
+  is the distribution and not the source tree.
+
+- **The "no `dsoxlab` import" rule is held by a test,** on the model of
+  `tests/test_i18n_coverage.py`. Three doors, because one alone can be walked
+  around: a syntax check over every file of the suite for `import dsoxlab`, a
+  second for the dynamic route (`importlib.import_module("dsoxlab")`), and a
+  third that reads `sys.modules` at run time, which no syntactic trick escapes.
+
+### Changed
+
+- **CI gains a job of its own, `End-to-end (black box, installed wheel)`.** It
+  is kept separate from the unit matrix on purpose: a red end-to-end run and a
+  red unit run do not mean the same thing, and only the first one says the
+  packaged tool is broken. `tests_e2e/` carries its own `pytest.ini`, so
+  `uv run pytest` still runs the unit suite alone and the contribution gate
+  keeps its measured duration.
+
+- The ruff step now lints `tests_e2e` as well, aligning it with the pre-commit
+  hook, which has always run on every Python file of the tree.
+
 ## [0.1.50] - 2026-08-20
 
 ### Changed

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -65,10 +65,27 @@ cd ~/Projets/ansible-training && dsoxlab list-labs
 À lancer avant d'ouvrir une pull request. La CI exécute les mêmes contrôles.
 
 ```bash
-uv run ruff check src/dsoxlab tests fuzz   # lint + sécurité (règles flake8-bandit S)
-uv run mypy src/dsoxlab                    # typage (strict)
-uv run pytest                              # tests
+uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts   # lint + sécurité (règles flake8-bandit S)
+uv run mypy src/dsoxlab                                      # typage (strict)
+uv run pytest                                                # tests unitaires
+uv run pytest tests_e2e                                      # bout en bout, sur la roue construite
 ```
+
+### Les deux suites, et pourquoi elles sont séparées
+
+`tests/` importe le paquet et prouve que les fonctions font ce qu'elles disent.
+`tests_e2e/` ne l'importe jamais : elle construit la roue, l'installe dans un
+environnement virtuel jetable et pilote le binaire `dsoxlab` par sous-processus,
+en n'assérant que sur les codes de retour, la sortie standard, la sortie
+d'erreur et les fichiers laissés sur le disque. C'est la seule façon qu'un
+fichier de données absent de la roue, ou un point d'entrée `console_scripts`
+cassé, fasse rougir une construction.
+
+Une règle porte tout l'édifice, et un test porte la règle : **aucun fichier de
+`tests_e2e/` n'importe `dsoxlab`**. Ajoutez un tel import et
+`test_boite_noire.py` passe au rouge : c'est le moyen le plus rapide de
+comprendre à quoi sert cette suite. `tests_e2e/` a sa propre `pytest.ini`, donc
+le `testpaths` du projet la tient hors d'un simple `uv run pytest`.
 
 ### Scanners de workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,26 @@ cd ~/Projets/ansible-training && dsoxlab list-labs
 Run these before opening a pull request. CI runs the same checks.
 
 ```bash
-uv run ruff check src/dsoxlab tests fuzz   # lint + security (flake8-bandit S rules)
-uv run mypy src/dsoxlab                    # type-check (strict)
-uv run pytest                              # tests
+uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts   # lint + security (flake8-bandit S rules)
+uv run mypy src/dsoxlab                                      # type-check (strict)
+uv run pytest                                                # unit tests
+uv run pytest tests_e2e                                      # end-to-end, on the built wheel
 ```
+
+### The two suites, and why they are separate
+
+`tests/` imports the package and proves the functions do what they say.
+`tests_e2e/` never imports it: it builds the wheel, installs it into a
+throwaway virtualenv and drives the `dsoxlab` binary by subprocess, asserting
+only on exit codes, stdout, stderr and the files left on disk. That is the only
+way a data file missing from the wheel, or a broken `console_scripts` entry
+point, ever turns a build red.
+
+One rule holds the whole thing up, and a test holds the rule: **no file under
+`tests_e2e/` may import `dsoxlab`**. Add such an import and
+`test_boite_noire.py` goes red — try it, it is the fastest way to understand
+what the suite is for. `tests_e2e/` carries its own `pytest.ini`, so the
+project's `testpaths` keeps it out of a plain `uv run pytest`.
 
 ### Workflow scanners
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -354,8 +354,14 @@ uv sync                                     # installe les dépendances de dev
 uv run pre-commit install --install-hooks   # active les hooks git
 uv run ruff check src/dsoxlab               # lint + sécurité
 uv run mypy src/dsoxlab                     # typage (strict)
-uv run pytest                               # tests
+uv run pytest                               # tests unitaires
+uv run pytest tests_e2e                     # bout en bout, sur la roue construite
 ```
+
+`tests_e2e/` est une suite boîte noire : elle n'importe jamais `dsoxlab`. Elle
+construit la roue, l'installe dans un environnement virtuel jetable et pilote le
+binaire par sous-processus, de `dsoxlab demo` jusqu'au 100/100. C'est le seul
+contrôle qui voie un défaut d'empaquetage.
 
 Voir [CONTRIBUTING.fr.md](./CONTRIBUTING.fr.md) pour le workflow, les conventions de
 commit et les règles non négociables (le moteur reste neutre vis-à-vis du

--- a/README.md
+++ b/README.md
@@ -396,8 +396,14 @@ uv sync                                     # install dev dependencies
 uv run pre-commit install --install-hooks   # enable the git hooks
 uv run ruff check src/dsoxlab               # lint + security
 uv run mypy src/dsoxlab                     # type-check (strict)
-uv run pytest                               # tests
+uv run pytest                               # unit tests
+uv run pytest tests_e2e                     # end-to-end, on the built wheel
 ```
+
+`tests_e2e/` is a black-box suite: it never imports `dsoxlab`. It builds the
+wheel, installs it into a throwaway virtualenv and drives the binary by
+subprocess, from `dsoxlab demo` to a 100/100 score. It is the only check that
+sees a packaging defect.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the workflow, the commit
 conventions, and the non-negotiable rules (the engine must stay

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.50"
+version = "0.1.51"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -173,6 +173,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101"]  # assertions are the whole point of a test
+"tests_e2e/**" = ["S101"]  # même raison, pour la suite boîte noire
 
 [tool.mypy]
 strict = true

--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -1,0 +1,268 @@
+"""Le harnais de la suite E2E : construire la roue, l'installer, s'en servir.
+
+Cette suite est une boîte noire. Elle n'importe jamais `dsoxlab` (un test le
+vérifie, cf. `test_boite_noire.py`) : elle construit la distribution, l'installe
+dans un environnement neuf, lance le binaire par sous-processus, et n'assère que
+sur le code de retour, la sortie standard, la sortie d'erreur et les fichiers
+laissés sur le disque.
+
+**Ce qui fait la valeur du procédé, et ce qu'il faut ne pas casser.**
+
+La roue est le sujet du test, pas un détail d'exécution. Une installation
+« editable », ou un `src/` laissé sur le `sys.path`, rendrait la suite verte
+tout en ne testant plus l'empaquetage : un fichier de données oublié dans la
+roue, un `console_scripts` mal déclaré, un point d'entrée cassé passeraient
+inaperçus, et ce sont exactement les défauts que la suite unitaire ne peut pas
+voir. D'où trois précautions, toutes vérifiables :
+
+* l'environnement d'installation est un venv créé pour l'occasion, jamais celui
+  du projet (`_sans_venv()` retire `VIRTUAL_ENV` de l'appel à uv) ;
+* l'environnement d'exécution est reconstruit à la main, sans `PYTHONPATH` et
+  avec un `PATH` qui ne contient que le venv et le système ;
+* chaque commande part d'un `HOME` neuf, avec ses répertoires XDG à lui, pour
+  qu'aucun test ne lise la progression d'un autre ni celle de la machine.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+#: La racine du dépôt : le parent de cette suite. Aucun chemin personnel, et
+#: rien qui suppose d'où pytest a été lancé.
+DEPOT = Path(__file__).resolve().parent.parent
+
+#: Le lab du catalogue de démonstration packagé. La suite ne le découvre pas
+#: par magie : c'est celui que `dsoxlab demo` annonce, et celui qu'un
+#: utilisateur joue en premier.
+LAB_DEMO = "premiers-pas"
+
+#: Ce qu'il faut produire pour résoudre ce lab, écrit ici comme un apprenant
+#: l'aurait lu dans le cours, la mission et l'indice. C'est le seul endroit de
+#: la suite où une réponse est connue d'avance : tout le reste passe par la CLI.
+REPONSES = {
+    "cours.txt": "catalogue",
+    "mission.txt": "challenge",
+    "indice.txt": "progression",
+}
+
+#: Large, parce qu'un runner de CI froid est lent, et fini, parce qu'une suite
+#: qui pend est pire qu'une suite rouge.
+DELAI = 300
+
+
+def _uv() -> str:
+    """Le chemin d'uv, ou un échec qui dit pourquoi.
+
+    On ne saute pas la suite : une E2E désactivée en silence est une E2E qui
+    n'existe pas. Si uv manque, c'est l'environnement qu'il faut réparer.
+    """
+    chemin = shutil.which("uv")
+    if chemin is None:
+        pytest.fail(
+            "uv est introuvable. Cette suite construit la roue et l'installe "
+            "avec uv, comme la CI et comme l'utilisateur qui fait "
+            "`uv tool install dsoxlab`."
+        )
+    return chemin
+
+
+def _sans_venv() -> dict[str, str]:
+    """L'environnement des appels à uv, débarrassé du venv du projet.
+
+    Sans cela, `uv venv` et `uv pip install` viseraient l'environnement actif,
+    celui d'où pytest tourne : on installerait la roue par-dessus la source
+    déjà présente, et la suite ne prouverait plus rien de l'empaquetage.
+    """
+    env = dict(os.environ)
+    for variable in ("VIRTUAL_ENV", "PYTHONPATH", "UV_PROJECT_ENVIRONMENT"):
+        env.pop(variable, None)
+    return env
+
+
+def _executer(commande: list[str]) -> subprocess.CompletedProcess[str]:
+    """Une étape de préparation, qui doit réussir ou tout arrêter."""
+    return subprocess.run(
+        commande,
+        cwd=DEPOT,
+        env=_sans_venv(),
+        # check=True : construire ou installer la roue n'est pas ce que la
+        # suite mesure. Un échec ici est une panne du harnais, pas un verdict.
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=DELAI,
+    )
+
+
+@pytest.fixture(scope="session")
+def roue(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """La distribution construite, celle que PyPI servirait.
+
+    `DSOXLAB_E2E_WHEEL` permet de fournir une roue déjà construite : c'est ce
+    dont une matrice de distributions a besoin pour jouer le même scénario sur
+    plusieurs systèmes sans reconstruire à chaque fois.
+    """
+    fournie = os.environ.get("DSOXLAB_E2E_WHEEL")
+    if fournie:
+        chemin = Path(fournie).expanduser().resolve()
+        assert chemin.is_file(), f"DSOXLAB_E2E_WHEEL pointe sur un fichier absent : {chemin}"
+        return chemin
+
+    dist = tmp_path_factory.mktemp("dist")
+    _executer([_uv(), "build", "--wheel", "--out-dir", str(dist)])
+
+    roues = sorted(dist.glob("*.whl"))
+    assert len(roues) == 1, f"une roue et une seule attendue, obtenu : {roues}"
+    return roues[0]
+
+
+@dataclass(frozen=True)
+class Installation:
+    """Un dsoxlab installé comme un utilisateur l'installe."""
+
+    #: La distribution d'où tout vient.
+    roue: Path
+    #: L'environnement créé pour l'occasion.
+    venv: Path
+    #: Le script console posé par le point d'entrée `dsoxlab`.
+    binaire: Path
+    #: Le `site-packages` de ce venv, pour prouver ce qui y a été posé.
+    site_packages: Path
+
+
+@pytest.fixture(scope="session")
+def installation(roue: Path, tmp_path_factory: pytest.TempPathFactory) -> Installation:
+    """Installe la roue dans un environnement neuf, et rien d'autre dedans."""
+    venv = tmp_path_factory.mktemp("outil") / "venv"
+
+    # Le même interpréteur que celui qui fait tourner pytest : la matrice de
+    # versions Python de la CI garde ainsi son sens jusqu'ici.
+    _executer([_uv(), "venv", "--python", sys.executable, str(venv)])
+    _executer([_uv(), "pip", "install", "--python", str(venv / "bin" / "python"), str(roue)])
+
+    paquets = sorted((venv / "lib").glob("python3.*/site-packages"))
+    assert len(paquets) == 1, f"un seul site-packages attendu, obtenu : {paquets}"
+
+    return Installation(
+        roue=roue,
+        venv=venv,
+        binaire=venv / "bin" / "dsoxlab",
+        site_packages=paquets[0],
+    )
+
+
+@dataclass(frozen=True)
+class Poste:
+    """Le poste d'un utilisateur : un HOME neuf et le binaire installé."""
+
+    binaire: Path
+    maison: Path
+    #: Le répertoire neutre : pas de `meta.yml` au-dessus, donc pas de
+    #: catalogue. C'est là qu'on vérifie ce que l'outil dit quand il n'a rien.
+    neutre: Path
+    env: dict[str, str]
+
+    def lance(
+        self, *arguments: str, cwd: Path | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        """Lance `dsoxlab <arguments>` et rend le résultat brut.
+
+        `stdin` est fermé : `dsoxlab run` ouvre un sous-shell interactif, qui
+        lit une fin de fichier et rend la main aussitôt. C'est ce qui permet de
+        dérouler un lab sans terminal.
+        """
+        return subprocess.run(
+            [str(self.binaire), *arguments],
+            cwd=str(cwd or self.maison),
+            env=self.env,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=DELAI,
+            # check=False : la suite joue des parcours où l'échec est ATTENDU
+            # (un lab non résolu vaut 0 et sort en 1). Ce sont les assertions
+            # qui jugent, jamais subprocess.
+            check=False,
+        )
+
+
+@pytest.fixture
+def poste(installation: Installation, tmp_path: Path) -> Poste:
+    """Un poste vierge par test : rien ne fuit d'un test à l'autre."""
+    maison = tmp_path / "maison"
+    neutre = maison / "neutre"
+    for sous in (maison / ".local" / "share", maison / ".local" / "state",
+                 maison / ".cache", neutre):
+        sous.mkdir(parents=True, exist_ok=True)
+
+    env = {
+        # PATH reconstruit : rien de l'environnement de développement ne peut
+        # servir de béquille. `PYTHONPATH` est absent par construction, ce qui
+        # interdit au `src/` du dépôt de se glisser dans l'exécution.
+        "PATH": f"{installation.venv / 'bin'}:/usr/local/bin:/usr/bin:/bin",
+        "HOME": str(maison),
+        "XDG_DATA_HOME": str(maison / ".local" / "share"),
+        "XDG_STATE_HOME": str(maison / ".local" / "state"),
+        "XDG_CACHE_HOME": str(maison / ".cache"),
+        # Aucun appel réseau : la CI tourne derrière une politique d'egress, et
+        # un avis de mise à jour n'a rien à faire dans un test.
+        "DSOXLAB_NO_UPDATE_CHECK": "1",
+        # Langue figée : les assertions portent sur des phrases affichées.
+        "DSOXLAB_LANG": "en",
+        # Rich : sans couleur et à largeur fixe, sinon un repli de ligne ferait
+        # échouer une assertion sur la forme au lieu du fond.
+        "NO_COLOR": "1",
+        "TERM": "dumb",
+        "COLUMNS": "200",
+        # `run` ouvre `$SHELL` ; sans entrée, il rend la main immédiatement.
+        "SHELL": "/bin/sh",
+        # Le rendu porte des caractères non ASCII. Sans locale héritée, il faut
+        # le dire, sinon l'écriture sur un flux redirigé lève.
+        "PYTHONIOENCODING": "utf-8",
+    }
+
+    return Poste(binaire=installation.binaire, maison=maison, neutre=neutre, env=env)
+
+
+@pytest.fixture
+def catalogue(poste: Poste) -> Path:
+    """Le catalogue de démonstration, posé par la CLI elle-même.
+
+    C'est le premier maillon du parcours que promet le README : rien n'est
+    cloné, rien n'est copié à la main, l'outil se suffit à lui-même.
+    """
+    resultat = poste.lance("demo")
+    assert resultat.returncode == 0, resultat.stderr or resultat.stdout
+
+    racine = poste.maison / ".local" / "share" / "dsoxlab" / "demo"
+    assert (racine / "meta.yml").is_file(), (
+        "le catalogue packagé n'est pas arrivé sur le disque : signe que les "
+        "fichiers de données manquent à la roue"
+    )
+    return racine
+
+
+@pytest.fixture
+def resoudre() -> Callable[[Path], None]:
+    """Rend le geste de l'apprenant : écrire les réponses dans le workdir.
+
+    Le répertoire de travail est passé par l'appelant, qui l'a lu dans la
+    sortie `--json` de la CLI. La suite ne recopie donc aucun chemin du
+    contrat : elle utilise celui que le programme annonce.
+    """
+
+    def _resoudre(workdir: Path) -> None:
+        reponses = workdir / "reponses"
+        reponses.mkdir(parents=True, exist_ok=True)
+        for fichier, mot in REPONSES.items():
+            (reponses / fichier).write_text(mot + "\n", encoding="utf-8")
+
+    return _resoudre

--- a/tests_e2e/pytest.ini
+++ b/tests_e2e/pytest.ini
@@ -1,0 +1,17 @@
+# Configuration propre à la suite E2E, séparée de celle du dépôt.
+#
+# Deux raisons, et la seconde est la vraie.
+#
+# 1. `pyproject.toml` déclare `testpaths = ["tests"]`. Sans configuration
+#    distincte, `uv run pytest` ramasserait cette suite au milieu des tests
+#    unitaires, et le contrat de vitesse de la porte de contribution changerait
+#    sans que personne l'ait décidé.
+# 2. Cette suite ne parle pas au même sujet. Les tests de `tests/` prouvent que
+#    les fonctions font ce qu'elles disent ; ceux d'ici prouvent que le
+#    PROGRAMME INSTALLÉ se comporte comme promis. Un même run les mélangerait,
+#    et un échec ne dirait plus lequel des deux a cédé.
+#
+# Lancement :  uv run pytest tests_e2e
+[pytest]
+testpaths = .
+addopts = -ra

--- a/tests_e2e/test_boite_noire.py
+++ b/tests_e2e/test_boite_noire.py
@@ -1,0 +1,122 @@
+"""La règle de cette suite, tenue par un test plutôt que par la bonne volonté.
+
+**Aucun fichier de `tests_e2e/` n'importe `dsoxlab`.** C'est ce qui fait la
+différence entre « les fonctions font ce qu'elles disent » et « le programme
+installé se comporte comme promis ». Un import, même innocent, même dans un
+helper, rouvre la porte : on se remettrait à interroger le paquet source au
+lieu du binaire, et l'empaquetage cesserait d'être testé sans que la suite
+change de couleur.
+
+Le principe est celui de `tests/test_i18n_coverage.py`, qui analyse `cli.py`
+pour interdire les chaînes en dur : une règle écrite en prose ne tient pas, une
+règle vérifiée tient. Trois portes, parce qu'une seule se contourne :
+
+1. l'analyse syntaxique attrape `import dsoxlab` et `from dsoxlab… import …` ;
+2. elle attrape aussi l'import dynamique, `importlib.import_module("dsoxlab")`
+   et `__import__("dsoxlab")`, qu'aucune lecture d'`ast.Import` ne verrait ;
+3. et l'état du processus tranche à l'exécution : si le paquet avait été chargé
+   par un chemin auquel personne n'a pensé, il serait dans `sys.modules`.
+
+Pour vérifier que ce garde-fou mord, ajoutez `import dsoxlab` en tête de
+n'importe quel fichier de ce répertoire : les trois tests passent au rouge.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+#: Tous les fichiers Python de la suite, conftest compris. `rglob` et non
+#: `glob` : un sous-répertoire d'aides ne doit pas échapper à la règle.
+SUITE = sorted(Path(__file__).resolve().parent.rglob("*.py"))
+
+#: Le paquet interdit. Écrit une fois, pour que la règle se lise.
+INTERDIT = "dsoxlab"
+
+#: Les portes d'entrée de l'import dynamique.
+IMPORTEURS = {"import_module", "__import__"}
+
+
+def _vise_le_paquet(nom: str | None) -> bool:
+    """Le nom de module désigne-t-il `dsoxlab` ou l'un de ses sous-modules ?"""
+    return bool(nom) and (nom == INTERDIT or str(nom).startswith(f"{INTERDIT}."))
+
+
+def _arbre(fichier: Path) -> ast.Module:
+    return ast.parse(fichier.read_text(encoding="utf-8"), filename=str(fichier))
+
+
+def test_la_suite_a_bien_des_fichiers_a_controler() -> None:
+    """Un garde-fou qui ne regarde rien est vert pour de mauvaises raisons.
+
+    Si la découverte cassait, les trois tests suivants passeraient sur une
+    liste vide et ne prouveraient plus rien.
+    """
+    noms = {fichier.name for fichier in SUITE}
+    assert "conftest.py" in noms, f"suite introuvable depuis {Path(__file__).parent}"
+    assert len(SUITE) >= 3, f"suite anormalement courte : {sorted(noms)}"
+
+
+def test_aucun_fichier_de_la_suite_n_importe_le_paquet() -> None:
+    """`import dsoxlab` et `from dsoxlab import …` : la règle de base."""
+    coupables: list[str] = []
+    for fichier in SUITE:
+        for noeud in ast.walk(_arbre(fichier)):
+            if isinstance(noeud, ast.Import):
+                coupables += [
+                    f"{fichier.name}:{noeud.lineno} — import {alias.name}"
+                    for alias in noeud.names
+                    if _vise_le_paquet(alias.name)
+                ]
+            elif isinstance(noeud, ast.ImportFrom) and _vise_le_paquet(noeud.module):
+                coupables.append(f"{fichier.name}:{noeud.lineno} — from {noeud.module}")
+
+    assert not coupables, (
+        "Cette suite est une boîte noire : elle parle au programme installé, "
+        "jamais au paquet source. Un import de dsoxlab lui ferait tester "
+        "autre chose que la roue.\n  " + "\n  ".join(coupables)
+    )
+
+
+def test_aucun_import_dynamique_du_paquet() -> None:
+    """`importlib.import_module("dsoxlab")` contourne l'analyse des imports."""
+    coupables: list[str] = []
+    for fichier in SUITE:
+        for noeud in ast.walk(_arbre(fichier)):
+            if not isinstance(noeud, ast.Call):
+                continue
+            appele = noeud.func
+            nom = appele.attr if isinstance(appele, ast.Attribute) else (
+                appele.id if isinstance(appele, ast.Name) else None
+            )
+            if nom not in IMPORTEURS or not noeud.args:
+                continue
+            premier = noeud.args[0]
+            if isinstance(premier, ast.Constant) and _vise_le_paquet(
+                premier.value if isinstance(premier.value, str) else None
+            ):
+                coupables.append(f"{fichier.name}:{noeud.lineno} — {nom}({premier.value!r})")
+
+    assert not coupables, (
+        "Import dynamique du paquet : même règle, autre porte.\n  "
+        + "\n  ".join(coupables)
+    )
+
+
+def test_le_paquet_n_est_pas_charge_dans_ce_processus() -> None:
+    """La preuve à l'exécution, celle qu'aucune astuce syntaxique n'esquive.
+
+    Les modules de la suite sont tous importés avant que le premier test ne
+    s'exécute : un import en tête de fichier serait donc déjà là.
+    """
+    charges = sorted(
+        module
+        for module in sys.modules
+        if module == INTERDIT or module.startswith(f"{INTERDIT}.")
+    )
+
+    assert not charges, (
+        "Le paquet a été chargé dans le processus de test. La suite ne mesure "
+        f"plus l'empaquetage mais l'arborescence source : {charges}"
+    )

--- a/tests_e2e/test_installation.py
+++ b/tests_e2e/test_installation.py
@@ -1,0 +1,131 @@
+"""Ce que la suite unitaire ne peut pas voir : la distribution elle-même.
+
+Un point d'entrée mal déclaré, un fichier de données oublié dans la roue, un
+paquet installé en « editable » qui masque le défaut : rien de tout cela
+n'apparaît quand les tests importent le paquet depuis `src/`. Ces contrôles
+portent donc sur l'archive construite et sur l'environnement où elle a été
+installée, avant même de lancer la moindre commande.
+
+Pour vérifier qu'ils mordent : exclure `src/dsoxlab/templates/demo` de la cible
+`wheel` dans `pyproject.toml` fait rougir le premier test, puis le parcours
+complet, qui n'a soudain plus de catalogue à installer.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from conftest import DEPOT, Installation, Poste
+
+#: Ce que la roue doit porter en plus du code. Aucun de ces fichiers n'est
+#: importable : ce sont des données lues par `importlib.resources`, donc
+#: exactement la catégorie qu'un empaquetage rate en silence.
+DONNEES_ATTENDUES = (
+    # Le marqueur PEP 561, sans lequel les dépôts de labs perdent le typage.
+    "dsoxlab/py.typed",
+    # Le catalogue de démonstration : le premier lab que voit un utilisateur.
+    "dsoxlab/templates/demo/meta.yml",
+    "dsoxlab/templates/demo/labs/demo/premiers-pas/lab.yaml",
+    "dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/hints.yaml",
+    "dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/tests/test_functional.py",
+    # L'infra packagée : un dépôt de labs ne fournit ni Terraform ni cloud-init.
+    "dsoxlab/templates/terraform/kvm/main.tf",
+    "dsoxlab/templates/cloud-init/almalinux.yaml.tmpl",
+)
+
+
+def _contenu(roue: Path) -> list[str]:
+    with zipfile.ZipFile(roue) as archive:
+        return archive.namelist()
+
+
+def _fichier_de_la_roue(roue: Path, suffixe: str) -> str:
+    """Le contenu texte du premier membre dont le nom finit par *suffixe*."""
+    with zipfile.ZipFile(roue) as archive:
+        for nom in archive.namelist():
+            if nom.endswith(suffixe):
+                return archive.read(nom).decode("utf-8")
+    raise AssertionError(f"{suffixe} absent de la roue {roue.name}")
+
+
+def test_la_roue_embarque_les_fichiers_de_donnees(installation: Installation) -> None:
+    """Le code seul ne suffit pas : sans ces fichiers, l'outil ne sert à rien."""
+    presents = set(_contenu(installation.roue))
+    manquants = [attendu for attendu in DONNEES_ATTENDUES if attendu not in presents]
+
+    assert not manquants, (
+        f"la roue {installation.roue.name} ne porte pas ses données : {manquants}"
+    )
+
+
+def test_le_point_d_entree_console_est_declare(installation: Installation) -> None:
+    """`dsoxlab` doit exister comme commande, pas seulement comme module."""
+    declaration = _fichier_de_la_roue(installation.roue, ".dist-info/entry_points.txt")
+
+    # Espaces retirés : le format tolère « nom = cible » comme « nom=cible »,
+    # et ce test porte sur la déclaration, pas sur sa mise en page.
+    compacte = "".join(declaration.split())
+
+    assert "[console_scripts]" in declaration, declaration
+    assert "dsoxlab=dsoxlab.cli:main" in compacte, declaration
+
+
+def test_l_outil_teste_est_bien_la_roue_installee(installation: Installation) -> None:
+    """La garantie sans laquelle tout le reste perd son intérêt.
+
+    Trois faits, chacun vérifiable : le binaire est celui du venv éphémère, le
+    paquet y est posé en dur (pas un lien vers `src/`), et rien dans ce venv ne
+    ramène l'arborescence source sur le chemin d'import.
+    """
+    assert installation.binaire.is_file(), "aucun script console installé"
+    assert installation.venv in installation.binaire.parents
+
+    pose = installation.site_packages / "dsoxlab"
+    assert (pose / "cli.py").is_file(), "le paquet n'est pas installé en dur"
+    assert (pose / "templates" / "demo" / "meta.yml").is_file(), (
+        "les données de la roue ne sont pas arrivées dans site-packages"
+    )
+
+    # Une installation editable pose un `.pth` ou un module `__editable__…`
+    # qui ajoute `src/` au sys.path. Il n'y en a pas ici, et c'est la
+    # différence entre tester l'empaquetage et le contourner.
+    renvois = [
+        chemin
+        for chemin in installation.site_packages.glob("*.pth")
+        if str(DEPOT) in chemin.read_text(encoding="utf-8")
+    ]
+    editables = list(installation.site_packages.glob("__editable__*"))
+    assert not renvois, f"un .pth ramène le dépôt sur le sys.path : {renvois}"
+    assert not editables, f"installation editable détectée : {editables}"
+
+
+def test_la_version_annoncee_est_celle_de_la_roue(
+    poste: Poste, installation: Installation
+) -> None:
+    """Le programme installé dit la version qu'il porte, pas une autre."""
+    version = installation.roue.name.split("-")[1]
+    resultat = poste.lance("--version")
+
+    assert resultat.returncode == 0, resultat.stderr
+    assert version in resultat.stdout, (version, resultat.stdout)
+
+
+def test_l_aide_annonce_les_commandes_du_parcours(poste: Poste) -> None:
+    """`--help` est la première chose que lit un inconnu : elle doit répondre."""
+    resultat = poste.lance("--help")
+
+    assert resultat.returncode == 0, resultat.stderr
+    for commande in ("demo", "list-labs", "run", "check", "scores"):
+        assert commande in resultat.stdout, f"{commande} absente de l'aide"
+
+
+def test_une_commande_inconnue_sort_en_erreur(poste: Poste) -> None:
+    """Contrôle du harnais autant que de l'outil.
+
+    Si le lanceur rendait toujours 0, toutes les assertions de code de retour
+    de cette suite seraient décoratives. Celle-ci le prouve du contraire.
+    """
+    resultat = poste.lance("commande-qui-n-existe-pas")
+
+    assert resultat.returncode != 0

--- a/tests_e2e/test_parcours.py
+++ b/tests_e2e/test_parcours.py
@@ -1,0 +1,185 @@
+"""Le parcours que promet le README, joué en entier par sous-processus.
+
+Installation, catalogue, premier lab, note. C'est le chemin qu'emprunte un
+inconnu, et c'était le seul que personne ne rejouait. Tout passe par le binaire
+installé : la suite ne connaît de dsoxlab que ce qu'il imprime et ce qu'il
+laisse sur le disque.
+
+**La suite doit pouvoir échouer**, sinon elle ne mesure rien. Deux leviers le
+prouvent, et ils sont ici, pas dans un commentaire : le même lab rend 100 une
+fois résolu et strictement moins quand il ne l'est pas, et un indice pris coûte
+des points au barème. Modifier le lab de démonstration sans toucher à ses tests
+fait rougir cette suite, ce qui est exactement le but.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from conftest import LAB_DEMO, Poste
+
+
+def _document(sortie: str) -> Any:
+    """Le JSON de la sortie standard, refusé s'il traîne quoi que ce soit.
+
+    `json.loads` lève sur un flux qui commence par un message d'ambiance ou qui
+    se termine par une barre de progression : c'est le contrat de `--json`, et
+    c'est un défaut déjà vu trois fois en écrivant la CLI.
+    """
+    return json.loads(sortie)
+
+
+def _lab_annonce(poste: Poste, catalogue: Path) -> dict[str, Any]:
+    """Le lab tel que la CLI le décrit, pas tel que le contrat le raconte."""
+    resultat = poste.lance("list-labs", "--json", cwd=catalogue)
+    assert resultat.returncode == 0, resultat.stderr
+
+    document = _document(resultat.stdout)
+    assert document["count"] == 1, document
+    return dict(document["labs"][0])
+
+
+def _workdir(lab: dict[str, Any]) -> Path:
+    """Le répertoire de travail annoncé par la CLI, jamais recopié à la main."""
+    return Path(lab["path"]) / lab["runtime"]["workdir"]
+
+
+def _note(sortie: str) -> str:
+    """La ligne de score, ramenée à sa forme comparable.
+
+    Le panneau Rich rend « Score:       100 / 100 pts ». On ne compare donc pas
+    la mise en page, seulement les deux nombres.
+    """
+    return " ".join(sortie.split())
+
+
+# ── ce que l'outil fait quand il n'a rien ─────────────────────────────────────
+
+def test_hors_catalogue_l_outil_le_dit_sans_planter(poste: Poste) -> None:
+    """Lancé n'importe où, dsoxlab répond au lieu de laisser croire au vide."""
+    resultat = poste.lance("list-labs", cwd=poste.neutre)
+
+    assert resultat.returncode == 0, resultat.stderr
+    assert "No labs found" in resultat.stdout, resultat.stdout
+
+
+# ── le parcours complet ───────────────────────────────────────────────────────
+
+def test_de_l_installation_au_100_sur_100(
+    poste: Poste, catalogue: Path, resoudre: Callable[[Path], None]
+) -> None:
+    """Installer, voir le catalogue, jouer le lab, le résoudre, être noté.
+
+    Le `check` final se passe d'argument : c'est `run` qui a mémorisé le lab
+    actif, et cette mémoire fait partie du parcours promis.
+    """
+    liste = poste.lance("list-labs", cwd=catalogue)
+    assert liste.returncode == 0, liste.stderr
+    assert LAB_DEMO in liste.stdout, liste.stdout
+
+    lancement = poste.lance("run", LAB_DEMO, cwd=catalogue)
+    assert lancement.returncode == 0, lancement.stderr or lancement.stdout
+
+    workdir = _workdir(_lab_annonce(poste, catalogue))
+    assert workdir.is_dir(), f"run n'a pas créé le répertoire de travail {workdir}"
+
+    resoudre(workdir)
+
+    verdict = poste.lance("check", cwd=catalogue)
+    assert verdict.returncode == 0, verdict.stdout[-2000:]
+    assert "100 / 100" in _note(verdict.stdout), verdict.stdout[-2000:]
+
+    scores = poste.lance("scores", cwd=catalogue)
+    assert scores.returncode == 0, scores.stderr
+    assert "100/100" in _note(scores.stdout), scores.stdout
+
+
+def test_le_meme_lab_non_resolu_ne_vaut_pas_100(poste: Poste, catalogue: Path) -> None:
+    """L'autre moitié de la preuve : sans travail, pas de note.
+
+    Sans ce test, un `check` qui rendrait 100 quoi qu'il arrive passerait la
+    suite au vert. C'est le contrôle qui rend le précédent crédible.
+    """
+    lancement = poste.lance("run", LAB_DEMO, cwd=catalogue)
+    assert lancement.returncode == 0, lancement.stderr or lancement.stdout
+
+    verdict = poste.lance("check", LAB_DEMO, cwd=catalogue)
+
+    assert verdict.returncode == 1, "un lab non résolu doit sortir en erreur"
+    note = _note(verdict.stdout)
+    assert "0 / 100" in note, verdict.stdout[-2000:]
+    assert "100 / 100" not in note, verdict.stdout[-2000:]
+
+
+def test_un_indice_pris_coute_des_points(
+    poste: Poste, catalogue: Path, resoudre: Callable[[Path], None]
+) -> None:
+    """Le barème est vivant : un lab parfait ne vaut pas toujours 100.
+
+    L'unique indice du lab de démonstration coûte 20 points. Le travail est
+    juste, les trois tests passent, et la note descend quand même : c'est ce
+    que le scoring promet, et rien d'autre ne le vérifie de bout en bout.
+    """
+    assert poste.lance("run", LAB_DEMO, cwd=catalogue).returncode == 0
+
+    indice = poste.lance("hint", LAB_DEMO, cwd=catalogue)
+    assert indice.returncode == 0, indice.stderr
+
+    resoudre(_workdir(_lab_annonce(poste, catalogue)))
+    verdict = poste.lance("check", LAB_DEMO, cwd=catalogue)
+
+    assert verdict.returncode == 0, verdict.stdout[-2000:]
+    assert "80 / 100" in _note(verdict.stdout), verdict.stdout[-2000:]
+
+
+# ── le contrat de la sortie machine ───────────────────────────────────────────
+
+def test_la_sortie_json_se_lit_sans_reste(
+    poste: Poste, catalogue: Path, resoudre: Callable[[Path], None]
+) -> None:
+    """Une intégration lit ce flux : un mot de trop et il n'est plus lisible.
+
+    Le cas du `check` en échec est celui qui casse le plus facilement : un lab
+    qui passe n'emprunte jamais la branche qui imprime la sortie de pytest.
+    """
+    lab = _lab_annonce(poste, catalogue)
+    assert lab["id"] == LAB_DEMO, lab
+    assert lab["runtime"]["type"] == "shell", "le parcours doit tenir sans hyperviseur"
+
+    assert poste.lance("run", LAB_DEMO, cwd=catalogue).returncode == 0
+
+    echec = poste.lance("check", LAB_DEMO, "--json", cwd=catalogue)
+    assert echec.returncode == 1, echec.stdout[-2000:]
+    document = _document(echec.stdout)
+    assert document["check"]["ok"] is False
+    assert document["check"]["score"] == 0, document["check"]
+
+    resoudre(_workdir(lab))
+
+    reussite = poste.lance("check", LAB_DEMO, "--json", cwd=catalogue)
+    assert reussite.returncode == 0, reussite.stdout[-2000:]
+    document = _document(reussite.stdout)
+    assert document["check"] == {
+        **document["check"],
+        "ok": True,
+        "passed": 3,
+        "total": 3,
+        "score": 100,
+        "max_score": 100,
+    }
+
+
+# ── le catalogue packagé tient le contrat qu'il enseigne ──────────────────────
+
+def test_le_catalogue_package_passe_son_validateur(poste: Poste, catalogue: Path) -> None:
+    """Le premier lab que voit un utilisateur ne peut pas violer le contrat.
+
+    Le contrôle est joué par le binaire installé sur le catalogue qu'il vient
+    de poser : c'est l'outil qui se juge lui-même, sans dépôt tiers.
+    """
+    resultat = poste.lance("validate-structure", cwd=catalogue)
+
+    assert resultat.returncode == 0, resultat.stdout[-2000:]

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.50"
+version = "0.1.51"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
# Summary

Adds `tests_e2e/`, a black-box suite that installs the **built wheel** into a
throwaway venv and drives the binary by subprocess. Sixteen tests, 6 seconds.

The 421 existing tests all speak to the engine from the inside. They prove the
functions do what they say; they never prove that **the installed program**
behaves as promised. A broken entry point, a data file missing from the wheel, a
mis-declared `console_scripts`: none of it is detectable today. Three defects
found in recent work were exactly of that family, and all three were invisible to
a green suite.

## The three proofs that this suite can fail

A test that has never failed proves nothing, so each guarantee was broken on
purpose and the red observed.

**1. A data file dropped from the wheel is caught.** Adding
`exclude = ["src/dsoxlab/templates/demo"]` to `[tool.hatch.build.targets.wheel]`
— **without touching a single line of source** — gives:

```
FAILED test_installation.py::test_la_roue_embarque_les_fichiers_de_donnees
FAILED test_installation.py::test_l_outil_teste_est_bien_la_roue_installee
2 failed, 9 passed, 5 errors
```

The unit suite stays green throughout. That gap is the entire point of the lot.

**2. The no-import rule bites.** Adding `import dsoxlab` to a file of the suite:

```
FAILED test_boite_noire.py::test_aucun_fichier_de_la_suite_n_importe_le_paquet
FAILED test_boite_noire.py::test_le_paquet_n_est_pas_charge_dans_ce_processus
```

Static imports, dynamic `importlib.import_module`, and `sys.modules` at runtime
are all covered — plus a guard asserting the discovery itself is not empty, so
the rule cannot pass by finding nothing to check.

**3. The 100/100 assertion carries weight.** Breaking one expected answer in the
solved run turns three tests red, including the full journey, while the
"unsolved" test stays green — it asserts `rc=1`, `0 / 100` present and
`100 / 100` absent. A third lever: taking a hint on perfect work must yield
`80 / 100`.

All three were restored; the suite returns to 16 passed.

## Type of change

- [x] New feature
- [x] Chore / tooling

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — no issues in 57 source files
- [x] `uv run pytest` — **421 passed**, unchanged; `uv run pytest tests_e2e` — **16 passed**
- [x] Domain-agnostic: **not one line added to `src/dsoxlab/`**. The suite uses the
      packaged demo catalogue, so no teaching fixture enters the tool.
- [x] No hardcoded personal path or host
- [x] Manually tested against the **three** lab repositories with the wheel-installed
      binary: 84 / 113 / 87 labs, `list-labs` and `validate-structure` rc=0 on each.
      Their `git status` is identical before and after, and no `git checkout` was
      ever run there.

### When behavior changes

- [x] Both CHANGELOG files updated; version 0.1.51; `uv.lock` refreshed

### When a command or option is added, removed or changed

N/A — no command, option or displayed string changes, so no i18n key and no
`fullhelp` entry moves.

### When `.github/workflows/` is touched

- [x] `actionlint` rc=0
- [x] `zizmor --offline .github/workflows/` — No findings to report
- [x] `poutine analyze_local . --fail-on-violation` — rc=0, 13 rules passed
- [x] Every action pinned to a full 40-character SHA with its `# vX.Y.Z` comment
- [x] `step-security/harden-runner` is the job's first step
- [x] **No job renamed.** One job is added, `End-to-end (black box, installed
      wheel)` — see the action required below.
- [x] No new third-party action, so `.plumber.yaml` and `.poutine.yml` are unchanged
      (`plumber analyze` still PASSED, score A — 100.0/100)

## Duration, measured

| | |
|---|---|
| E2E, warm uv cache | **5.7–6.9 s** for 16 tests, wheel build included |
| E2E, cold uv cache (51 MB downloaded) | **7.2 s** |
| Unit suite, for comparison | 9.1 s for 421 tests |

#73 asks for this explicitly, and for good reason: an end-to-end suite that
doubles CI time gets disabled within six months. This one does not.

## Action required after merge

**The new job is not in the required status checks.** No job was renamed, so
nothing silently stopped being required — but `End-to-end (black box, installed
wheel)` will run without blocking until it is added to the ruleset. That is a
repository setting, not something this PR can carry.

## Decisions worth reviewing

1. **`tests_e2e/` is deliberately outside `testpaths`.** `uv run pytest` remains
   the unit suite alone; `uv run pytest tests_e2e` is the second. The alternative
   — one `testpaths` plus a `-m "not e2e"` default — was rejected so that neither
   command can disguise itself as the other.
2. **`uv` is a hard dependency of the suite**: if missing, `pytest.fail` with an
   explicit message rather than `skip`. An end-to-end suite that disables itself
   in silence does not exist.
3. **No Python matrix on the E2E job** — that is #84's subject. The harness is
   ready: `DSOXLAB_E2E_WHEEL` accepts a pre-built wheel.
4. **No pre-commit hook** for this suite: the CI parity gate would replay it a
   second time, and a `git push` offline with a cold uv cache would become
   blocking.
5. **`tests/test_demo.py::test_de_l_installation_au_100_sur_100` was left alone.**
   It covers a neighbouring journey but from the inside — it imports the package,
   uses the current environment's binary, and skips if absent. It tests something
   else.
6. **The demo catalogue is the only material.** A dedicated test catalogue would
   allow more (several labs, sections) but would need maintaining; as a bonus,
   the suite now also proves the packaged catalogue passes its own
   `validate-structure`.

## Related issues

Closes #73
Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
