### PR TITLE
fix(i18n): étendre le garde-fou à tout le paquet, et solder les 43 phrases en dur (0.1.53)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,55 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.53] - 2026-08-21
+
+### Modifié
+
+- **Le garde-fou i18n analyse désormais tout le paquet, plus le seul `cli.py`.**
+  La règle « tout texte affiché passe par `_()` » était déjà tenue par un test,
+  ce qui est la bonne façon de la tenir. Mais ce test n'analysait qu'un fichier.
+  Tout ce que lèvent `infra/`, `runtimes/`, `services/` et `templates/` lui
+  échappait, c'est-à-dire exactement les messages qu'un apprenant lit quand
+  quelque chose casse : une session entièrement anglaise répondait `terraform est
+  absent du PATH`. La règle avait un gardien qui ne regardait qu'une porte sur
+  cinq.
+
+- **Le critère est écrit dans le test, parce que c'est là qu'est la difficulté.**
+  Un garde-fou trop laxiste ne garde rien ; trop strict, il se fait désactiver au
+  premier faux positif. Un littéral est un texte d'interface quand deux choses
+  sont vraies ensemble. Il atteint un humain, par l'un de quatre puits : `help=`
+  et `description=`, les helpers `error`/`info`/`warn`/`success`, le texte d'un
+  `raise` (cette CLI rend ses erreurs par `error(str(exc))`, donc le message
+  d'une exception **est** de l'interface), et les verbes de sortie
+  `.print()`/`.echo()`/`.secho()`. Et il s'écrit comme une phrase, définie ici
+  comme au moins deux mots séparés par une espace, un fragment sans espace
+  comptant pour un seul mot. Cette dernière clause est tout le réglage : elle
+  laisse passer `meta.yml`, `challenge/tests`, `lab_starting` et la mise en forme
+  pure telle que `f"  ✔ {fqdn} ({ip})"`, tout en attrapant ce qui est écrit pour
+  être lu.
+
+- **Deux exclusions sont décidées à voix haute, chacune tenue par son test.**
+  `logger.*` n'est pas un puits d'interface : le journal est un artefact de
+  diagnostic, lu à côté d'une trace Python, et le traduire rendrait deux rapports
+  de bug incomparables selon la langue de qui les produit. `models/` reste hors
+  périmètre parce que le bon patron y vit déjà, `UnsupportedSchemaVersion` et
+  `ProviderUnresolved` portant des données pendant que la CLI compose la phrase
+  traduite ; convertir à ce patron les 24 `ValueError` du contrat est une
+  refonte, pas un correctif d'i18n.
+
+### Corrigé
+
+- **43 phrases françaises en dur ne fuient plus dans une session anglaise.**
+  Elles sont la conséquence du garde-fou étendu, pas sa raison d'être : il les a
+  fait apparaître d'un coup, dans `infra/credentials.py` (13), `runtimes/vm.py`
+  (8), `runtimes/services.py` (5), `infra/inventory.py` (4),
+  `infra/terraform.py` (4), `infra/ansible.py` (3), `runtimes/manager.py` (2),
+  `templates/__init__.py` (2), `infra/snapshot/__init__.py` (1) et
+  `services/lab_service.py` (1). Les 38 clés nouvelles ont été ajoutées
+  simultanément dans `i18n/strings/en.py` et `i18n/strings/fr.py`, et
+  `dsoxlab provision` sans terraform sur le PATH répond maintenant dans la langue
+  de la session, ce qui était le symptôme à l'origine de l'issue.
+
 ## [0.1.51] - 2026-08-21
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.53] - 2026-08-21
+
+### Changed
+
+- **The i18n guard now reads the whole package, not just `cli.py`.** The rule
+  "every displayed text goes through `_()`" was already held by a test, which is
+  the right way to hold it. But that test parsed a single file. Everything raised
+  from `infra/`, `runtimes/`, `services/` and `templates/` escaped it, and those
+  are precisely the messages a learner reads when something breaks: an entirely
+  English session answered `terraform est absent du PATH`. The rule had a keeper
+  watching one door out of five.
+
+- **The criterion is written into the test, because it is the hard part.** A
+  guard too loose keeps nothing; too strict, it gets disabled at the first false
+  positive. A literal is interface text when two things are true together. It
+  reaches a human, through one of four sinks: `help=` and `description=`, the
+  `error`/`info`/`warn`/`success` helpers, the text of a `raise` (this CLI
+  renders errors with `error(str(exc))`, so an exception message *is* interface
+  text), and the `.print()`/`.echo()`/`.secho()` output verbs. And it reads as a
+  sentence, defined as at least two words separated by a space, a whitespace-free
+  fragment counting for a single word. That last clause is the whole tuning: it
+  lets `meta.yml`, `challenge/tests`, `lab_starting` and pure layout such as
+  `f"  ✔ {fqdn} ({ip})"` through, while catching anything written to be read.
+
+- **Two exclusions are decided out loud, each held by its own test.** `logger.*`
+  is not an interface sink: the journal is a diagnostic artefact, read beside a
+  Python traceback, and translating it would make two bug reports incomparable
+  depending on the locale of whoever produced them. `models/` is left out because
+  the right pattern already lives there, `UnsupportedSchemaVersion` and
+  `ProviderUnresolved` carrying data while the CLI composes the translated
+  sentence; converting the contract's 24 `ValueError`s to that pattern is a
+  redesign, not an i18n fix.
+
+### Fixed
+
+- **43 hardcoded French sentences no longer leak into an English session.** They
+  are the consequence of the extended guard, not the reason for it: it surfaced
+  all of them at once, in `infra/credentials.py` (13), `runtimes/vm.py` (8),
+  `runtimes/services.py` (5), `infra/inventory.py` (4), `infra/terraform.py` (4),
+  `infra/ansible.py` (3), `runtimes/manager.py` (2), `templates/__init__.py` (2),
+  `infra/snapshot/__init__.py` (1) and `services/lab_service.py` (1). The 38 new
+  keys were added to `i18n/strings/en.py` and `i18n/strings/fr.py` at the same
+  time, and `dsoxlab provision` without terraform on the PATH now answers in the
+  language of the session, which was the symptom that opened the issue.
+
 ## [0.1.51] - 2026-08-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.51"
+version = "0.1.53"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -760,4 +760,106 @@ silent.
         "No libvirt domain matches host '{host}'. Names tried: {tried}. "
         "Existing domains: {domains}.",
     "libvirt_no_domain": "none",
+
+    # ── Errors raised outside cli.py ──────────────────────────────────────────
+    # The CLI renders these through `error(str(exc))`, so an exception message
+    # IS interface text — as much as a `help=`. They used to live hardcoded in
+    # French inside infra/, runtimes/, services/ and templates/, and came out
+    # untranslated under DSOXLAB_LANG=en. That is exactly the path a learner
+    # walks when something breaks.
+    "err_terraform_missing":
+        "terraform is not on your PATH: it provisions the machines of vm labs.\n"
+        "Install it: https://developer.hashicorp.com/terraform/install",
+    "err_terraform_host_unsupported":
+        "--host is not implemented for provider '{provider}'.",
+    "err_ansible_runner_missing":
+        "ansible-runner is not installed. Run: "
+        "uv tool install --force --with ansible-runner dsoxlab "
+        "or: pipx inject dsoxlab ansible-runner",
+    "err_ansible_playbook_missing":
+        "ansible-playbook is not on your PATH: a vm lab cannot play its "
+        "setup.yaml without it. ansible-runner drives ansible-core but does "
+        "not install it. Run: uv tool install ansible-core",
+    "err_ansible_playbook_file_missing": "Playbook not found: {path}",
+    "err_credentials_loader_unsupported":
+        "No credentials loader for provider '{provider}'. "
+        "See src/dsoxlab/infra/credentials.py.",
+    "err_credentials_outscale_file":
+        "File {path} is missing. Configure your Outscale credentials with "
+        "'oapi-cli configure' (or write the JSON by hand).",
+    "err_credentials_outscale_json": "{path}: invalid JSON ({error}).",
+    "err_credentials_profile_unknown":
+        "Profile '{profile}' not found in {path}. Available profiles: "
+        "{profiles}. Set it through meta.yml: {option}, or {env}=<name>.",
+    "err_credentials_profile_unknown_plain":
+        "Profile '{profile}' not found in {path}. Profiles: {profiles}.",
+    "err_credentials_fields_required":
+        "Profile '{profile}' in {path}: {fields} are required.",
+    "err_credentials_aws_file":
+        "File {path} is missing. Configure it with 'aws configure'.",
+    "err_credentials_gcp_file":
+        "File {path} is missing. Configure it with "
+        "'gcloud auth application-default login'.",
+    "err_credentials_azure_file":
+        "File {path} is missing. Configure it with 'az login'.",
+    "err_credentials_proxmox_file":
+        "File {path} is missing. Create it by hand with a Proxmox API token "
+        "(api_url, token_id, token_secret).",
+    "err_inventory_not_provisioned":
+        "No host has an address: the lab infrastructure is not provisioned.",
+    "err_inventory_target_unknown":
+        "target_fqdn '{fqdn}' is not in the list of known hosts: {known}",
+    "err_inventory_role_unknown":
+        "role '{role}' → '{fqdn}' is not in the list of known hosts: {known} "
+        "(host not declared in meta.yml, or not provisioned).",
+    "err_host_ready_timeout":
+        "{fqdn} is unreachable over SSH after {timeout}s "
+        "(cloud-init too slow, or the VM failed to boot).",
+    "err_snapshot_provider_unsupported":
+        "Snapshots are not implemented yet for provider '{provider}'. "
+        "See src/dsoxlab/infra/snapshot/__init__.py to add a backend.",
+    "err_runtime_unavailable":
+        "Runtime '{runtime}' is not available on this machine. Install the "
+        "dependencies (`dsoxlab instructor bootstrap`), or pick a lab that "
+        "runs on another runtime.",
+    "err_runtime_type_unknown": "Unknown RuntimeType: {rt_type}",
+    "err_service_network_failed":
+        "Cannot create network '{name}':\n{detail}",
+    "err_service_port_closed":
+        "Service '{name}' did not open port {port} within {timeout}s.",
+    "err_service_probe_failed":
+        "Service '{name}' never answered « {probe} » within {timeout}s.",
+    "err_service_start_failed":
+        "Service '{name}' failed to start:\n{detail}",
+    "err_service_post_start_failed":
+        "Initialising service '{name}' failed on « {command} »:\n{detail}",
+    "err_vm_setup_missing":
+        "Lab {lab_id} must ship setup.yaml at its root (dsoxlab contract for "
+        "runtime: vm). Expected file: {path}",
+    "err_vm_setup_failed":
+        "setup.yaml failed for {lab_id} on target '{target}' "
+        "(rc={rc}, status={status}). Stats: {stats}",
+    "err_vm_cleanup_missing":
+        "Lab {lab_id} must ship cleanup.yaml at its root (dsoxlab contract "
+        "for runtime: vm). Expected file: {path}",
+    "err_vm_cleanup_failed":
+        "cleanup.yaml failed for {lab_id} on target '{target}' "
+        "(rc={rc}, status={status}).",
+    "err_vm_no_target":
+        "Lab {lab_id} (runtime: vm) must declare at least one target under "
+        "runtime.targets[] in lab.yaml.",
+    "err_vm_target_unknown":
+        "Target '{name}' is unknown for lab {lab_id}. "
+        "Available targets: {available}",
+    "err_vm_no_meta":
+        "No meta.yml found walking up from {path}. "
+        "dsoxlab cannot derive the inventory.",
+    "err_vm_meta_invalid": "Invalid meta.yml: {path}",
+    "err_lab_not_found": "Lab not found: {lab_id}",
+    "err_template_terraform_missing":
+        "No Terraform template for provider '{provider}'. "
+        "Providers packaged in dsoxlab: {available}",
+    "err_template_cloud_init_missing":
+        "No cloud-init template for distribution '{distro}'. "
+        "Packaged distros: {available}",
 }

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -763,4 +763,107 @@ hors ligne, elle se tait.
         "Aucun domaine libvirt ne correspond à l'hôte « {host} ». "
         "Noms essayés : {tried}. Domaines existants : {domains}.",
     "libvirt_no_domain":  "aucun",
+
+    # ── Erreurs levées hors de cli.py ─────────────────────────────────────────
+    # La CLI les rend par `error(str(exc))` : le texte d'une exception EST de
+    # l'interface, au même titre qu'un `help=`. Il vivait en dur, en français,
+    # dans infra/, runtimes/, services/ et templates/, et sortait tel quel sous
+    # DSOXLAB_LANG=en. C'est exactement le chemin que suit un apprenant quand
+    # quelque chose casse.
+    "err_terraform_missing":
+        "terraform est absent du PATH : il provisionne les machines des labs vm.\n"
+        "Installe-le : https://developer.hashicorp.com/terraform/install",
+    "err_terraform_host_unsupported":
+        "--host non implémenté pour le provider « {provider} ».",
+    "err_ansible_runner_missing":
+        "ansible-runner n'est pas installé. Lance : "
+        "uv tool install --force --with ansible-runner dsoxlab "
+        "ou : pipx inject dsoxlab ansible-runner",
+    "err_ansible_playbook_missing":
+        "ansible-playbook est absent du PATH : un lab vm ne peut pas jouer "
+        "son setup.yaml sans lui. ansible-runner pilote ansible-core mais "
+        "ne l'installe pas. Lance : uv tool install ansible-core",
+    "err_ansible_playbook_file_missing": "Playbook absent : {path}",
+    "err_credentials_loader_unsupported":
+        "Loader credentials non implémenté pour le provider « {provider} ». "
+        "Voir src/dsoxlab/infra/credentials.py.",
+    "err_credentials_outscale_file":
+        "Fichier {path} absent. Configure tes credentials Outscale via "
+        "« oapi-cli configure » (ou crée le JSON manuellement).",
+    "err_credentials_outscale_json": "{path} : JSON invalide ({error}).",
+    "err_credentials_profile_unknown":
+        "Profil « {profile} » introuvable dans {path}. Profils disponibles : "
+        "{profiles}. Précise-le via meta.yml: {option}, ou {env}=<name>.",
+    "err_credentials_profile_unknown_plain":
+        "Profil « {profile} » introuvable dans {path}. Profils : {profiles}.",
+    "err_credentials_fields_required":
+        "Profil « {profile} » dans {path} : {fields} requis.",
+    "err_credentials_aws_file":
+        "Fichier {path} absent. Configure-le via « aws configure ».",
+    "err_credentials_gcp_file":
+        "Fichier {path} absent. Configure-le via "
+        "« gcloud auth application-default login ».",
+    "err_credentials_azure_file":
+        "Fichier {path} absent. Configure-le via « az login ».",
+    "err_credentials_proxmox_file":
+        "Fichier {path} absent. Crée-le manuellement avec un token API "
+        "Proxmox (api_url, token_id, token_secret).",
+    "err_inventory_not_provisioned":
+        "Aucun hôte n'a d'adresse : l'infrastructure du lab n'est pas "
+        "provisionnée.",
+    "err_inventory_target_unknown":
+        "target_fqdn « {fqdn} » n'est pas dans la liste des hôtes connus : {known}",
+    "err_inventory_role_unknown":
+        "role « {role} » → « {fqdn} » n'est pas dans la liste des hôtes "
+        "connus : {known} (host non déclaré dans meta.yml, ou non provisionné).",
+    "err_host_ready_timeout":
+        "{fqdn} injoignable en SSH après {timeout}s "
+        "(cloud-init trop long, ou VM en échec de démarrage).",
+    "err_snapshot_provider_unsupported":
+        "Snapshots non encore implémentés pour le provider « {provider} ». "
+        "Voir src/dsoxlab/infra/snapshot/__init__.py pour ajouter un backend.",
+    "err_runtime_unavailable":
+        "Le runtime « {runtime} » n'est pas disponible sur cette machine. "
+        "Installe les dépendances (`dsoxlab instructor bootstrap`), ou "
+        "utilise un lab compatible avec un autre runtime.",
+    "err_runtime_type_unknown": "RuntimeType inconnu : {rt_type}",
+    "err_service_network_failed":
+        "Impossible de créer le réseau « {name} » :\n{detail}",
+    "err_service_port_closed":
+        "Le service « {name} » n'a pas ouvert le port {port} en {timeout}s.",
+    "err_service_probe_failed":
+        "Le service « {name} » n'a jamais répondu à « {probe} » en {timeout}s.",
+    "err_service_start_failed":
+        "Le démarrage du service « {name} » a échoué :\n{detail}",
+    "err_service_post_start_failed":
+        "L'initialisation du service « {name} » a échoué sur « {command} » :\n{detail}",
+    "err_vm_setup_missing":
+        "Le lab {lab_id} doit fournir setup.yaml à la racine (contrat dsoxlab "
+        "pour runtime: vm). Fichier attendu : {path}",
+    "err_vm_setup_failed":
+        "setup.yaml a échoué pour {lab_id} sur la target « {target} » "
+        "(rc={rc}, status={status}). Stats : {stats}",
+    "err_vm_cleanup_missing":
+        "Le lab {lab_id} doit fournir cleanup.yaml à la racine (contrat "
+        "dsoxlab pour runtime: vm). Fichier attendu : {path}",
+    "err_vm_cleanup_failed":
+        "cleanup.yaml a échoué pour {lab_id} sur la target « {target} » "
+        "(rc={rc}, status={status}).",
+    "err_vm_no_target":
+        "Le lab {lab_id} (runtime: vm) doit déclarer au moins une target "
+        "dans runtime.targets[] de lab.yaml.",
+    "err_vm_target_unknown":
+        "Target « {name} » inconnue pour le lab {lab_id}. "
+        "Targets disponibles : {available}",
+    "err_vm_no_meta":
+        "Pas de meta.yml trouvé en remontant depuis {path}. "
+        "dsoxlab ne peut pas dériver l'inventory.",
+    "err_vm_meta_invalid": "meta.yml invalide : {path}",
+    "err_lab_not_found": "Lab introuvable : {lab_id}",
+    "err_template_terraform_missing":
+        "Template Terraform absent pour le provider « {provider} ». "
+        "Providers packagés dans dsoxlab : {available}",
+    "err_template_cloud_init_missing":
+        "Template cloud-init absent pour la distribution « {distro} ». "
+        "Distros packagées : {available}",
 }

--- a/src/dsoxlab/infra/ansible.py
+++ b/src/dsoxlab/infra/ansible.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from ..i18n import _
+
 logger = logging.getLogger(__name__)
 
 
@@ -134,21 +136,15 @@ def run_playbook(
     try:
         import ansible_runner  # sonde d'import : la valeur ne sert pas
     except ImportError:
-        raise AnsibleNotInstalled(
-            "ansible-runner n'est pas installé. Lance : "
-            "uv tool install --force --with ansible-runner dsoxlab "
-            "ou : pipx inject dsoxlab ansible-runner"
-        ) from None
+        raise AnsibleNotInstalled(_("err_ansible_runner_missing")) from None
 
     if not has_ansible_playbook():
-        raise AnsibleNotInstalled(
-            "ansible-playbook est absent du PATH : un lab vm ne peut pas jouer "
-            "son setup.yaml sans lui. ansible-runner pilote ansible-core mais "
-            "ne l'installe pas. Lance : uv tool install ansible-core"
-        )
+        raise AnsibleNotInstalled(_("err_ansible_playbook_missing"))
 
     if not playbook_path.is_file():
-        raise FileNotFoundError(f"Playbook absent : {playbook_path}")
+        raise FileNotFoundError(
+            _("err_ansible_playbook_file_missing", path=playbook_path)
+        )
 
     import ansible_runner
 

--- a/src/dsoxlab/infra/credentials.py
+++ b/src/dsoxlab/infra/credentials.py
@@ -31,6 +31,8 @@ import logging
 import os
 from pathlib import Path
 
+from ..i18n import _
+
 logger = logging.getLogger(__name__)
 
 
@@ -76,8 +78,7 @@ def load(provider: str, profile: str | None = None) -> dict[str, str]:
     loader = loaders.get(provider)
     if loader is None:
         raise NotImplementedError(
-            f"Loader credentials non implémenté pour le provider "
-            f"'{provider}'. Voir src/dsoxlab/infra/credentials.py."
+            _("err_credentials_loader_unsupported", provider=provider)
         )
     return loader(profile_resolved)
 
@@ -104,35 +105,31 @@ def _load_outscale(profile: str) -> dict[str, str]:
     """
     cfg_path = Path.home() / ".osc" / "config.json"
     if not cfg_path.is_file():
-        raise CredentialsNotFound(
-            f"Fichier {cfg_path} absent. Configure tes credentials "
-            f"Outscale via 'oapi-cli configure' (ou crée le JSON manuellement)."
-        )
+        raise CredentialsNotFound(_("err_credentials_outscale_file", path=cfg_path))
 
     try:
         data = json.loads(cfg_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise CredentialsNotFound(
-            f"{cfg_path} : JSON invalide ({exc})."
+            _("err_credentials_outscale_json", path=cfg_path, error=exc)
         ) from exc
 
     if profile not in data:
-        raise CredentialsNotFound(
-            f"Profil '{profile}' introuvable dans {cfg_path}. "
-            f"Profils disponibles : {sorted(data.keys())}. "
-            f"Précise via meta.yml: providers.outscale.profile ou "
-            f"DSOXLAB_OUTSCALE_PROFILE=<name>."
-        )
+        raise CredentialsNotFound(_(
+            "err_credentials_profile_unknown",
+            profile=profile, path=cfg_path, profiles=sorted(data.keys()),
+            option="providers.outscale.profile", env="DSOXLAB_OUTSCALE_PROFILE",
+        ))
 
     cfg = data[profile]
     access_key = cfg.get("access_key")
     secret_key = cfg.get("secret_key")
     region = cfg.get("region") or "eu-west-2"
     if not access_key or not secret_key:
-        raise CredentialsNotFound(
-            f"Profil '{profile}' dans {cfg_path} : access_key et "
-            f"secret_key requis."
-        )
+        raise CredentialsNotFound(_(
+            "err_credentials_fields_required",
+            profile=profile, path=cfg_path, fields="access_key, secret_key",
+        ))
 
     return {
         "OSC_ACCESS_KEY": str(access_key),
@@ -148,27 +145,25 @@ def _load_aws(profile: str) -> dict[str, str]:
     creds_path = Path.home() / ".aws" / "credentials"
     config_path = Path.home() / ".aws" / "config"
     if not creds_path.is_file():
-        raise CredentialsNotFound(
-            f"Fichier {creds_path} absent. Configure via 'aws configure'."
-        )
+        raise CredentialsNotFound(_("err_credentials_aws_file", path=creds_path))
 
     creds = configparser.ConfigParser()
     creds.read(creds_path)
     if profile not in creds:
-        raise CredentialsNotFound(
-            f"Profil '{profile}' introuvable dans {creds_path}. "
-            f"Profils : {sorted(creds.sections())}. "
-            f"Précise via meta.yml: providers.aws.profile ou "
-            f"DSOXLAB_AWS_PROFILE=<name>."
-        )
+        raise CredentialsNotFound(_(
+            "err_credentials_profile_unknown",
+            profile=profile, path=creds_path, profiles=sorted(creds.sections()),
+            option="providers.aws.profile", env="DSOXLAB_AWS_PROFILE",
+        ))
     section = creds[profile]
     access_key = section.get("aws_access_key_id")
     secret_key = section.get("aws_secret_access_key")
     if not access_key or not secret_key:
-        raise CredentialsNotFound(
-            f"Profil '{profile}' dans {creds_path} : aws_access_key_id "
-            f"et aws_secret_access_key requis."
-        )
+        raise CredentialsNotFound(_(
+            "err_credentials_fields_required",
+            profile=profile, path=creds_path,
+            fields="aws_access_key_id, aws_secret_access_key",
+        ))
 
     # La région est dans ~/.aws/config (parfois avec le préfixe "profile")
     region = ""
@@ -200,10 +195,7 @@ def _load_gcp(profile: str) -> dict[str, str]:
     del profile  # GCP ne distingue pas par profil au niveau ADC
     adc_path = Path.home() / ".config" / "gcloud" / "application_default_credentials.json"
     if not adc_path.is_file():
-        raise CredentialsNotFound(
-            f"Fichier {adc_path} absent. Configure via "
-            f"'gcloud auth application-default login'."
-        )
+        raise CredentialsNotFound(_("err_credentials_gcp_file", path=adc_path))
     return {
         "GOOGLE_APPLICATION_CREDENTIALS": str(adc_path),
     }
@@ -216,9 +208,7 @@ def _load_azure(profile: str) -> dict[str, str]:
     del profile
     cfg_path = Path.home() / ".azure" / "azureProfile.json"
     if not cfg_path.is_file():
-        raise CredentialsNotFound(
-            f"Fichier {cfg_path} absent. Configure via 'az login'."
-        )
+        raise CredentialsNotFound(_("err_credentials_azure_file", path=cfg_path))
     # Le provider azurerm Terraform lit directement la session az CLI.
     # Il suffit que `az login` ait été fait — pas besoin de variables.
     return {}
@@ -239,26 +229,24 @@ def _load_proxmox(profile: str) -> dict[str, str]:
     """
     cfg_path = Path.home() / ".proxmoxer" / "config"
     if not cfg_path.is_file():
-        raise CredentialsNotFound(
-            f"Fichier {cfg_path} absent. Crée-le manuellement avec "
-            f"un token API Proxmox (api_url, token_id, token_secret)."
-        )
+        raise CredentialsNotFound(_("err_credentials_proxmox_file", path=cfg_path))
     cfg = configparser.ConfigParser()
     cfg.read(cfg_path)
     if profile not in cfg:
-        raise CredentialsNotFound(
-            f"Profil '{profile}' introuvable dans {cfg_path}. "
-            f"Profils : {sorted(cfg.sections())}."
-        )
+        raise CredentialsNotFound(_(
+            "err_credentials_profile_unknown_plain",
+            profile=profile, path=cfg_path, profiles=sorted(cfg.sections()),
+        ))
     section = cfg[profile]
     api_url = section.get("api_url")
     token_id = section.get("token_id")
     token_secret = section.get("token_secret")
     if not (api_url and token_id and token_secret):
-        raise CredentialsNotFound(
-            f"Profil '{profile}' dans {cfg_path} : api_url, token_id "
-            f"et token_secret requis."
-        )
+        raise CredentialsNotFound(_(
+            "err_credentials_fields_required",
+            profile=profile, path=cfg_path,
+            fields="api_url, token_id, token_secret",
+        ))
     return {
         "PROXMOX_VE_ENDPOINT": api_url,
         "PROXMOX_VE_API_TOKEN": f"{token_id}={token_secret}",

--- a/src/dsoxlab/infra/inventory.py
+++ b/src/dsoxlab/infra/inventory.py
@@ -29,6 +29,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ..i18n import _
 from ..models.repo import RepoMetadata
 
 logger = logging.getLogger(__name__)
@@ -139,10 +140,7 @@ def build_inventory(
     # ne doit surtout pas se manifester par une traceback : on lève une erreur
     # que la CLI sait rendre en une phrase actionnable.
     if repo_meta.infra.hosts and not inventory_hosts:
-        raise InfraNotProvisioned(
-            "Aucun hôte n'a d'adresse : l'infrastructure du lab n'est pas "
-            "provisionnée."
-        )
+        raise InfraNotProvisioned(_("err_inventory_not_provisioned"))
 
     children: dict[str, Any] = {
         "labenv": {"hosts": inventory_hosts},
@@ -155,10 +153,10 @@ def build_inventory(
     # ``hosts:`` — Ansible résout les vars depuis labenv).
     if target_fqdn:
         if target_fqdn not in inventory_hosts:
-            raise ValueError(
-                f"target_fqdn '{target_fqdn}' n'est pas dans la liste des "
-                f"hôtes connus : {sorted(inventory_hosts)}"
-            )
+            raise ValueError(_(
+                "err_inventory_target_unknown",
+                fqdn=target_fqdn, known=sorted(inventory_hosts),
+            ))
         children["lab_target"] = {
             "hosts": {target_fqdn: {}},
         }
@@ -168,11 +166,10 @@ def build_inventory(
     # ``lab_target``. Les host_vars restent hérités du groupe ``labenv``.
     for role_name, role_fqdn in (roles or {}).items():
         if role_fqdn not in inventory_hosts:
-            raise ValueError(
-                f"role '{role_name}' → '{role_fqdn}' n'est pas dans la liste "
-                f"des hôtes connus : {sorted(inventory_hosts)} "
-                "(host non déclaré dans meta.yml ou non provisionné)."
-            )
+            raise ValueError(_(
+                "err_inventory_role_unknown",
+                role=role_name, fqdn=role_fqdn, known=sorted(inventory_hosts),
+            ))
         children[f"lab_{role_name}"] = {
             "hosts": {role_fqdn: {}},
         }
@@ -513,10 +510,9 @@ def wait_for_hosts_ready(
                 logger.info("Host %s prêt (tentative %d).", fqdn, attempt)
                 break
             if time.monotonic() >= deadline:
-                raise HostReadyTimeout(
-                    f"{fqdn} injoignable en SSH après {timeout:.0f}s "
-                    "(cloud-init trop long, ou VM en échec de démarrage)."
-                )
+                raise HostReadyTimeout(_(
+                    "err_host_ready_timeout", fqdn=fqdn, timeout=f"{timeout:.0f}",
+                ))
             # Un host dont sshd n'a JAMAIS répondu après `reset_after` est
             # probablement coincé au boot (kernel panic Debian cloud + OVMF +
             # resize, cf. _reset_kvm_domain). Un reset unique le débloque. Sans

--- a/src/dsoxlab/infra/snapshot/__init__.py
+++ b/src/dsoxlab/infra/snapshot/__init__.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import importlib
 from typing import Protocol
 
+from ...i18n import _
 from ...models.repo import RepoMetadata
 
 
@@ -58,9 +59,7 @@ def _backend(repo_meta: RepoMetadata) -> SnapshotBackend:
         )
     except ImportError as exc:
         raise NotImplementedError(
-            f"Snapshots non encore implémentés pour le provider "
-            f"'{provider}'. Voir src/dsoxlab/infra/snapshot/__init__.py "
-            f"pour ajouter un backend."
+            _("err_snapshot_provider_unsupported", provider=provider)
         ) from exc
     return module
 

--- a/src/dsoxlab/infra/terraform.py
+++ b/src/dsoxlab/infra/terraform.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import Any
 
 from ..config import xdg_state_home
+from ..i18n import _
 from ..models.repo import ProviderUnresolved, RepoMetadata
 from ..templates import terraform_template
 from ..utils.shell import CommandError, run_command
@@ -279,10 +280,7 @@ def init(
     """
     tf_dir = workdir(repo_meta)
     if not is_available():
-        raise TerraformNotInstalled(
-            "terraform est absent du PATH : il provisionne les machines des labs vm.\n"
-            "Installe-le : https://developer.hashicorp.com/terraform/install"
-        )
+        raise TerraformNotInstalled(_("err_terraform_missing"))
 
     cmd = ["terraform", f"-chdir={tf_dir}", "init", "-input=false"]
     if on_event is not None:
@@ -538,10 +536,7 @@ def apply(
         ``ProvisionResult`` avec outputs JSON et map FQDN→IP.
     """
     if not is_available():
-        raise TerraformNotInstalled(
-            "terraform est absent du PATH : il provisionne les machines des labs vm.\n"
-            "Installe-le : https://developer.hashicorp.com/terraform/install"
-        )
+        raise TerraformNotInstalled(_("err_terraform_missing"))
 
     tf_dir = workdir(repo_meta)
     write_tfvars(repo_meta)
@@ -685,10 +680,7 @@ def destroy(
     rejouer une seule VM sans toucher au réseau ni aux images de base.
     """
     if not is_available():
-        raise TerraformNotInstalled(
-            "terraform est absent du PATH : il provisionne les machines des labs vm.\n"
-            "Installe-le : https://developer.hashicorp.com/terraform/install"
-        )
+        raise TerraformNotInstalled(_("err_terraform_missing"))
 
     tf_dir = workdir(repo_meta)
     # Re-génère le tfvars : Terraform exige les variables même pour
@@ -758,9 +750,7 @@ def host_targets(provider: str, fqdn: str) -> list[str]:
             f'incus_instance.host["{fqdn}"]',
             f'incus_storage_volume.extra["{fqdn}"]',
         ]
-    raise NotImplementedError(
-        f"--host non implémenté pour le provider '{provider}'"
-    )
+    raise NotImplementedError(_("err_terraform_host_unsupported", provider=provider))
 
 
 def get_outputs(repo_meta: RepoMetadata) -> ProvisionResult | None:

--- a/src/dsoxlab/runtimes/manager.py
+++ b/src/dsoxlab/runtimes/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..i18n import _
 from ..models.lab import LabDefinition
 from ..models.runtime import RuntimeType
 from .base import BaseRuntime
@@ -16,10 +17,7 @@ class RuntimeManager:
         runtime = self._build(lab)
         if not runtime.is_available():
             raise RuntimeError(
-                f"Le runtime '{lab.runtime.type.value}' n'est pas "
-                f"disponible sur cette machine. Installe les "
-                f"dépendances (`dsoxlab instructor bootstrap`) ou "
-                f"utilise un lab compatible avec un autre runtime."
+                _("err_runtime_unavailable", runtime=lab.runtime.type.value)
             )
         return runtime
 
@@ -32,4 +30,4 @@ class RuntimeManager:
             return ShellRuntime()
         if rt_type in (RuntimeType.VM, RuntimeType.KVM, RuntimeType.INCUS):
             return VmRuntime()
-        raise ValueError(f"RuntimeType inconnu : {rt_type}")
+        raise ValueError(_("err_runtime_type_unknown", rt_type=rt_type))

--- a/src/dsoxlab/runtimes/services.py
+++ b/src/dsoxlab/runtimes/services.py
@@ -28,6 +28,7 @@ import socket
 import time
 from dataclasses import dataclass
 
+from ..i18n import _
 from ..models.runtime import Service
 from ..utils.shell import CommandError, run_command
 
@@ -80,7 +81,7 @@ def _ensure_network(name: str) -> None:
     if not run_command(["docker", "network", "inspect", name],
                        check=False, timeout=15).ok:
         raise ServiceError(
-            f"Impossible de créer le réseau '{name}' :\n{res.stderr.strip()}"
+            _("err_service_network_failed", name=name, detail=res.stderr.strip())
         )
 
 
@@ -185,15 +186,17 @@ def _wait_ready(service: Service, name: str) -> None:
     sans rien exiger de l'image, ``ready_exec`` prouve que le service répond.
     """
     if service.ready_tcp and not _wait_tcp(service.ready_tcp, service.ready_timeout):
-        raise ServiceError(
-            f"Le service '{service.name}' n'a pas ouvert le port "
-            f"{service.ready_tcp} en {service.ready_timeout}s."
-        )
+        raise ServiceError(_(
+            "err_service_port_closed",
+            name=service.name, port=service.ready_tcp,
+            timeout=service.ready_timeout,
+        ))
     if service.ready_exec and not _wait_exec(name, service.ready_exec, service.ready_timeout):
-        raise ServiceError(
-            f"Le service '{service.name}' n'a jamais répondu à « "
-            f"{' '.join(service.ready_exec)} » en {service.ready_timeout}s."
-        )
+        raise ServiceError(_(
+            "err_service_probe_failed",
+            name=service.name, probe=" ".join(service.ready_exec),
+            timeout=service.ready_timeout,
+        ))
 
 
 def _run_post_start(service: Service, name: str) -> None:
@@ -209,10 +212,11 @@ def _run_post_start(service: Service, name: str) -> None:
     for argv in service.post_start:
         res = run_command(["docker", "exec", name, *argv], check=False, timeout=120)
         if not res.ok:
-            raise ServiceError(
-                f"L'initialisation du service '{service.name}' a échoué sur "
-                f"« {' '.join(argv)} » :\n{(res.stderr or res.stdout).strip()}"
-            )
+            raise ServiceError(_(
+                "err_service_post_start_failed",
+                name=service.name, command=" ".join(argv),
+                detail=(res.stderr or res.stdout).strip(),
+            ))
 
 
 def start(service: Service, repo_id: str) -> str:
@@ -267,9 +271,10 @@ def start(service: Service, repo_id: str) -> str:
 
     res = run_command(cmd, check=False, timeout=180)
     if not res.ok:
-        raise ServiceError(
-            f"Le démarrage du service '{service.name}' a échoué :\n{res.stderr.strip()}"
-        )
+        raise ServiceError(_(
+            "err_service_start_failed",
+            name=service.name, detail=res.stderr.strip(),
+        ))
 
     _wait_ready(service, name)
     _run_post_start(service, name)

--- a/src/dsoxlab/runtimes/vm.py
+++ b/src/dsoxlab/runtimes/vm.py
@@ -32,6 +32,7 @@ import os
 from typing import Any
 
 from ..discovery.repo import find_meta_yml, read_repo_metadata
+from ..i18n import _
 from ..infra import ansible as ansible_infra
 from ..infra import snapshot as snapshot_infra
 from ..infra.inventory import build_inventory, read_terraform_outputs
@@ -74,8 +75,7 @@ class VmRuntime(BaseRuntime):
         setup = lab.path / "setup.yaml"
         if not setup.is_file():
             raise FileNotFoundError(
-                f"Le lab {lab.id} doit fournir setup.yaml à la racine "
-                f"(contrat dsoxlab pour runtime: vm). Fichier attendu : {setup}"
+                _("err_vm_setup_missing", lab_id=lab.id, path=setup)
             )
 
         if lab.runtime.snapshot_required:
@@ -94,10 +94,11 @@ class VmRuntime(BaseRuntime):
             on_event=on_event,
         )
         if not result.ok:
-            raise RuntimeError(
-                f"setup.yaml a échoué pour {lab.id} sur target '{target.name}' "
-                f"(rc={result.rc}, status={result.status}). Stats : {result.stats}"
-            )
+            raise RuntimeError(_(
+                "err_vm_setup_failed",
+                lab_id=lab.id, target=target.name, rc=result.rc,
+                status=result.status, stats=result.stats,
+            ))
 
     def stop(self, lab: LabDefinition, target_name: str | None = None) -> None:
         """No-op : les VMs sont persistantes (gérées par dsoxlab destroy)."""
@@ -125,8 +126,7 @@ class VmRuntime(BaseRuntime):
         cleanup = lab.path / "cleanup.yaml"
         if not cleanup.is_file():
             raise FileNotFoundError(
-                f"Le lab {lab.id} doit fournir cleanup.yaml à la racine "
-                f"(contrat dsoxlab pour runtime: vm). Fichier attendu : {cleanup}"
+                _("err_vm_cleanup_missing", lab_id=lab.id, path=cleanup)
             )
 
         result = ansible_infra.run_playbook(
@@ -135,10 +135,11 @@ class VmRuntime(BaseRuntime):
             on_event=on_event,
         )
         if not result.ok:
-            raise RuntimeError(
-                f"cleanup.yaml a échoué pour {lab.id} sur target '{target.name}' "
-                f"(rc={result.rc}, status={result.status})."
-            )
+            raise RuntimeError(_(
+                "err_vm_cleanup_failed",
+                lab_id=lab.id, target=target.name, rc=result.rc,
+                status=result.status,
+            ))
 
     def status(self, lab: LabDefinition, target_name: str | None = None) -> str:
         del lab, target_name
@@ -232,10 +233,7 @@ class VmRuntime(BaseRuntime):
                 ou si le nom résolu ne matche aucune target.
         """
         if not lab.runtime.targets:
-            raise TargetNotResolved(
-                f"Le lab {lab.id} (runtime: vm) doit déclarer au moins "
-                f"une target dans runtime.targets[] de lab.yaml."
-            )
+            raise TargetNotResolved(_("err_vm_no_target", lab_id=lab.id))
 
         name = (
             explicit_name
@@ -246,10 +244,10 @@ class VmRuntime(BaseRuntime):
         target = lab.runtime.target(name)
         if target is None:
             available = ", ".join(t.name for t in lab.runtime.targets)
-            raise TargetNotResolved(
-                f"Target '{name}' inconnue pour le lab {lab.id}. "
-                f"Targets disponibles : {available}"
-            )
+            raise TargetNotResolved(_(
+                "err_vm_target_unknown",
+                name=name, lab_id=lab.id, available=available,
+            ))
         return target
 
     @staticmethod
@@ -270,13 +268,10 @@ class VmRuntime(BaseRuntime):
     def _repo_meta(self, lab: LabDefinition) -> RepoMetadata:
         meta_path = find_meta_yml(lab.path)
         if meta_path is None:
-            raise RuntimeError(
-                f"Pas de meta.yml trouvé en remontant depuis {lab.path}. "
-                f"dsoxlab ne peut pas dériver l'inventory."
-            )
+            raise RuntimeError(_("err_vm_no_meta", path=lab.path))
         meta = read_repo_metadata(meta_path.parent)
         if meta is None:
-            raise RuntimeError(f"meta.yml invalide : {meta_path}")
+            raise RuntimeError(_("err_vm_meta_invalid", path=meta_path))
         return meta
 
     def _inventory(

--- a/src/dsoxlab/services/lab_service.py
+++ b/src/dsoxlab/services/lab_service.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from ..discovery.repo import find_meta_yml
 from ..discovery.scanner import discover_labs
+from ..i18n import _
 from ..models.hint import HintFile
 from ..models.lab import LabDefinition
 from ..runtimes.base import EventCallback, SessionSpec
@@ -155,7 +156,7 @@ def find_lab(labs: list[LabDefinition], lab_id: str) -> LabDefinition:
     for lab in labs:
         if lab.id == lab_id:
             return lab
-    raise ValueError(f"Lab introuvable : {lab_id}")
+    raise ValueError(_("err_lab_not_found", lab_id=lab_id))
 
 
 def get_lab(root: Path, lab_id: str, lang: str = "en") -> LabDefinition:

--- a/src/dsoxlab/templates/__init__.py
+++ b/src/dsoxlab/templates/__init__.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..i18n import _
+
 
 def template_root() -> Path:
     """Retourne la racine des templates packagés (dsoxlab/templates/)."""
@@ -68,11 +70,13 @@ def terraform_template(provider: str) -> Path:
     """
     path = template_root() / "terraform" / provider
     if not path.is_dir():
-        raise FileNotFoundError(
-            f"Template Terraform absent pour le provider '{provider}'. "
-            f"Providers packagés dans dsoxlab : "
-            f"{sorted(p.name for p in (template_root() / 'terraform').iterdir() if p.is_dir())}"
-        )
+        raise FileNotFoundError(_(
+            "err_template_terraform_missing",
+            provider=provider,
+            available=sorted(
+                p.name for p in (template_root() / "terraform").iterdir() if p.is_dir()
+            ),
+        ))
     return path
 
 
@@ -90,9 +94,12 @@ def cloud_init_template(distro: str) -> Path:
     """
     path = template_root() / "cloud-init" / f"{distro}.yaml.tmpl"
     if not path.is_file():
-        raise FileNotFoundError(
-            f"Template cloud-init absent pour la distribution '{distro}'. "
-            f"Distros packagées : "
-            f"{sorted(p.stem.replace('.yaml', '') for p in (template_root() / 'cloud-init').glob('*.yaml.tmpl'))}"
-        )
+        raise FileNotFoundError(_(
+            "err_template_cloud_init_missing",
+            distro=distro,
+            available=sorted(
+                p.stem.replace(".yaml", "")
+                for p in (template_root() / "cloud-init").glob("*.yaml.tmpl")
+            ),
+        ))
     return path

--- a/tests/test_i18n_coverage.py
+++ b/tests/test_i18n_coverage.py
@@ -1,4 +1,4 @@
-"""Guard: no user-facing string may be hardcoded in `cli.py`.
+"""Guard: no user-facing string may be hardcoded, anywhere in the package.
 
 The rule already existed in prose ("every displayed text goes through
 `_()`"), and prose did not hold: option helps, progress-bar labels and a
@@ -6,14 +6,77 @@ handful of error messages had drifted back into literals. Some were French,
 so an English run showed French; others were English, so a French run showed
 English. Both are the same defect.
 
-Rather than re-audit by hand, this module parses `cli.py` and asserts the
-invariant. It deliberately checks only what can be decided without judgement:
+Rather than re-audit by hand, this module parses the source and asserts the
+invariant. It used to parse **`cli.py` and nothing else**, which is why the
+defect kept coming back: the messages a learner reads when something breaks
+are raised by `infra/` and `runtimes/`, not printed by `cli.py`. The guard
+watched one door out of five.
 
-* `help=` and `description=` keywords must be `_()` calls, no exception;
-* a bare string literal handed to `error/info/warn/success` is forbidden;
-* an f-string handed to those is allowed **only** if its literal parts carry
-  no word, i.e. it is pure layout around already-translated values
-  (`f"  ✔ {fqdn} ({ip})"` passes, `f"Host inconnu : {fqdn}"` does not).
+
+Le critère : une phrase, pas un littéral
+========================================
+
+Interdire *toute* chaîne littérale serait intenable ; n'en interdire aucune
+est la situation qu'on répare. La ligne passe ici, et elle a deux moitiés qui
+doivent être vraies **ensemble** :
+
+1. **Le puits** — la chaîne atteint-elle un humain ? Trois seulement comptent :
+
+   * les mots-clés ``help=`` et ``description=``, que Typer affiche tels quels ;
+   * les helpers d'affichage ``error`` / ``info`` / ``warn`` / ``success``
+     appelés par leur nom nu, dont le premier argument est le message ;
+   * un ``raise Exc(...)``, parce que la CLI de ce dépôt rend les erreurs par
+     ``error(str(exc))`` : le texte d'une exception **est** un texte d'interface,
+     c'est ce que le garde-fou restreint à ``cli.py`` ne voyait pas ;
+   * un ``.print(...)`` / ``.echo(...)`` / ``.secho(...)``, les verbes de sortie
+     de Rich, Typer et Click.
+
+2. **La forme** — le littéral est-il une phrase ? Une phrase, ici, c'est
+   **au moins deux mots séparés par une espace**, un mot valant trois lettres
+   consécutives ou plus. Un fragment sans espace compte donc pour **un seul**
+   mot, quel que soit le nombre de lettres qu'il enchaîne : ``meta.yml``,
+   ``challenge/tests``, ``lab_starting`` et ``DSOXLAB_PROVIDER`` sont des jetons,
+   pas des phrases. C'est ce qui laisse passer la mise en forme pure autour de
+   valeurs déjà traduites — ``f"  ✔ {fqdn} ({ip})"`` ne porte aucun mot — et le
+   vocabulaire emprunté à l'outil qu'on relaie (``(skipped)``, ``UNREACHABLE``,
+   ``Error:``, ``dsoxlab {version}``), qui n'en porte qu'un.
+
+Le prix de ce réglage est assumé : un message d'un seul mot (``error("Timeout")``)
+passe sous le radar. Le rendre détectable demanderait de distinguer un mot d'un
+identifiant, ce qu'aucune règle courte ne fait sans se tromper — et un test
+qu'on désactive au premier faux positif ne garde plus rien.
+
+
+Ce que le garde-fou ne regarde pas, et pourquoi
+===============================================
+
+**``logger.*`` n'est pas un puits d'interface.** Le journal est un artefact de
+diagnostic : il part sur stderr au-delà de ``-v`` et dans le fichier que
+``dsoxlab support`` ramasse, il porte des noms d'outils, des codes retour et des
+chemins, et il se lit à côté d'une trace Python. Le traduire rendrait deux
+rapports de bug incomparables selon la locale de qui les produit, et se heurte
+au formatage paresseux (``logger.info("x %s", v)``) que la famille de règles
+``G`` impose ici : ``_()`` formate à l'appel, ``logging`` au rendu. Le journal
+doit être *cohérent* — il mélange aujourd'hui le français et l'anglais, ce qui
+est un vrai défaut — mais cohérent n'est pas traduit, et c'est un autre lot.
+
+**``models/`` est hors périmètre, sciemment.** Le bon patron y est déjà écrit :
+``UnsupportedSchemaVersion`` et ``ProviderUnresolved`` portent des **données**
+(``source``, ``found``, ``supported``, ``candidates``) et laissent la CLI
+composer la phrase traduite. Les coercions du contrat (``models/_contract.py``,
+``models/lab.py``, ``models/repo.py``, ``models/schema_version.py``) portent
+encore la dette inverse : 24 ``ValueError`` dont le texte français est rendu tel
+quel par ``error(str(exc))``. Les passer par ``_()`` serait traduire dans le
+modèle, c'est-à-dire graver le mauvais patron ; les convertir en exceptions
+porteuses de données est le bon geste, mais c'est une refonte du contrat, pas un
+correctif d'i18n. La dette est nommée ici plutôt que masquée par un test qui
+l'ignore en silence. Même raison pour ``validators/content.py`` et
+``validators/metadata.py``, dont les messages vivent dans des champs de
+dataclasses qu'aucun puits ci-dessus ne voit.
+
+**``templates/demo/`` est du contenu pédagogique**, pas le code de l'outil : le
+lab de démonstration packagé s'adresse à l'apprenant dans le fichier même qu'il
+va lire, et n'a aucune raison de passer par la table de traduction.
 """
 
 from __future__ import annotations
@@ -26,11 +89,34 @@ import pytest
 
 import dsoxlab
 
-CLI = Path(dsoxlab.__file__).parent / "cli.py"
+_RACINE = Path(dsoxlab.__file__).parent
+
+#: Répertoires écartés du garde-fou, avec la raison — voir le docstring.
+#: Toute entrée ajoutée ici doit y être justifiée : c'est une porte qu'on
+#: choisit de ne pas surveiller, pas un détail de configuration.
+_HORS_PERIMETRE = ("models/", "templates/demo/")
+
+
+def _sources() -> list[Path]:
+    """Tous les modules du paquet, moins le hors-périmètre documenté."""
+    return sorted(
+        chemin
+        for chemin in _RACINE.rglob("*.py")
+        if not chemin.relative_to(_RACINE).as_posix().startswith(_HORS_PERIMETRE)
+    )
+
 
 #: Les helpers d'affichage de `reporting.console`. Leur premier argument est
 #: le message vu par l'apprenant.
 MESSAGE_FUNCS = {"error", "info", "warn", "success"}
+
+#: Les verbes de sortie de Rich, Typer et Click, appelés sur un objet
+#: (`console.print`, `typer.echo`, `progress.console.print`…).
+SORTIE_FUNCS = {"print", "echo", "secho"}
+
+#: `typer.Exit` et `SystemExit` portent un code de sortie, jamais un message :
+#: les inclure ferait crier le garde-fou sur chaque sortie propre de la CLI.
+CONTROLE_DE_FLUX = {"Exit", "SystemExit"}
 
 #: Balises Rich (`[bold]`, `[/green]`…) : de la mise en forme, pas du texte.
 _RICH_TAG = re.compile(r"\[/?[a-z0-9 #]+\]", re.IGNORECASE)
@@ -39,10 +125,20 @@ _RICH_TAG = re.compile(r"\[/?[a-z0-9 #]+\]", re.IGNORECASE)
 #: on est dans les symboles, la ponctuation ou les unités, pas dans la phrase.
 _WORD = re.compile(r"[^\W\d_]{3,}", re.UNICODE)
 
+#: En deçà de deux mots séparés par une espace, on n'a pas une phrase.
+_SEUIL_PHRASE = 2
+
 
 @pytest.fixture(scope="module")
-def tree() -> ast.Module:
-    return ast.parse(CLI.read_text(encoding="utf-8"), filename=str(CLI))
+def arbres() -> list[tuple[str, ast.Module]]:
+    """Le paquet couvert, parsé une fois, nommé en chemin relatif."""
+    return [
+        (
+            chemin.relative_to(_RACINE).as_posix(),
+            ast.parse(chemin.read_text(encoding="utf-8"), filename=str(chemin)),
+        )
+        for chemin in _sources()
+    ]
 
 
 def _is_i18n_call(node: ast.AST) -> bool:
@@ -54,84 +150,202 @@ def _is_i18n_call(node: ast.AST) -> bool:
     )
 
 
-def _literal_words(node: ast.JoinedStr) -> list[str]:
-    """Les mots portés par les parties littérales d'une f-string."""
-    mots: list[str] = []
-    for part in node.values:
-        if isinstance(part, ast.Constant) and isinstance(part.value, str):
-            mots += _WORD.findall(_RICH_TAG.sub("", part.value))
-    return mots
+def _parties_litterales(node: ast.AST) -> list[str]:
+    """Le texte écrit en dur : la constante, ou les morceaux fixes d'une f-string."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, ast.JoinedStr):
+        return [
+            part.value
+            for part in node.values
+            if isinstance(part, ast.Constant) and isinstance(part.value, str)
+        ]
+    return []
 
 
-def test_option_help_and_progress_labels_go_through_i18n(tree: ast.Module) -> None:
-    """`help=` et `description=` sont affichés tels quels : jamais de littéral."""
-    coupables: list[str] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        for kw in node.keywords:
-            if kw.arg not in {"help", "description"}:
-                continue
-            if isinstance(kw.value, (ast.Constant, ast.JoinedStr)) and not _is_i18n_call(
-                kw.value
-            ):
-                coupables.append(f"cli.py:{kw.value.lineno} — {kw.arg}=")
+def _mots_de_phrase(node: ast.AST) -> list[str]:
+    """Les mots du littéral, à raison d'**un par fragment séparé d'espaces**.
 
-    assert not coupables, (
-        "Ces libellés s'afficheraient dans une seule langue :\n  "
-        + "\n  ".join(coupables)
-    )
+    Compter un mot par fragment est tout le réglage du test. Sans ce plafond,
+    ``lab_starting``, ``meta.yml`` ou ``challenge/tests`` vaudraient deux mots
+    et le garde-fou crierait sur des clés, des chemins et des identifiants.
+    Avec lui, il ne reste que ce qui s'écrit comme une phrase.
 
-
-def test_messages_are_translated_or_pure_layout(tree: ast.Module) -> None:
-    """Aucun `error/info/warn/success` ne porte de phrase en dur."""
-    coupables: list[str] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
-            continue
-        if node.func.id not in MESSAGE_FUNCS or not node.args:
-            continue
-
-        premier = node.args[0]
-        if _is_i18n_call(premier):
-            continue
-        if isinstance(premier, ast.Constant) and isinstance(premier.value, str):
-            coupables.append(f"cli.py:{premier.lineno} — {premier.value[:50]!r}")
-        elif isinstance(premier, ast.JoinedStr):
-            mots = _literal_words(premier)
-            if mots:
-                coupables.append(f"cli.py:{premier.lineno} — mots en dur : {mots}")
-
-    assert not coupables, (
-        "Ces messages ne suivraient pas DSOXLAB_LANG :\n  " + "\n  ".join(coupables)
-    )
-
-
-def test_the_guard_would_actually_catch_a_regression() -> None:
-    """Un test qui ne peut pas échouer ne prouve rien : on le fait échouer.
-
-    Sans ce contrôle, une heuristique trop laxiste (ou un `_WORD` mal réglé)
-    laisserait les deux tests ci-dessus passer sur n'importe quel code.
+    Rend une liste vide dès que le compte n'atteint pas le seuil : un appelant
+    n'a jamais à connaître le seuil, seulement à tester la vérité de la liste.
     """
-    fautif = ast.parse('error("Host inconnu")\ninfo(f"Cible : {x}")\n')
-    trouves = 0
-    for node in ast.walk(fautif):
-        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
-            continue
-        if node.func.id not in MESSAGE_FUNCS or not node.args:
-            continue
-        premier = node.args[0]
-        if isinstance(premier, ast.Constant) or (
-            isinstance(premier, ast.JoinedStr) and _literal_words(premier)
+    mots: list[str] = []
+    for partie in _parties_litterales(node):
+        for fragment in _RICH_TAG.sub(" ", partie).split():
+            if _WORD.search(fragment):
+                mots.append(fragment)
+    return mots if len(mots) >= _SEUIL_PHRASE else []
+
+
+def _nom_appele(func: ast.AST) -> str:
+    """Le nom terminal d'un appelé : `warn`, `print` pour `console.print`…"""
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _coupables(module: str, tree: ast.Module) -> list[str]:
+    """Les phrases en dur qui atteindraient l'utilisateur dans ce module."""
+    trouves: list[str] = []
+
+    def _retenir(node: ast.AST, quoi: str) -> None:
+        mots = _mots_de_phrase(node)
+        if mots:
+            extrait = " ".join(mots)[:60]
+            trouves.append(f"{module}:{node.lineno} — {quoi} : {extrait!r}")
+
+    for node in ast.walk(tree):
+        # ── Puits 1 : les libellés que Typer affiche tels quels ───────────────
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                litteral = isinstance(kw.value, ast.JoinedStr) or (
+                    isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str)
+                )
+                if kw.arg in {"help", "description"} and litteral:
+                    trouves.append(f"{module}:{kw.value.lineno} — {kw.arg}=")
+
+        # ── Puits 2 : les helpers d'affichage, appelés par leur nom nu ────────
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in MESSAGE_FUNCS
+            and node.args
+            and not _is_i18n_call(node.args[0])
         ):
-            trouves += 1
+            _retenir(node.args[0], node.func.id)
 
-    assert trouves == 2, "le garde-fou ne détecte plus les chaînes en dur"
+        # ── Puits 3 : le texte d'une exception, rendu par `error(str(exc))` ───
+        if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
+            nom = _nom_appele(node.exc.func)
+            if nom not in CONTROLE_DE_FLUX:
+                arguments = list(node.exc.args) + [kw.value for kw in node.exc.keywords]
+                for argument in arguments:
+                    if not _is_i18n_call(argument):
+                        _retenir(argument, f"raise {nom}")
+
+        # ── Puits 4 : les verbes de sortie de Rich, Typer et Click ────────────
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in SORTIE_FUNCS
+            and node.args
+            and not _is_i18n_call(node.args[0])
+        ):
+            _retenir(node.args[0], f".{node.func.attr}()")
+
+    return trouves
 
 
-def test_pure_layout_is_not_flagged() -> None:
-    """Et il ne doit pas crier sur de la mise en forme sans texte."""
-    layout = ast.parse('success(f"  ✔ {fqdn} ({ip})")\ninfo(f"[bold]{a}[/bold] → {b}")\n')
-    for node in ast.walk(layout):
-        if isinstance(node, ast.JoinedStr):
-            assert not _literal_words(node)
+# ── Le garde-fou lui-même ─────────────────────────────────────────────────────
+
+
+def test_le_paquet_ne_porte_aucune_phrase_en_dur(
+    arbres: list[tuple[str, ast.Module]],
+) -> None:
+    """Aucun puits d'interface ne porte de phrase écrite en dur.
+
+    Un échec ici se répare en ajoutant la clé dans `i18n/strings/en.py` **et**
+    `i18n/strings/fr.py`, jamais en élargissant `_HORS_PERIMETRE`.
+    """
+    coupables: list[str] = []
+    for module, tree in arbres:
+        coupables += _coupables(module, tree)
+
+    assert not coupables, (
+        "Ces textes ne suivraient pas DSOXLAB_LANG :\n  " + "\n  ".join(coupables)
+    )
+
+
+def test_le_perimetre_couvre_bien_les_chemins_dinfra(
+    arbres: list[tuple[str, ast.Module]],
+) -> None:
+    """Le périmètre est un invariant, pas une conséquence de l'arborescence.
+
+    Le défaut d'origine n'était pas une chaîne oubliée, c'était un garde-fou
+    qui ne regardait qu'un fichier. Si un jour `infra/` ou `runtimes/` sortait
+    de la couverture, la régression serait invisible : elle se verrait ici.
+    """
+    couverts = {module for module, _tree in arbres}
+    for attendu in (
+        "cli.py",
+        "infra/terraform.py",
+        "infra/inventory.py",
+        "infra/credentials.py",
+        "runtimes/vm.py",
+        "runtimes/services.py",
+        "services/lab_service.py",
+        "reporting/console.py",
+    ):
+        assert attendu in couverts, f"{attendu} n'est plus analysé par le garde-fou"
+
+
+# ── Le garde-fou mord-il ? Une famille de cas par test ────────────────────────
+#
+# Un test qui ne peut pas échouer ne prouve rien. Chaque famille que le
+# garde-fou prétend couvrir est donc jouée ici sur du code fautif écrit à la
+# main, puis sur son équivalent légitime.
+
+
+def _analyse(source: str) -> list[str]:
+    return _coupables("sonde.py", ast.parse(source))
+
+
+def test_il_mord_sur_un_libelle_typer() -> None:
+    assert _analyse('typer.Option("--x", help="Force the rebuild")')
+    assert not _analyse('typer.Option("--x", help=_("opt_force"))')
+
+
+def test_il_mord_sur_un_helper_daffichage() -> None:
+    assert _analyse('error("Host inconnu dans meta.yml")')
+    assert _analyse('info(f"Cible retenue : {x}")')
+    assert not _analyse('error(_("host_unknown", fqdn=f))')
+
+
+def test_il_mord_sur_le_texte_porte_par_une_exception() -> None:
+    assert _analyse('raise RuntimeError("terraform absent du PATH")')
+    assert _analyse('raise ServiceError(f"Le service {n} n\'a jamais répondu")')
+    assert not _analyse('raise TerraformNotInstalled(_("terraform_missing"))')
+
+
+def test_il_mord_sur_un_verbe_de_sortie() -> None:
+    assert _analyse('console.print("Aucun lab trouvé")')
+    assert _analyse('progress.console.print(f"  Tâche échouée : {t}")')
+    assert not _analyse('console.print(_("no_labs_found"))')
+
+
+def test_il_laisse_passer_la_mise_en_forme() -> None:
+    """La frontière écrite dans le CLAUDE.md : du décor autour d'un traduit."""
+    assert not _analyse('success(f"  ✔ {fqdn} ({ip})")')
+    assert not _analyse('console.print(f"[bold]{a}[/bold] → {b}")')
+    assert not _analyse('console.print(f"dsoxlab {__version__}")')
+    assert not _analyse('console.print(f"  [dim]⊘ {short}  (skipped)[/dim]")')
+
+
+def test_il_laisse_passer_les_jetons_techniques() -> None:
+    """Un identifiant, un chemin, une clé : un seul mot, donc pas une phrase."""
+    assert not _analyse('error(_("lab_starting"))')
+    assert not _analyse('raise RuntimeError(f"{lab.path}/challenge/tests")')
+    assert not _analyse('raise KeyError("DSOXLAB_PROVIDER")')
+
+
+def test_il_ignore_les_sorties_de_controle_de_flux() -> None:
+    """`typer.Exit(1)` n'est pas un message, et n'a pas à être traduit."""
+    assert not _analyse('raise typer.Exit(1)')
+    assert not _analyse('raise SystemExit(1)')
+
+
+def test_le_journal_reste_hors_du_perimetre() -> None:
+    """Décision explicite, pas un oubli : voir le docstring du module.
+
+    Ce test existe pour qu'un futur lecteur voie que le cas a été tranché.
+    Le jour où l'on décide l'inverse, c'est lui qu'il faut retourner.
+    """
+    assert not _analyse('logger.warning("snapshot-delete a échoué pour %s", d)')
+    assert not _analyse('logger.info("Host %s prêt (tentative %d).", f, n)')

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.51"
+version = "0.1.53"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
# Summary

The i18n rule was held by a test — the right way to hold it — but that test only
read `cli.py`. Everything in `infra/`, `runtimes/`, `services/` and `reporting/`
escaped it, and those are exactly the paths a learner meets when something
breaks. The rule had a guard watching one door out of five.

**The deliverable is the guard, not the 43 fixed strings.** Fixing the strings
takes ten minutes and the problem returns next month.

The guard now parses the whole package, through four interface sinks: `help=` /
`description=`, the `error`/`info`/`warn`/`success` helpers, the text of a `raise`
(the CLI renders it via `error(str(exc))`), and `.print()` / `.echo()` /
`.secho()`. The shape criterion is written in the module docstring: **a sentence
is at least two words separated by a space, a whitespace-free fragment counting
as one word** — which lets `meta.yml`, `lab_starting` and `challenge/tests`
through while catching prose.

It found **43** hardcoded French sentences: credentials 13, vm 8, services 5,
inventory 4, terraform 4, ansible 3, manager 2, templates 2, snapshot 1,
lab_service 1. All fixed through 38 new `err_*` keys, added simultaneously to
`en.py` and `fr.py`.

## The symptom in the issue, before and after

```console
$ DSOXLAB_LANG=en dsoxlab provision
✘ terraform is not on your PATH: it provisions the machines of vm labs.
  Install it: https://developer.hashicorp.com/terraform/install

$ DSOXLAB_LANG=fr dsoxlab provision
✘ terraform est absent du PATH : il provisionne les machines des labs vm.
  Installe-le : https://developer.hashicorp.com/terraform/install
```

Same exit code (3) on both sides. Before, an English session got the French
sentence.

## The guard bites

Verified independently, not taken on trust: injecting a French sentence into
`infra/inventory.py` — a module the old guard never looked at — turns
`test_le_paquet_ne_porte_aucune_phrase_en_dur` red; restored, 10 passed. The five
case families were each broken and restored in the same way.

Key-consistency check, beyond the diff: the **38 `err_*` keys are used 38 times,
defined 38 times in EN and 38 times in FR**. No key used without a definition, no
dead key, and **no diverging placeholder** between the two languages — a `{field}`
present on one side only would raise a `KeyError` in that language alone, at
runtime, on an error path.

## Type of change

- [x] Bug fix

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — no issues in 57 source files
- [x] `uv run pytest` — **427 passed**; `uv run pytest tests_e2e` — **16 passed**
- [x] The engine stays domain-agnostic
- [x] No hardcoded personal path or host
- [x] Manually tested against the **three** lab repositories: `validate-structure`
      rc=0 with 84 / 113 / 87 labs and no `✘`. Their `git status` is identical
      before and after, compared by `diff`; no `git checkout` was run there.

### When behavior changes

- [x] Both CHANGELOG files updated; version **0.1.53**; `uv.lock` aligned
- [x] `scripts/check-release.py` passes 9 of 10 — the only red is "not on main",
      expected on a branch

### When a command or option is added, removed or changed

N/A — no command or option changes; the 38 new keys are error messages, so
`fullhelp` is untouched.

### When `.github/workflows/` is touched — N/A

### When the declarative contract changes — N/A

## A measurement trap, flagged so it does not mislead review

`dsoxlab list-labs` returns **20** labs on `linux-dsoxlab-training` and **4** on
`ansible-training`, not 84 and 113. That is not a regression: those repositories
carry an active section in their `.dsoxlab-context.json` (`l1`, `decouvrir`) and
`list-labs` filters on it, while `terraform-training`, with no active section,
returns all 87. `validate-structure` iterates `discover_labs()` without that
filter and lands exactly on 84 / 113 / 87.

## Deliberate exclusions, each documented by its own test

- **`logger.*`** — a journal message is not interface text, and translating it
  would make it harder to search, to compare between two machines, and to match
  against an answer found online. The journal's current FR/EN inconsistency is a
  real but separate defect, tracked in #140.
- **`models/`** — the correct pattern already exists there
  (`UnsupportedSchemaVersion` carries `source`, `found`, `supported`, and the CLI
  composes the translated message). Translating inside the model would put
  language where there should only be facts. Tracked in #139, with the validators
  that carry the same debt.

## Also found, not fixed here

`dsoxlab run` does not catch `FileNotFoundError`, so the learner gets a Python
traceback wrapped around a message this PR just translated correctly. Tracked in
#138.

## Note on the branch

The first commit is labelled `TRAVAIL EN COURS` — it was made under a forced
reboot. Its body lists a to-do that is now done. The branch was already pushed,
so it was not rewritten; a squash merge makes it disappear.

## Related issues

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
