### PR TITLE
fix(infra): les deux murs d'une installation fraîche, le pool et AppArmor (0.1.52)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,74 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.52] - 2026-08-21
+
+### Corrigé
+
+- **Les disques des VM se déclarent par chemin, et AppArmor cesse de tous les
+  refuser.** Le template KVM empaqueté demandait un disque déclaré par référence
+  de pool (`<disk type='volume'>`), or `virt-aa-helper`, qui fabrique le profil
+  AppArmor du domaine à partir de ce XML, ne sait pas résoudre cette forme en
+  chemin de fichier. Aucun disque n'entrait donc dans le profil, et qemu se
+  voyait tout refuser : `Could not open '…qcow2': Permission denied`, sur une
+  machine où `dsoxlab doctor` venait de passer au vert. Cela ressemblait à un
+  problème de propriétaire sans en être un : mettre tous les volumes en
+  `libvirt-qemu:kvm` n'y changeait rien.
+
+  Les trois disques (système, seed cloud-init et disque additionnel optionnel)
+  pointent désormais le chemin absolu de leur volume. Les volumes restent créés
+  dans le pool : seule la façon dont le domaine les désigne change. libvirt
+  accorde alors les droits de lui-même, droit de verrouillage `k` compris, celui
+  sans lequel l'échec devient `Failed to lock byte 100`.
+
+  Rien n'est modifié sur la machine de l'apprenant, et c'est tout l'intérêt.
+  Poser `security_driver = "none"` dans `/etc/libvirt/qemu.conf` fait bien
+  démarrer le domaine, et éteint du même geste le confinement de toutes les VM
+  de la machine : un contre-exemple enseigné, dans un outil DevSecOps, à des
+  gens qui apprennent le métier. Une règle AppArmor locale aurait marché aussi,
+  mais c'est une modification du système dont ce correctif n'a pas besoin.
+
+  Mesuré sur Ubuntu 24.04.2 avec dmacvicar/libvirt 0.9.8 et le `virt-aa-helper`
+  de la distribution, sur deux domaines créés côte à côte à partir du même
+  volume : `type='volume'` produit un profil ne portant aucune règle de disque,
+  `type='file'` produit `"/var/lib/…/x.qcow2" rwk,`. Ce qui reste à confirmer
+  sur une machine réellement neuve, c'est le bout du parcours : les profils
+  libvirt de la machine de développement sont en mode `complain`, où toute VM
+  démarre dans les deux cas.
+
+- **`doctor` ne confond plus un pool de stockage arrêté avec un pool absent.**
+  `virsh pool-list --name` ne liste que les pools **actifs**. Un pool défini
+  mais jamais démarré n'y figurait pas, le contrôle le déclarait introuvable, et
+  proposait un `pool-define-as` qui échoue aussitôt sur « pool already exists ».
+  Terraform, lui, sort sur un message entièrement différent (`storage pool 'x'
+  is not active`), et le geste qui débloque est `pool-start`. Les deux états
+  sont désormais distingués, chacun avec sa remédiation.
+
+- **La remédiation nomme le pool que le dépôt vise réellement.** L'explication
+  « Pool Not Found » affichée après un `provision` en échec codait `default` en
+  dur. Un catalogue pointant son propre pool via
+  `infra.providers.kvm.storage_pool` se voyait proposer la création d'un pool
+  que personne n'utilise. Le nom est maintenant lu dans le message que libvirt a
+  produit.
+
+### Ajouté
+
+- **`infra.providers.kvm.storage_pool` entre dans le contrat documenté.** Le
+  réglage est lisible par le template empaqueté depuis la 0.1.42 et n'était
+  décrit nulle part : un formateur dont le pool ne s'appelle pas `default`
+  n'avait aucun moyen de l'apprendre autrement qu'en lisant le Terraform
+  empaqueté. `docs/contract-v1.md`, sa version française et
+  `schemas/meta.schema.json` le portent désormais, avec `default` pour valeur
+  par défaut. Pas de montée de version du contrat : un champ optionnel muni
+  d'un défaut ne casse aucun catalogue.
+
+- **Un test lit le template et exige que le contrat en parle.** Il parcourt les
+  appels `lookup(var.provider_config, …)` du `main.tf` KVM et tombe sur toute
+  clé pilotable depuis `meta.yml` mais absente des trois documents, ou dont le
+  défaut a dérivé. Le contrôle bidirectionnel de `tests/test_json_schemas.py` ne
+  peut pas voir ces clés, qui ne passent jamais par `models/repo.py` : c'est la
+  porte qui manquait.
+
 ## [0.1.51] - 2026-08-21
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.52] - 2026-08-21
+
+### Fixed
+
+- **VM disks are declared by path, and AppArmor stops denying every one of
+  them.** The packaged KVM template asked for a disk declared as a pool
+  reference (`<disk type='volume'>`), and `virt-aa-helper` — which builds the
+  per-domain AppArmor profile out of that XML — cannot resolve that form into a
+  file path. No disk entered the profile at all, and qemu was refused
+  everything: `Could not open '…qcow2': Permission denied`, on a machine where
+  `dsoxlab doctor` had just gone green. It looked like an ownership problem and
+  was not: setting every volume to `libvirt-qemu:kvm` changed nothing.
+
+  The three disks — system, cloud-init seed and the optional extra disk — now
+  point at the absolute path of their volume. The volumes are still created in
+  the pool; only the way the domain designates them changes. libvirt then grants
+  the rights by itself, lock right `k` included, the one without which the
+  failure becomes `Failed to lock byte 100`.
+
+  Nothing is changed on the learner's machine, and that is the point. Setting
+  `security_driver = "none"` in `/etc/libvirt/qemu.conf` does start the domain,
+  and also switches off the confinement of every VM on that host — taught, in a
+  DevSecOps tool, to people learning the trade. A local AppArmor rule would have
+  worked too, but it is a system change this fix does not need.
+
+  Measured on Ubuntu 24.04.2 with dmacvicar/libvirt 0.9.8 and the distribution's
+  `virt-aa-helper`, on two domains created side by side from the same volume:
+  `type='volume'` produced a profile carrying no disk rule at all, `type='file'`
+  produced `"/var/lib/…/x.qcow2" rwk,`. What remains to be confirmed on a truly
+  fresh machine is the end of the journey, because the development host runs its
+  libvirt profiles in `complain` mode, where every VM starts either way.
+
+- **`doctor` no longer mistakes a stopped storage pool for a missing one.**
+  `virsh pool-list --name` lists only the *active* pools. A pool defined but
+  never started did not appear there, the check declared it missing, and offered
+  a `pool-define-as` that fails on the spot with "pool already exists".
+  Terraform, for its part, exits on an entirely different message there
+  (`storage pool 'x' is not active`), and the gesture that unblocks is
+  `pool-start`. The two states are now told apart, each with its own
+  remediation.
+
+- **The remediation names the pool the repository really targets.** The "Pool
+  Not Found" explanation printed after a failed `provision` hardcoded `default`.
+  A catalog pointing at its own pool through `infra.providers.kvm.storage_pool`
+  was handed the creation command for a pool nobody uses. The name is now read
+  from the message libvirt produced.
+
+### Added
+
+- **`infra.providers.kvm.storage_pool` enters the documented contract.** The
+  setting has been readable by the packaged template since 0.1.42 and described
+  nowhere, so a trainer whose pool is not called `default` had no way to learn
+  of it short of reading the packaged Terraform. `docs/contract-v1.md`, its
+  French counterpart and `schemas/meta.schema.json` now carry it, with `default`
+  as its default value. No contract version bump: an optional field with a
+  default breaks no catalog.
+
+- **A test reads the template and demands that the contract describe it.** It
+  walks the `lookup(var.provider_config, …)` calls of the KVM `main.tf` and
+  fails on any key that is steerable from `meta.yml` yet absent from the three
+  documents, or whose default has drifted. The bidirectional check of
+  `tests/test_json_schemas.py` cannot see these keys, since they never pass
+  through `models/repo.py`: this is the door that was missing.
+
 ## [0.1.51] - 2026-08-21
 
 ### Added

--- a/docs/contract-v1.fr.md
+++ b/docs/contract-v1.fr.md
@@ -74,12 +74,36 @@ labs sont `shell` n'a aucun bloc `infra:`, et c'est un cas prévu, pas un oubli.
 | `network` | non | chaîne | | Réseau que rejoignent les VM, dédié à ce dépôt. |
 | `cidr` | non | chaîne | | Sous-réseau de ce réseau. |
 | `hosts` | non | liste de mappings | `[]` | Les VM. Voir ci-dessous. |
-| `providers` | non | mapping | `{}` | Surcharges par provider, lues par le module Terraform correspondant. Valeurs libres : chaque provider a ses variables. |
+| `providers` | non | mapping | `{}` | Surcharges par provider, lues par le module Terraform correspondant. Valeurs libres : chaque provider a ses variables. Voir ci-dessous celles que lisent les templates empaquetés. |
 
 Résolution du provider, première règle gagnante : `DSOXLAB_PROVIDER`, puis le
 contexte de session posé par `dsoxlab use --provider`, puis une chaîne brute ou
 une liste à un seul élément. Non résolu n'est pas une erreur : seules les
 commandes d'infrastructure en exigent un.
+
+### `infra.providers.<provider>`
+
+Contenu libre, transmis tel quel au module Terraform du provider concerné. Une
+clé mérite d'être nommée, parce qu'une machine neuve en a besoin :
+
+| Champ | Provider | Obligatoire | Type | Défaut | Remarques |
+| --- | --- | --- | --- | --- | --- |
+| `storage_pool` | `kvm` | non | chaîne | `default` | Pool libvirt où sont créés les volumes. |
+
+Le défaut est précisément ce qu'une installation de libvirt ne fournit pas
+toujours : sur une Ubuntu 24.04 fraîche, `virsh pool-list --all` est vide, et
+`provision` s'arrête sur un `Pool Not Found` brut de Terraform. Deux issues,
+toutes deux prévues : créer le pool `default` (`dsoxlab doctor` affiche les
+quatre commandes), ou pointer cette clé sur un pool que l'on possède déjà. Ne
+jamais éditer le template empaqueté.
+
+```yaml
+infra:
+  provider: kvm
+  providers:
+    kvm:
+      storage_pool: labs-pool
+```
 
 ### `infra.hosts[]`
 

--- a/docs/contract-v1.md
+++ b/docs/contract-v1.md
@@ -75,11 +75,34 @@ omission.
 | `network` | no | string | — | Network the VMs join, dedicated to this repository. |
 | `cidr` | no | string | — | Subnet of that network. |
 | `hosts` | no | list of mappings | `[]` | The VMs. See below. |
-| `providers` | no | mapping | `{}` | Per-provider overrides, read by the matching Terraform module. Free-form values: each provider has its own variables. |
+| `providers` | no | mapping | `{}` | Per-provider overrides, read by the matching Terraform module. Free-form values: each provider has its own variables. See below for the ones the packaged templates read. |
 
 Provider resolution, first rule wins: `DSOXLAB_PROVIDER`, then the session
 context set by `dsoxlab use --provider`, then a bare string or a single-item
 list. Unresolved is not an error — only infrastructure commands require one.
+
+### `infra.providers.<provider>`
+
+Free-form, and passed to the Terraform module of that provider as-is. One key
+is worth naming, because a fresh machine needs it:
+
+| Field | Provider | Required | Type | Default | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `storage_pool` | `kvm` | no | string | `default` | libvirt pool the volumes are created in. |
+
+The default is what a stock libvirt install does *not* always give you: on a
+fresh Ubuntu 24.04, `virsh pool-list --all` is empty, and `provision` stops on a
+raw `Pool Not Found` from Terraform. Two ways out, and both are supported:
+create the `default` pool (`dsoxlab doctor` prints the four commands), or point
+this key at a pool you already own. Never edit the packaged template.
+
+```yaml
+infra:
+  provider: kvm
+  providers:
+    kvm:
+      storage_pool: labs-pool
+```
 
 ### `infra.hosts[]`
 

--- a/fuzz/corpus/meta_yml/full-infra.yml
+++ b/fuzz/corpus/meta_yml/full-infra.yml
@@ -21,6 +21,8 @@ infra:
     - name: ubuntu-lfcs-1.lab
       distro: ubuntu24
   providers:
+    kvm:
+      storage_pool: labs-pool
     outscale:
       network: lab-linux-osc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.51"
+version = "0.1.52"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/meta.schema.json
+++ b/schemas/meta.schema.json
@@ -98,9 +98,17 @@
         },
         "providers": {
           "type": "object",
-          "description": "Per-provider overrides, read by the matching Terraform module. Keys are provider names; values are free-form mappings, because each provider has its own variables.",
+          "description": "Per-provider overrides, read by the matching Terraform module. Keys are provider names; values are free-form mappings, because each provider has its own variables. The keys described below are the ones the packaged templates read; any other key is passed through untouched.",
           "additionalProperties": {
-            "type": ["object", "null"]
+            "type": ["object", "null"],
+            "properties": {
+              "storage_pool": {
+                "type": "string",
+                "minLength": 1,
+                "default": "default",
+                "description": "kvm only. libvirt storage pool the volumes are created in. Defaults to `default`, which a fresh install does not always declare: `virsh pool-list --all` is empty on a stock Ubuntu, and provisioning stops on a raw \"Pool Not Found\". Point this at a pool you own rather than editing the packaged template."
+              }
+            }
           }
         }
       }

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -606,6 +606,9 @@ silent.
     "detail_pool_missing":
         "the `{pool}` pool does not exist: `provision` will fail with "
         "\"Pool Not Found\"",
+    "detail_pool_inactive":
+        "the `{pool}` pool is defined but never started: `provision` will fail "
+        "with \"storage pool is not active\"",
     "detail_pool_unknown":   "cannot be checked without virsh",
     "explain_apparmor_denied":
         "Known cause: AppArmor denies the VM disks. virt-aa-helper cannot "
@@ -615,6 +618,10 @@ silent.
     "explain_pool_not_found":
         "Known cause: the libvirt storage pool does not exist. A fresh install "
         "declares none. Create it:",
+    "explain_pool_inactive":
+        "Known cause: the libvirt storage pool exists but was never started. "
+        "Defining a pool is not enough, nothing can be written to it until it "
+        "runs. Start it:",
     "explain_domain_exists":
         "Known cause: an earlier provisioning failed AFTER defining this "
         "machine, so it never entered the Terraform state and `destroy` cannot "

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -608,6 +608,9 @@ hors ligne, elle se tait.
     "detail_pool_missing":
         "le pool « {pool} » n'existe pas : « provision » échouera sur "
         "« Pool Not Found »",
+    "detail_pool_inactive":
+        "le pool « {pool} » est défini mais jamais démarré : « provision » "
+        "échouera sur « storage pool is not active »",
     "detail_pool_unknown":   "non vérifiable sans virsh",
     "explain_apparmor_denied":
         "Cause connue : AppArmor refuse les disques des VM. virt-aa-helper ne "
@@ -617,6 +620,10 @@ hors ligne, elle se tait.
     "explain_pool_not_found":
         "Cause connue : le pool de stockage libvirt n'existe pas. Une "
         "installation fraîche n'en déclare aucun. Crée-le :",
+    "explain_pool_inactive":
+        "Cause connue : le pool de stockage libvirt existe mais n'a jamais été "
+        "démarré. Le définir ne suffit pas, rien ne peut y être écrit tant "
+        "qu'il ne tourne pas. Démarre-le :",
     "explain_domain_exists":
         "Cause connue : un provisionnement précédent a échoué APRÈS avoir "
         "défini cette machine, qui n'est donc pas dans le state Terraform. "

--- a/src/dsoxlab/services/doctor.py
+++ b/src/dsoxlab/services/doctor.py
@@ -26,6 +26,7 @@ Le module reste agnostique du domaine : il ne connaît que le contrat
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -259,6 +260,47 @@ def _check_ansible() -> Check:
     return Check(_("check_ansible"), True, _("detail_ansible_ok"))
 
 
+def creer_pool_command(pool: str) -> str:
+    """La commande qui crée un pool libvirt de bout en bout.
+
+    Les quatre étapes comptent : ``pool-define-as`` seul laisse un pool défini
+    mais **inactif**, dans lequel Terraform ne peut rien écrire.
+    """
+    return (
+        f"sudo virsh pool-define-as {pool} dir --target "
+        f"/var/lib/libvirt/images && sudo virsh pool-build {pool} && "
+        f"sudo virsh pool-start {pool} && sudo virsh pool-autostart {pool}"
+    )
+
+
+def demarrer_pool_command(pool: str) -> str:
+    """La commande qui démarre un pool déjà défini, et le rend permanent."""
+    return f"sudo virsh pool-start {pool} && sudo virsh pool-autostart {pool}"
+
+
+def _pools_libvirt(*, definis: bool) -> list[str] | None:
+    """Noms des pools libvirt : les actifs seuls, ou tous ceux qui sont définis.
+
+    Rendre ``None`` quand la sonde n'aboutit pas. ``virsh`` absent ou muet est
+    l'affaire du contrôle KVM ; le redire ici empilerait deux rouges pour une
+    seule cause.
+    """
+    cmd = ["virsh", "-c", "qemu:///system", "pool-list"]
+    if definis:
+        cmd.append("--all")
+    cmd.append("--name")
+    # check=False : le code retour est lu juste en dessous pour décider.
+    try:
+        probe = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=5, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if probe.returncode != 0:
+        return None
+    return probe.stdout.split()
+
+
 def _check_libvirt_pool(pool: str) -> Check:
     """Le template KVM écrit ses volumes dans un pool libvirt.
 
@@ -269,28 +311,30 @@ def _check_libvirt_pool(pool: str) -> Check:
     Le nom vient de ``meta.yml: infra.providers.kvm.storage_pool``, faute de
     quoi ``default``. Le contrôle porte donc sur le pool que le dépôt vise
     réellement, et non sur un nom présumé.
-    """
-    # check=False : le code retour est lu plus bas pour décider, et un virsh
-    # injoignable est traité comme « rien à ajouter », pas comme une erreur.
-    try:
-        probe = subprocess.run(
-            ["virsh", "-c", "qemu:///system", "pool-list", "--name"],
-            capture_output=True, text=True, timeout=5, check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        # virsh absent ou injoignable : c'est le contrôle KVM qui le dira,
-        # celui-ci n'a rien à ajouter et ne doit pas doubler le rouge.
-        return Check(_("check_libvirt_pool"), True, _("detail_pool_unknown"))
 
-    if probe.returncode == 0 and pool in probe.stdout.split():
+    Absent et inactif sont **deux états distincts**, et les confondre faisait
+    mentir le diagnostic. ``virsh pool-list --name`` ne liste que les pools
+    **actifs** : un pool défini mais jamais démarré n'y figure pas, le contrôle
+    le déclarait donc introuvable et proposait un ``pool-define-as`` qui échoue
+    aussitôt (« pool already exists »). Or Terraform, lui, sort sur une erreur
+    entièrement différente (« storage pool 'x' is not active »), et le geste qui
+    débloque est ``pool-start``, pas une création.
+    """
+    actifs = _pools_libvirt(definis=False)
+    if actifs is None:
+        return Check(_("check_libvirt_pool"), True, _("detail_pool_unknown"))
+    if pool in actifs:
         return Check(_("check_libvirt_pool"), True, pool)
+
+    definis = _pools_libvirt(definis=True)
+    if definis is not None and pool in definis:
+        return Check(
+            _("check_libvirt_pool"), False, _("detail_pool_inactive", pool=pool),
+            fix=demarrer_pool_command(pool),
+        )
     return Check(
         _("check_libvirt_pool"), False, _("detail_pool_missing", pool=pool),
-        fix=(
-            f"sudo virsh pool-define-as {pool} dir --target "
-            f"/var/lib/libvirt/images && sudo virsh pool-build {pool} && "
-            f"sudo virsh pool-start {pool} && sudo virsh pool-autostart {pool}"
-        ),
+        fix=creer_pool_command(pool),
     )
 
 
@@ -339,12 +383,34 @@ def apparmor_fix_command() -> str:
     )
 
 
+#: Le nom du pool tel que libvirt le cite dans ses deux messages d'échec.
+#: L'extraire évite de nommer « default » à un dépôt qui vise le sien via
+#: ``meta.yml: infra.providers.kvm.storage_pool`` : la remédiation porterait
+#: alors sur un pool que personne n'utilise.
+_POOL_ABSENT = re.compile(
+    r"no storage pool with matching name '([^']+)'"
+    r"|storage pool '([^']+)' not found",
+    re.IGNORECASE,
+)
+_POOL_INACTIF = re.compile(
+    r"storage pool '([^']+)' is not active", re.IGNORECASE
+)
+
+
+def _pool_cite(motif: re.Pattern[str], message: str) -> str | None:
+    """Le pool que ``message`` nomme, ou ``None`` si le motif ne mord pas."""
+    trouve = motif.search(message)
+    if trouve is None:
+        return None
+    return next((groupe for groupe in trouve.groups() if groupe), None)
+
+
 def explique_echec_provision(message: str) -> tuple[str, str] | None:
     """Reconnaît une cause connue dans l'erreur brute d'un provisionnement.
 
     Terraform rend des messages exacts mais opaques pour qui découvre l'outil.
-    Deux d'entre eux ont une cause connue et un correctif d'une ligne, et ce
-    sont ceux qui arrêtent un débutant sur une machine fraîche.
+    Quelques-uns ont une cause connue et un correctif d'une ligne, et ce sont
+    ceux qui arrêtent un débutant sur une machine fraîche.
 
     Rendre ``(explication, commande)``, ou ``None`` si rien n'est reconnu : on
     ne devine pas, on nomme ce qu'on sait nommer.
@@ -354,6 +420,12 @@ def explique_echec_provision(message: str) -> tuple[str, str] | None:
     # « Permission denied » sur une image du pool : l'échec type d'AppArmor
     # décrit dans apparmor_override_absent(). On ne le propose QUE si
     # l'override manque effectivement, sans quoi ce serait une fausse piste.
+    #
+    # Depuis que le template déclare ses disques par chemin de fichier plutôt
+    # que par référence de pool, une machine provisionnée par cette version ne
+    # tombe plus là-dessus. La branche reste pour les domaines définis par une
+    # version antérieure, qui portent encore la forme que virt-aa-helper ne sait
+    # pas résoudre : eux ne guériront qu'en étant recréés.
     if (
         "permission denied" in bas
         and "/var/lib/libvirt/images" in bas
@@ -361,14 +433,20 @@ def explique_echec_provision(message: str) -> tuple[str, str] | None:
     ):
         return _("explain_apparmor_denied"), apparmor_fix_command()
 
-    # « Pool not found » : le pool `default` n'existe pas sur une installation
-    # fraîche. Le contrôle de doctor l'attrape en amont, mais un provisionnement
-    # lancé sans diagnostic préalable tombe directement ici.
-    if "pool not found" in bas or "no storage pool with matching name" in bas:
-        return _("explain_pool_not_found"), (
-            "sudo virsh pool-define-as default dir --target "
-            "/var/lib/libvirt/images && sudo virsh pool-build default && "
-            "sudo virsh pool-start default && sudo virsh pool-autostart default"
+    # « is not active » : le pool existe mais n'a jamais été démarré. C'est un
+    # état DIFFÉRENT de l'absence, et il appelle un autre geste. Un
+    # `pool-define-as` proposé ici échouerait sur « pool already exists ».
+    pool_inactif = _pool_cite(_POOL_INACTIF, message)
+    if pool_inactif is not None:
+        return _("explain_pool_inactive"), demarrer_pool_command(pool_inactif)
+
+    # « Pool not found » : le pool visé n'existe pas. Une installation fraîche
+    # n'en déclare aucun. Le contrôle de doctor l'attrape en amont, mais un
+    # provisionnement lancé sans diagnostic préalable tombe directement ici.
+    pool_absent = _pool_cite(_POOL_ABSENT, message)
+    if pool_absent is not None or "pool not found" in bas:
+        return _("explain_pool_not_found"), creer_pool_command(
+            pool_absent or "default"
         )
 
     # « already exists » sur un domaine : un provisionnement précédent a échoué

--- a/src/dsoxlab/templates/terraform/kvm/main.tf
+++ b/src/dsoxlab/templates/terraform/kvm/main.tf
@@ -358,6 +358,30 @@ resource "libvirt_domain" "host" {
     mode = "host-passthrough"
   }
 
+  # Les disques se déclarent par CHEMIN DE FICHIER (`source.file`), jamais par
+  # référence de pool (`source.volume`). Ce n'est pas une préférence de style :
+  # c'est ce qui rend les VM démarrables sur Ubuntu et Debian.
+  #
+  # `source.volume` produit `<disk type='volume'><source pool=… volume=…/>`.
+  # `virt-aa-helper`, qui fabrique le profil AppArmor du domaine à partir de ce
+  # XML, ne sait pas résoudre cette forme en chemin : AUCUN disque n'entre alors
+  # dans le profil, et qemu se voit tout refuser par un « Permission denied » qui
+  # ressemble à un problème de propriétaire sans en être un (le corriger ne
+  # change rien). Sur une Ubuntu 24.04 fraîche, où les profils par domaine sont
+  # en `enforce`, aucun lab `vm` ne démarrait.
+  #
+  # `source.file` produit `<disk type='file'><source file='/chemin/absolu'/>`,
+  # que `virt-aa-helper` résout et autorise de lui-même, droit de verrouillage
+  # `k` compris, celui sans lequel l'erreur devient « Failed to lock byte 100 ».
+  #
+  # Mesuré sur Ubuntu 24.04.2 avec dmacvicar/libvirt 0.9.8 et le virt-aa-helper
+  # du paquet, les deux domaines créés côte à côte :
+  #   type='volume'  → profil généré : aucune règle de disque
+  #   type='file'    → « /var/lib/libvirt/images/…/x.qcow2 » rwk,
+  #
+  # Le volume reste créé dans le pool : seule la façon de le DÉSIGNER au domaine
+  # change. `libvirt_volume.<x>.path` rend le chemin absolu que libvirt lui a
+  # attribué, quel que soit le pool visé.
   devices = {
     disks = concat(
       [
@@ -371,9 +395,8 @@ resource "libvirt_domain" "host" {
             type = "qcow2"
           }
           source = {
-            volume = {
-              pool   = libvirt_volume.host[each.key].pool
-              volume = libvirt_volume.host[each.key].name
+            file = {
+              file = libvirt_volume.host[each.key].path
             }
           }
           target = {
@@ -391,9 +414,8 @@ resource "libvirt_domain" "host" {
             type = "raw"
           }
           source = {
-            volume = {
-              pool   = libvirt_volume.cloudinit[each.key].pool
-              volume = libvirt_volume.cloudinit[each.key].name
+            file = {
+              file = libvirt_volume.cloudinit[each.key].path
             }
           }
           target = {
@@ -413,9 +435,8 @@ resource "libvirt_domain" "host" {
             type = "qcow2"
           }
           source = {
-            volume = {
-              pool   = libvirt_volume.extra[each.key].pool
-              volume = libvirt_volume.extra[each.key].name
+            file = {
+              file = libvirt_volume.extra[each.key].path
             }
           }
           target = {

--- a/tests/test_doctor_installation.py
+++ b/tests/test_doctor_installation.py
@@ -409,3 +409,163 @@ def test_une_erreur_inconnue_ne_produit_aucune_explication() -> None:
     """On ne devine pas : une explication inventée coûte plus qu'aucune."""
     assert doctor.explique_echec_provision("boom") is None
     assert doctor.explique_echec_provision("") is None
+
+
+# ── absent et inactif sont deux états, pas un seul ───────────────────────────
+
+def _virsh_pools(actifs: list[str], definis: list[str]):
+    """Simule `virsh pool-list [--all] --name`.
+
+    La sonde réelle est jouée : c'est bien elle qui oubliait le `--all`, donc
+    la remplacer par un faux `_pools_libvirt` ne prouverait rien. On ne
+    contrefait que virsh, au niveau du sous-processus.
+    """
+
+    def _run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        noms = definis if "--all" in cmd else actifs
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="\n".join(noms) + "\n", stderr="",
+        )
+
+    return _run
+
+
+def test_un_pool_actif_est_vert(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Le contre-cas, sans lequel les deux suivants passeraient sur un bug
+    qui rendrait tout pool rouge."""
+    monkeypatch.setattr(
+        doctor.subprocess, "run", _virsh_pools(["default"], ["default"])
+    )
+    check = doctor._check_libvirt_pool("default")
+
+    assert check.ok
+    assert check.detail == "default"
+    assert check.fix is None
+
+
+def test_un_pool_absent_fait_proposer_sa_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Une Ubuntu fraîche n'en déclare aucun. Les quatre étapes comptent :
+    `pool-define-as` seul laisse un pool inactif, où rien ne s'écrit."""
+    monkeypatch.setattr(doctor.subprocess, "run", _virsh_pools([], []))
+    check = doctor._check_libvirt_pool("default")
+
+    assert not check.ok
+    assert check.detail == _("detail_pool_missing", pool="default")
+    assert check.fix is not None
+    for etape in ("pool-define-as", "pool-build", "pool-start", "pool-autostart"):
+        assert etape in check.fix, f"« {etape} » manque à la création du pool"
+
+
+def test_un_pool_defini_mais_arrete_est_dit_tel_quel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le défaut que ce lot corrige.
+
+    `virsh pool-list --name` ne liste que les pools **actifs**. Un pool défini
+    mais jamais démarré n'y figurait pas, le contrôle le déclarait introuvable,
+    et proposait un `pool-define-as` qui échoue aussitôt sur « pool already
+    exists ». Terraform, lui, sort sur un tout autre message (« storage pool
+    'x' is not active ») et le geste qui débloque est `pool-start`.
+    """
+    monkeypatch.setattr(
+        doctor.subprocess, "run", _virsh_pools([], ["default"])
+    )
+    check = doctor._check_libvirt_pool("default")
+
+    assert not check.ok
+    assert check.detail == _("detail_pool_inactive", pool="default")
+    assert check.fix is not None
+    assert "pool-start" in check.fix
+    assert "pool-autostart" in check.fix
+    assert "pool-define-as" not in check.fix, (
+        "définir un pool qui existe déjà échoue : la remédiation mentirait"
+    )
+
+
+def test_le_pool_du_depot_est_celui_qui_est_sonde(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Un dépôt qui vise son propre pool ne doit pas se voir répondre sur
+    « default », ni dans le constat ni dans la remédiation."""
+    monkeypatch.setattr(
+        doctor.subprocess, "run", _virsh_pools(["default"], ["default"])
+    )
+    check = doctor._check_libvirt_pool("labs-pool")
+
+    assert not check.ok
+    assert "labs-pool" in check.detail
+    assert check.fix is not None
+    assert "labs-pool" in check.fix
+    assert "default" not in check.fix
+
+
+def test_un_virsh_muet_ne_conclut_pas_a_l_absence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sonder n'est pas deviner : un virsh injoignable ne prouve pas qu'un pool
+    manque, et le rouge appartient alors au contrôle KVM, pas à celui-ci."""
+
+    def _run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        raise OSError("virsh a disparu entre deux appels")
+
+    monkeypatch.setattr(doctor.subprocess, "run", _run)
+    check = doctor._check_libvirt_pool("default")
+
+    assert check.ok
+    assert check.detail == _("detail_pool_unknown")
+
+
+# ── la remédiation nomme le pool que Terraform a nommé ────────────────────────
+
+def test_le_pool_absent_est_lu_dans_le_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Message réel de terraform-provider-libvirt 0.9.8, relevé sur la machine.
+
+    La remédiation codait « default » en dur : un dépôt qui vise son pool via
+    `infra.providers.kvm.storage_pool` se voyait proposer la création d'un pool
+    que personne n'utilise, et restait bloqué.
+    """
+    erreur = (
+        "Error: Pool Not Found\n\nStorage pool 'labs-pool' not found: Storage "
+        "pool not found: no storage pool with matching name 'labs-pool'"
+    )
+    resultat = doctor.explique_echec_provision(erreur)
+
+    assert resultat is not None
+    explication, commande = resultat
+    assert explication == _("explain_pool_not_found")
+    assert "labs-pool" in commande
+    assert "default" not in commande
+
+
+def test_un_pool_inactif_est_reconnu_a_l_echec() -> None:
+    """Autre message réel, mesuré en appliquant sur un pool défini non démarré.
+
+    Il ne dit pas la même chose que « Pool Not Found » et n'appelle pas le même
+    geste : le confondre avec l'absence renverrait vers une création qui échoue.
+    """
+    erreur = (
+        "Error: Volume Creation Failed\n\nFailed to create storage volume: "
+        "Requested operation is not valid: storage pool 'labs-pool' is not active"
+    )
+    resultat = doctor.explique_echec_provision(erreur)
+
+    assert resultat is not None
+    explication, commande = resultat
+    assert explication == _("explain_pool_inactive")
+    assert "pool-start labs-pool" in commande
+    assert "pool-define-as" not in commande
+
+
+@pytest.mark.parametrize(
+    "cle",
+    ["detail_pool_inactive", "explain_pool_inactive"],
+)
+def test_les_cles_du_pool_inactif_sont_bilingues(cle: str) -> None:
+    """Une clé qui n'existe que d'un côté n'existe pas."""
+    from dsoxlab.i18n.strings.en import STRINGS as EN
+    from dsoxlab.i18n.strings.fr import STRINGS as FR
+
+    assert cle in EN and cle in FR
+    assert EN[cle] != FR[cle], "une traduction identique est probablement oubliée"

--- a/tests/test_documentation_synchrone.py
+++ b/tests/test_documentation_synchrone.py
@@ -17,6 +17,7 @@ Il attrape donc aussi bien la commande oubliée que la commande fantôme.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -176,3 +177,60 @@ def test_la_table_des_commandes_du_readme_est_a_jour() -> None:
         f"la documentation a dérivé de la CLI :\n{proc.stdout}\n"
         "Régénère-la : python3 scripts/generer-doc.py"
     )
+
+
+# ── le contrat décrit les réglages que les templates lisent vraiment ──────────
+
+#: Les surcharges de `infra.providers.<provider>` ne passent pas par
+#: `models/repo.py` : elles sont transmises telles quelles au module Terraform,
+#: qui les lit par `lookup(var.provider_config, …)`. Le contrôle bidirectionnel
+#: de `tests/test_json_schemas.py` ne peut donc pas les voir, et une clé
+#: pilotable mais décrite nulle part reste introuvable pour l'auteur d'un
+#: catalogue. Ce test-ci lit le template et exige que le contrat en parle.
+_LOOKUP = re.compile(
+    r'lookup\(\s*var\.provider_config\s*,\s*"(\w+)"\s*,\s*"([^"]*)"\s*\)'
+)
+
+#: Clés que le template lit pour son propre compte, et qui ne relèvent pas du
+#: contrat : dsoxlab les pose lui-même dans les tfvars, un auteur ne les écrit
+#: jamais. Les documenter inviterait à les déclarer à la main.
+_POSEES_PAR_L_OUTIL = {"ssh_pubkey", "region", "profile", "cidr"}
+
+
+def test_les_reglages_kvm_du_contrat_sont_documentes() -> None:
+    """Une clé lue par le template packagé doit figurer dans le contrat.
+
+    `storage_pool` a vécu deux versions en étant lisible par le template et
+    absent des trois documents qui décrivent le contrat : un formateur dont le
+    pool ne s'appelle pas `default` n'avait aucun moyen de l'apprendre autrement
+    qu'en lisant le Terraform empaqueté.
+    """
+    from dsoxlab.templates import template_root
+
+    main_tf = (template_root() / "terraform" / "kvm" / "main.tf").read_text(
+        encoding="utf-8"
+    )
+    lues = {
+        cle: defaut
+        for cle, defaut in _LOOKUP.findall(main_tf)
+        if cle not in _POSEES_PAR_L_OUTIL and not cle.startswith("image_url_")
+    }
+    assert lues, "aucun lookup(var.provider_config, …) trouvé : ce test ne lit plus rien"
+
+    schema = json.loads((RACINE / "schemas" / "meta.schema.json").read_text("utf-8"))
+    decrites = schema["properties"]["infra"]["properties"]["providers"][
+        "additionalProperties"
+    ].get("properties", {})
+
+    for cle, defaut in sorted(lues.items()):
+        assert cle in decrites, (
+            f"« {cle} » est pilotable depuis meta.yml mais absent de "
+            "schemas/meta.schema.json"
+        )
+        assert decrites[cle].get("default") == defaut, (
+            f"le schéma annonce « {decrites[cle].get('default')} » comme défaut "
+            f"de « {cle} », le template applique « {defaut} »"
+        )
+        for document in ("docs/contract-v1.md", "docs/contract-v1.fr.md"):
+            texte = (RACINE / document).read_text(encoding="utf-8")
+            assert f"`{cle}`" in texte, f"« {cle} » n'est décrit nulle part dans {document}"

--- a/tests/test_kvm_disques_apparmor.py
+++ b/tests/test_kvm_disques_apparmor.py
@@ -1,0 +1,118 @@
+"""Les disques d'une VM KVM se déclarent par chemin, jamais par référence de pool.
+
+Ce n'est pas une préférence de style, c'est la condition pour qu'un lab `vm`
+démarre sur Ubuntu et sur Debian, où AppArmor est actif par défaut.
+
+`virt-aa-helper` fabrique le profil AppArmor d'un domaine à partir de son XML.
+Il sait résoudre `<disk type='file'><source file='/chemin/absolu'/>`, et pas
+`<disk type='volume'><source pool=… volume=…/>`. Avec la seconde forme, **aucun**
+disque n'entre dans le profil, et qemu se voit tout refuser par un « Permission
+denied » qui ressemble à un problème de propriétaire sans en être un : mettre
+tous les volumes en `libvirt-qemu:kvm` ne change rien.
+
+Mesuré sur Ubuntu 24.04.2, avec le `virt-aa-helper` du paquet et le provider
+`dmacvicar/libvirt` 0.9.8, sur deux domaines créés côte à côte à partir du même
+volume, puis détruits :
+
+    source.volume → <disk type='volume'> → profil généré : aucune règle de disque
+    source.file   → <disk type='file'>   → « /var/lib/…/x.qcow2 » rwk,
+
+Le `rwk` compte jusque dans sa dernière lettre : sans le droit de verrouillage
+`k`, l'échec devient « Failed to lock byte 100 ».
+
+Ce que ce module tient, c'est la forme du template packagé. Il ne peut pas
+prouver le démarrage d'une VM, ce qui demande une machine où les profils libvirt
+sont en `enforce` ; il empêche en revanche la régression silencieuse qui
+ramènerait la forme non résoluble, dont rien d'autre ne rendrait compte avant le
+premier `provision` d'un apprenant.
+"""
+
+from __future__ import annotations
+
+import re
+
+from dsoxlab.templates import template_root
+
+#: Bornes du bloc qui déclare les disques du domaine. Le pool reste la bonne
+#: façon de **créer** un volume : c'est la façon de le **désigner au domaine**
+#: qui décide du profil AppArmor. Les deux ne doivent donc pas être confondues,
+#: d'où la lecture d'une tranche précise du fichier plutôt que du tout.
+_DEBUT = "disks = concat("
+_FIN = "interfaces = ["
+
+_POOL = re.compile(r"^\s*pool\s*=", re.MULTILINE)
+_VOLUME = re.compile(r"^\s*volume\s*=\s*\{?", re.MULTILINE)
+_CHEMIN = re.compile(r"file\s*=\s*libvirt_volume\.(\w+)\[")
+
+
+def _main_tf() -> str:
+    return (template_root() / "terraform" / "kvm" / "main.tf").read_text(
+        encoding="utf-8"
+    )
+
+
+def _bloc_disques(texte: str) -> str:
+    """La tranche du main.tf qui déclare les disques du domaine.
+
+    L'assertion n'est pas décorative : si la structure du fichier change, la
+    tranche devient vide et tous les contrôles de ce module passeraient au vert
+    sans rien lire. Un test qui ne mesure plus rien doit tomber, pas se taire.
+    """
+    debut = texte.find(_DEBUT)
+    assert debut != -1, (
+        f"« {_DEBUT} » introuvable : la structure du main.tf a changé, "
+        "ce module ne lit plus les disques du domaine"
+    )
+    fin = texte.find(_FIN, debut)
+    assert fin > debut, (
+        f"« {_FIN} » introuvable après les disques : la tranche lue serait "
+        "vide, et les contrôles passeraient au vert à vide"
+    )
+    return texte[debut:fin]
+
+
+def test_aucun_disque_declare_par_reference_de_pool() -> None:
+    """La forme que virt-aa-helper ne sait pas résoudre ne doit plus exister."""
+    bloc = _bloc_disques(_main_tf())
+
+    assert not _POOL.search(bloc), (
+        "un disque du domaine désigne encore un pool : virt-aa-helper ne "
+        "résoudra aucun disque, et aucune VM ne démarrera sous AppArmor"
+    )
+    assert not _VOLUME.search(bloc), (
+        "un disque du domaine désigne encore un volume par son nom : c'est "
+        "l'autre moitié de la forme <disk type='volume'>"
+    )
+
+
+def test_les_trois_disques_pointent_un_chemin() -> None:
+    """Système, seed cloud-init et disque additionnel, tous les trois.
+
+    En compter le nombre exact plutôt que se contenter d'une présence : le
+    défaut d'origine tenait justement à ce qu'un seul des trois avait été
+    corrigé n'aurait rien changé, un domaine dont un disque manque au profil
+    échouant exactement comme un domaine dont aucun n'y figure.
+    """
+    ressources = _CHEMIN.findall(_bloc_disques(_main_tf()))
+
+    assert sorted(ressources) == ["cloudinit", "extra", "host"], (
+        f"les trois disques doivent pointer un chemin de volume, vus : {ressources}"
+    )
+
+
+def test_les_volumes_restent_crees_dans_le_pool() -> None:
+    """Le contrepoids : on ne règle pas AppArmor en abandonnant le pool.
+
+    Sans ce contrôle, supprimer purement et simplement le pool des ressources
+    `libvirt_volume` ferait passer les deux tests précédents, tout en cassant le
+    réglage `infra.providers.kvm.storage_pool` que l'issue #94 a introduit.
+    """
+    texte = _main_tf()
+    bloc = _bloc_disques(texte)
+    hors_disques = texte.replace(bloc, "")
+
+    assert len(_POOL.findall(hors_disques)) == 4, (
+        "les quatre ressources libvirt_volume doivent toujours déclarer leur "
+        "pool : le chemin du disque en dérive"
+    )
+    assert 'lookup(var.provider_config, "storage_pool", "default")' in hors_disques

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.51"
+version = "0.1.52"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
# Summary

The two successive walls a fresh Ubuntu hits, fixed together — separately they
would just move the failure one step further.

**#94** — `pool = "default"` was hardcoded in four places of the KVM template,
while Ubuntu's libvirt package declares **no** pool at all: `virsh pool-list
--all` is empty on a new machine, so `provision` dies on *Pool Not Found*.

**#93** — once past that, AppArmor blocks every disk.
`terraform-provider-libvirt` produced `<disk type='volume'>`, and
`virt-aa-helper` cannot resolve a `pool` + `volume` reference into a path, so
**no disk at all** entered the domain's profile and qemu got *Permission denied*.

In both cases `dsoxlab doctor` was **green** immediately before. That is the
defect underneath this whole family of issues: the tool declares ready what is
not.

## #93: which solution, and why not the others

**`security_driver = "none"` was excluded outright.** It appears in the issue as
a *diagnosis*, never as a remedy: it turns off confinement for every VM on the
machine, and would teach that to learners inside a DevSecOps training tool. The
lesson costs more than the bug.

**A local AppArmor rule works but was rejected**: it is still a modification of
the learner's system, and this fix does not need to ask for one.

**Solution retained: remove the cause.** The provider accepts `source.file`, and
`libvirt_volume` already exposes `.path`. The template now declares its three
disks by file path. Nothing changes on the learner's machine, and confinement
stays fully enforced.

Measured on this machine (Ubuntu 24.04.2, packaged `virt-aa-helper`, provider
0.9.8), on two domains created side by side from the same volume, then destroyed:

| Declaration | Profile generated by `virt-aa-helper -d -c` |
|---|---|
| `<disk type='volume'>` | **no disk rule at all** |
| `<disk type='file'>` | `"/var/lib/libvirt/images/…/x.qcow2" rwk,` |

The AppArmor branch of `explique_echec_provision()` is kept as a net for domains
defined by an older version, with a comment saying so.

## What is proven here, and what is not

**Proven**: the profile difference above; the provider really emits
`<disk type='file'><source file='/absolute/path'/>` (`virsh dumpxml` on both
domains); `terraform validate` and `terraform plan` green on the modified
template; an absent pool yields *Pool Not Found* while a defined-but-stopped pool
yields *storage pool 'x' is not active*, and `doctor` returns the right verdict in
all three real states of a throwaway pool.

**Not provable here**: the full journey for #93. This machine's libvirt profiles
are in **`complain`** mode (17 of them), so any VM starts with or without the fix
— measuring here would be observing an open door to conclude none are locked. The
protocol for a fresh Ubuntu, including the 0.1.51 control measurement that must
come first, is written in a comment on #93 and stays open until it is run.

## Type of change

- [x] Bug fix

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — no issues in 57 source files
- [x] `uv run pytest tests` — **434 passed** (421 before, +13); `tests_e2e` — **16 passed**
- [x] The engine stays domain-agnostic
- [x] No hardcoded personal path or host — that is precisely what #94 removes
- [x] Manually tested against the **three** lab repositories: 84 / 113 / 87 labs,
      `doctor` and `validate-structure` rc=0 on each. libvirt before: 14 domains,
      42 pools; after: **14 domains, 42 pools**, no `dsoxlab-probe-*` residue.
      The lab repositories' `git status` is unchanged and no `git checkout` was
      run there.

### When behavior changes

- [x] Both CHANGELOG files updated; version **0.1.52**; `uv.lock` regenerated

### When a command or option is added, removed or changed

N/A — no command or option changes. Two new i18n keys, added simultaneously to
EN and FR; `fullhelp` untouched.

### When `.github/workflows/` is touched — N/A

### When the declarative contract changes

- [x] `infra.providers.kvm.storage_pool` documented in `docs/contract-v1.md`,
      `docs/contract-v1.fr.md` and `schemas/meta.schema.json`. **Optional with a
      default, so no catalogue breaks and no contract v2 is needed.**
- [x] `fuzz/corpus/meta_yml/full-infra.yml` seeds the new field
- [x] A malformed value still raises inside the parser contract

**A gap in the guard, closed on the way.** The bidirectional schema test could
never have caught this field: `infra.providers.<name>.*` keys never pass through
`models/repo.py`, they are read by the Terraform template via
`lookup(var.provider_config, …)`. A new test reads those lookups straight from
the template and demands the three documents describe them, with the same
default. Without it, the next provider option would drift silently.

## Mutation testing

Ten mutations, each applied then restored in a `finally`, **all red**: disk put
back as a pool reference; `disks = concat(` renamed (the slice guard bites);
`libvirt_volume` deprived of its pool; `--all` removed from `pool-list`;
`default` re-hardcoded in the remediation; the inactive-pool branch disabled;
`storage_pool` removed from the schema; removed from the French contract; schema
default desynced from the template; the FR side of an i18n key deleted.

Verified independently before opening this PR: putting one disk back to a pool
reference turns `test_les_trois_disques_pointent_un_chemin` red; restored, 3
passed.

## Decisions worth reviewing

1. **The version bump is to arbitrate at merge**: this branch targets 0.1.52 and
   the #101 branch targets 0.1.53, agreed in advance. Overlap on `CHANGELOG.*`,
   `pyproject.toml`, `uv.lock` and the two i18n files.
2. **`explique_echec_provision()` does not suggest re-provisioning** as a durable
   AppArmor fix: saying so would assume the domain came from an older version,
   which the message cannot know. The module refuses that kind of assumption.
3. **A `virsh` that errors now yields "cannot be checked" (green) instead of
   "pool absent" (red).** More honest, but it is a changed verdict on an edge case.
4. **`CLAUDE.md` was not modified** (that working tree is off limits). Its contract
   section would gain the `storage_pool` line.

## Related issues

Closes #93
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
