### PR TITLE
fix(contrat): le moteur fait ce que le contrat déclare (0.1.54)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,72 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.54] - 2026-08-21
+
+### Corrigé
+
+- **Une `section` déclarée n'est plus écrasée par le moteur.** La valeur par
+  défaut de `LabDefinition.section` était `linux`, et le scanner se servait de
+  cette même chaîne comme sentinelle « rien de déclaré ». Les deux étaient donc
+  indiscernables : un lab qui écrivait `section: linux` dans un catalogue d'une
+  autre catégorie voyait sa déclaration remplacée en silence. La sentinelle est
+  désormais `None`, l'inférence du mode legacy rend `None` au lieu d'inventer
+  une valeur, et plus aucun nom de domaine ne vit dans le code qui lit un
+  catalogue. Aucun catalogue existant ne change de comportement — aucun des 284
+  labs ne déclare `section: linux` — mais le premier auteur tiers y serait
+  tombé.
+
+- **Les couleurs de section et de niveau ne viennent plus d'une liste de
+  domaines.** `reporting/console.py` associait `linux`, `ansible`, `terraform`,
+  `kubernetes`, `rhcsa`… à des couleurs, ce qui est de la connaissance de
+  domaine dans le moteur, avec une seule conséquence visible : les catalogues
+  de cette liste étaient colorés, tous les autres uniformément blancs. La
+  couleur est maintenant tirée du nom lui-même (`crc32` sur une palette fixe) :
+  stable d'une exécution à l'autre, et disponible pour tout catalogue.
+
+- **`exam_passing_score` pose enfin un seuil de réussite.** Onze labs d'examen
+  en déclaraient un — les examens blancs RHCSA et LFCS, et neuf drills — avec
+  un commentaire expliquant le seuil retenu, et personne ne le lisait : un
+  apprenant qui rendait 40/100 sur un mock RHCSA ne lisait nulle part qu'il
+  avait échoué. Le champ fait désormais partie du contrat, en **pourcentage**
+  du barème du lab, et il est rendu par `dsoxlab show` avant l'examen, par
+  `dsoxlab submit` sous forme de verdict reçu/recalé, et par `dsoxlab scores`
+  dans une colonne Verdict. La comparaison est exacte : 69,5 % du barème échoue
+  à une barre de 70 %.
+
+- **`meta.yml` gagne le mécanisme de traduction que le reste du contrat avait
+  déjà.** Les titres de section sont les noms de blocs qu'affiche `dsoxlab
+  progress`, et les trois catalogues les écrivent en français : une session
+  anglaise lisait donc du français. Un catalogue avait tenté `title_en:` /
+  `description_en:`, que personne ne lisait. Un `meta.<langue>.yml` posé à côté
+  du `meta.yml` surcharge désormais `repo.title`, `repo.description`,
+  `sections[].title` et `sections[].description` — même convention par fichier
+  que `lab.<langue>.yaml`, avec les sections appariées par `id` plutôt que par
+  position. Le catalogue de démonstration packagé en fournit un.
+
+### Ajouté
+
+- **`validate-structure` signale toute clé que personne ne lit.** Le vrai
+  correctif des quatre clés mortes n'est pas de solder ces quatre-là : c'est
+  qu'une cinquième ne puisse plus s'installer en silence. Le contrôle relit
+  `meta.yml`, `lab.yaml` et leurs fichiers de traduction depuis le disque,
+  descend dans chaque bloc que le contrat décrit, et nomme chaque clé inconnue
+  avec la clé la plus proche que le moteur lit vraiment. Il laisse tranquilles
+  les mappings libres — `runtime.targets[].roles`, `runtime.services[].env`,
+  `infra.providers.<provider>` — dont les clés appartiennent au catalogue. Les
+  clés connues sont tenues contre les schémas JSON publiés par un test, pour
+  que les deux ne puissent pas diverger.
+
+  Le **parseur, lui, reste tolérant** : ignorer une clé inconnue est une
+  garantie de la v1, et c'est ce qui permet à un outil v1 de survivre à un
+  catalogue v1.1. Ceci est un lint, pas le parseur.
+
+  Conséquence sur les catalogues en l'état : `linux-dsoxlab-training` signale
+  `runtime.hosts_required` (un lab, redondant avec les deux targets qu'il
+  déclare déjà), et `terraform-training` signale `sections[].title_en` et
+  `sections[].description_en` (à déplacer dans un `meta.fr.yml`).
+  `ansible-training` est propre.
+
 ## [0.1.53] - 2026-08-21
 
 ### Modifié

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.54] - 2026-08-21
+
+### Fixed
+
+- **A declared `section` is no longer overwritten by the engine.** The default
+  value of `LabDefinition.section` was `linux`, and the scanner used that same
+  string as its "nothing declared" sentinel. The two were therefore
+  indistinguishable: a lab writing `section: linux` in a catalog whose category
+  is something else had its declaration silently replaced. The sentinel is now
+  `None`, the legacy path inference returns `None` rather than inventing a
+  value, and a domain name no longer lives anywhere in the code that reads a
+  catalog. No existing catalog changes behaviour — none of the 284 labs
+  declares `section: linux` — but the next third-party author would have hit
+  it.
+
+- **Section and level colours no longer come from a list of domains.**
+  `reporting/console.py` mapped `linux`, `ansible`, `terraform`, `kubernetes`,
+  `rhcsa`… to colours, which is domain knowledge in the engine, with one
+  visible consequence: catalogs on that list were coloured, every other one was
+  uniformly white. The colour is now derived from the name itself (`crc32` over
+  a fixed palette): stable across runs, and available to every catalog.
+
+- **`exam_passing_score` finally sets a pass mark.** Eleven exam labs declared
+  one — the RHCSA and LFCS mocks, and nine drills — with a comment explaining
+  the chosen threshold, and nothing read it: a learner handing in 40/100 on a
+  mock RHCSA read nowhere that they had failed. It is now part of the contract,
+  as a **percentage** of the lab scale, and it is rendered by `dsoxlab show`
+  before the exam, by `dsoxlab submit` as a pass/fail verdict, and by `dsoxlab
+  scores` as a Verdict column. The comparison is exact: 69.5 % of the scale
+  fails a 70 % bar.
+
+- **`meta.yml` gains the translation mechanism the rest of the contract
+  already had.** Section titles are the bloc names shown by `dsoxlab progress`,
+  and all three catalogs write them in French, so an English session read
+  French. One catalog had tried `title_en:` / `description_en:`, which nothing
+  read. A `meta.<lang>.yml` next to `meta.yml` now overrides `repo.title`,
+  `repo.description`, `sections[].title` and `sections[].description` — the
+  same per-file convention as `lab.<lang>.yaml`, with sections matched by `id`
+  rather than by position. The packaged demonstration catalog ships one.
+
+### Added
+
+- **`validate-structure` reports every key nothing reads.** The real fix for
+  the four dead keys is not to settle those four: it is that a fifth cannot
+  install itself in silence. The check re-reads `meta.yml`, `lab.yaml` and
+  their translation files from disk, descends into every block the contract
+  describes, and names each unknown key along with the closest key the engine
+  actually reads. It leaves the free-form mappings alone —
+  `runtime.targets[].roles`, `runtime.services[].env`,
+  `infra.providers.<provider>` — whose keys belong to the catalog. The known
+  keys are held against the published JSON Schemas by a test, so the two cannot
+  drift.
+
+  The **parser stays tolerant**: ignoring unknown keys is a v1 guarantee, and
+  it is what lets a v1 tool survive a v1.1 catalog. This is a lint, not the
+  parser.
+
+  Consequence for catalogs as they stand: `linux-dsoxlab-training` reports
+  `runtime.hosts_required` (one lab, redundant with the two targets it already
+  declares), and `terraform-training` reports `sections[].title_en` and
+  `sections[].description_en` (to be moved into a `meta.fr.yml`).
+  `ansible-training` is clean.
+
 ## [0.1.53] - 2026-08-21
 
 ### Changed

--- a/README.fr.md
+++ b/README.fr.md
@@ -249,7 +249,10 @@ validation:
 ```
 
 Un `lab.fr.yaml` optionnel peut surcharger `title` et `description` pour le
-français uniquement.
+français uniquement. La même convention vaut un cran au-dessus : un
+`meta.fr.yml` posé à côté du `meta.yml` traduit `repo.title`,
+`repo.description` et les titres et descriptions des `sections[]`, appariées
+par `id`.
 
 `dsoxlab validate-structure` vérifie que tout le contrat tient : le `meta.yml`
 racine est conforme, chaque lab référencé existe avec un `lab.yaml` valide,

--- a/README.md
+++ b/README.md
@@ -230,7 +230,9 @@ validation:
 ```
 
 An optional `lab.fr.yaml` may override `title` and `description` for French
-only.
+only. The same convention applies one level up: a `meta.fr.yml` next to
+`meta.yml` translates `repo.title`, `repo.description` and the `sections[]`
+titles and descriptions, with sections matched by `id`.
 
 #### Optional `runtime.fixtures`: the starting files of a `shell` lab
 

--- a/docs/contract-v1.fr.md
+++ b/docs/contract-v1.fr.md
@@ -131,6 +131,36 @@ infra:
 lab : celle-ci tient à la présence de `labs/**/lab.yaml`, et le rattachement se
 fait sur le chemin, jamais sur l'identifiant du lab.
 
+### `meta.<langue>.yml`
+
+Un `meta.fr.yml` posé à côté de `meta.yml` surcharge `repo.title`,
+`repo.description`, `sections[].title` et `sections[].description` pour cette
+langue, **et rien d'autre**. Toute autre clé y est ignorée, `labs` compris :
+l'ordre pédagogique vit dans `meta.yml` et ne se traduit pas.
+
+Les sections sont appariées par **`id`**, jamais par position : une section
+insérée en tête de `meta.yml` décalerait sinon toutes les traductions
+suivantes, en silence.
+
+```yaml
+# meta.yml — le fichier de base est en anglais, comme partout dans le contrat
+sections:
+  - id: getting-started
+    title: Discover the tool
+```
+
+```yaml
+# meta.fr.yml
+sections:
+  - id: getting-started
+    title: Découvrir l'outil
+```
+
+C'est la même convention par fichier que `lab.<langue>.yaml` et
+`course.<langue>.yaml`. Un suffixe de langue par champ (`title_en:`) ne fait
+**pas** partie du contrat et n'est lu par personne : `dsoxlab
+validate-structure` le signale.
+
 ---
 
 ## `lab.yaml`, un par lab
@@ -145,13 +175,14 @@ fait sur le chemin, jamais sur l'identifiant du lab.
 | `skills` | **oui** | liste de chaînes | | Ne doit pas être vide. |
 | `distros` | **oui** | liste de chaînes | | Ne doit pas être vide. |
 | `doc_url` | **oui** | chaîne | | `http(s)` uniquement. |
-| `section` | non | chaîne | `repo.category` | |
+| `section` | non | chaîne | `repo.category` | Déclarée, elle est **toujours** conservée — y compris quand sa valeur se trouve nommer un domaine technique. |
 | `description` | non | chaîne | `""` | |
 | `track` | non | liste de chaînes | `[]` | |
 | `difficulty` | non | chaîne | `beginner` | Jamais validé, seulement affiché. |
 | `estimated_time` | non | chaîne | `30m` | Seulement affiché. |
 | `certification_tags` | non | liste de chaînes | `[]` | Libre : l'outil reste agnostique du domaine. |
 | `lab_type` | non | énuméré | `lab` | `lab`, `challenge` ou `capstone`. |
+| `exam_passing_score` | non | entier | `0` | Seuil de réussite d'un examen blanc, en **pourcentage** du barème. Voir plus bas. |
 | `bloc` | non | entier | dérivé | Normalement **pas écrit** : dérivé de `meta.yml` `sections[].labs[]`. |
 | `bloc_order` | non | entier | dérivé | Même remarque. |
 | `runtime` | non | mapping | défauts shell | Voir ci-dessous. |
@@ -161,6 +192,34 @@ fait sur le chemin, jamais sur l'identifiant du lab.
 n'est pas un lab. `skills`, `distros` et `doc_url` sont exigés par
 `dsoxlab validate-structure` : le fichier se lit sans eux, mais le lab n'est pas
 publiable.
+
+### `exam_passing_score`
+
+Un `lab_type: capstone` est un examen blanc, et un examen sans seuil de
+réussite n'en est pas un. Déclare la barre, et dsoxlab rend un verdict :
+
+```yaml
+lab_type: capstone
+exam_passing_score: 70   # pour cent du barème du lab
+```
+
+| Où | Ce que ça donne |
+| --- | --- |
+| `dsoxlab show` | Le seuil, avant que l'apprenant ne commence. |
+| `dsoxlab submit` | « Examen réussi » ou « Examen échoué », avec le pourcentage et la barre. |
+| `dsoxlab scores` | Une colonne **Verdict**, sur les catalogues qui portent au moins un examen. |
+
+C'est un **pourcentage**, pas un nombre de points. Le barème d'un lab est celui
+des `points` de son `challenge/hints.yaml` (100 par défaut, mais libre) : un
+seuil absolu voudrait donc dire autre chose d'un lab à l'autre.
+
+La comparaison est exacte : `score × 100 ≥ seuil × barème`. Une copie qui vaut
+69,5 % du barème échoue à une barre de 70 %. Un seuil d'examen ne s'arrondit
+pas en faveur du candidat.
+
+Absent, ou à `0`, le lab n'est pas un examen et aucun verdict n'est jamais
+rendu — c'est le cas de tout lab qui n'est ni un capstone ni un drill.
+`dsoxlab validate-structure` refuse une valeur hors de `1..100`.
 
 ### `runtime`
 
@@ -218,7 +277,9 @@ soit : ce sont les tests qui prouvent.
 ### `lab.<langue>.yaml`
 
 Un `lab.fr.yaml` posé à côté de `lab.yaml` surcharge `title` et `description`
-pour cette langue, **et rien d'autre**. Toute autre clé y est ignorée.
+pour cette langue, **et rien d'autre**. Toute autre clé y est ignorée, et
+`validate-structure` le dit. Un `id` y est toléré sans être lu : il nomme le
+lab pour qui ouvre le fichier.
 
 ---
 
@@ -259,12 +320,29 @@ qui déclare lire la v1.
 - retirer une valeur d'un énuméré ;
 - changer un défaut.
 
-Les clés inconnues sont **ignorées par le parseur** mais **refusées par les
-schémas JSON** (`additionalProperties: false`). C'est voulu : le moteur doit
-rester tolérant pour qu'un outil v1 survive à un catalogue v1.1, tandis que ton
-éditeur, lui, doit te dire que `skils:` ne sert à rien. Si un schéma signale une
-clé à laquelle tu crois, c'est que cette clé n'est pas dans le contrat : vérifie
-sur cette page.
+Les clés inconnues sont **ignorées par le parseur**, **refusées par les schémas
+JSON** (`additionalProperties: false`) et **signalées par `dsoxlab
+validate-structure`**. La combinaison est voulue, et chaque pièce répond à un
+besoin différent :
+
+- le **moteur** reste tolérant, pour qu'un outil v1 survive à un catalogue
+  v1.1. Cela ne changera pas : c'est ce qui fait tenir le versionnement ;
+- ton **éditeur** souligne `skils:` pendant que tu l'écris ;
+- `validate-structure` échoue dessus, parce que toléré n'est pas voulu. Quatre
+  clés écrites de bonne foi vivaient dans les catalogues réels sans que
+  personne ne les lise, dont un `exam_passing_score` dans onze labs d'examen :
+  leur auteur croyait poser un seuil de réussite, et rien ne le posait. À la
+  racine d'un `lab.yaml`, une clé inconnue est une faute de frappe ou une
+  attente déçue, presque jamais une extension délibérée.
+
+Le contrôle porte sur `meta.yml`, `lab.yaml` et leurs fichiers de traduction,
+et il descend dans chaque bloc que le contrat décrit. Il ne descend **pas**
+dans les mappings libres — `runtime.targets[].roles`,
+`runtime.services[].env`, `infra.providers.<provider>` — dont les clés
+appartiennent au catalogue.
+
+Si un schéma ou `validate-structure` signale une clé à laquelle tu crois, c'est
+que cette clé n'est pas dans le contrat : vérifie sur cette page.
 
 ---
 

--- a/docs/contract-v1.md
+++ b/docs/contract-v1.md
@@ -130,6 +130,34 @@ infra:
 that is settled by the presence of `labs/**/lab.yaml`, and the match is on the
 path, never on the lab id.
 
+### `meta.<lang>.yml`
+
+A `meta.fr.yml` next to `meta.yml` overrides `repo.title`, `repo.description`,
+`sections[].title` and `sections[].description` for that language, **and
+nothing else**. Any other key in it is ignored — including `labs`: the teaching
+order lives in `meta.yml` and is never translated.
+
+Sections are matched by **`id`**, never by position: a section inserted at the
+top of `meta.yml` would otherwise shift every translation below it, silently.
+
+```yaml
+# meta.yml — the base file is English, as everywhere in the contract
+sections:
+  - id: getting-started
+    title: Discover the tool
+```
+
+```yaml
+# meta.fr.yml
+sections:
+  - id: getting-started
+    title: Découvrir l'outil
+```
+
+This is the same per-file convention as `lab.<lang>.yaml` and
+`course.<lang>.yaml`. A per-field language suffix (`title_en:`) is **not** part
+of the contract and is ignored: `dsoxlab validate-structure` reports it.
+
 ---
 
 ## `lab.yaml` — one per lab
@@ -144,13 +172,14 @@ path, never on the lab id.
 | `skills` | **yes** | list of strings | — | Must not be empty. |
 | `distros` | **yes** | list of strings | — | Must not be empty. |
 | `doc_url` | **yes** | string | — | `http(s)` only. |
-| `section` | no | string | `repo.category` | |
+| `section` | no | string | `repo.category` | Declared, it is **always** kept — including when the value happens to name a technical domain. |
 | `description` | no | string | `""` | |
 | `track` | no | list of strings | `[]` | |
 | `difficulty` | no | string | `beginner` | Never validated, only displayed. |
 | `estimated_time` | no | string | `30m` | Only displayed. |
 | `certification_tags` | no | list of strings | `[]` | Free-form: the tool stays domain-agnostic. |
 | `lab_type` | no | enum | `lab` | `lab`, `challenge` or `capstone`. |
+| `exam_passing_score` | no | integer | `0` | Pass mark of a mock exam, as a **percentage** of the lab scale. See below. |
 | `bloc` | no | integer | derived | Normally **not written**: derived from `meta.yml` `sections[].labs[]`. |
 | `bloc_order` | no | integer | derived | Same remark. |
 | `runtime` | no | mapping | shell defaults | See below. |
@@ -160,6 +189,34 @@ path, never on the lab id.
 is not a lab at all. `skills`, `distros` and `doc_url` are required by
 `dsoxlab validate-structure`: the file parses without them, but the lab is not
 publishable.
+
+### `exam_passing_score`
+
+A `lab_type: capstone` is a mock exam, and an exam without a pass mark is not
+one. Declare the bar, and dsoxlab renders a verdict:
+
+```yaml
+lab_type: capstone
+exam_passing_score: 70   # per cent of the lab scale
+```
+
+| Where | What you get |
+| --- | --- |
+| `dsoxlab show` | The pass mark, before the learner starts. |
+| `dsoxlab submit` | `Exam passed` or `Exam failed`, with the percentage and the bar. |
+| `dsoxlab scores` | A **Verdict** column, on catalogs that have at least one exam. |
+
+It is a **percentage**, not a number of points. The scale of a lab is the
+`points` of its `challenge/hints.yaml` (100 by default, but free), so an
+absolute threshold would mean something different from one lab to the next.
+
+The comparison is exact: `score × 100 ≥ passing_score × scale`. A run worth
+69.5 % of the scale fails a 70 % bar. A pass mark is not rounded in the
+candidate's favour.
+
+Left out, or set to `0`, the lab is not an exam and no verdict is ever
+rendered — which is the case of every lab that is not a capstone or a drill.
+`dsoxlab validate-structure` refuses a value outside `1..100`.
 
 ### `runtime`
 
@@ -217,7 +274,9 @@ are what prove.
 ### `lab.<lang>.yaml`
 
 A `lab.fr.yaml` next to `lab.yaml` overrides `title` and `description` for that
-language, **and nothing else**. Any other key in it is ignored.
+language, **and nothing else**. Any other key in it is ignored, and
+`validate-structure` says so. An `id` is tolerated there without being read: it
+names the lab for whoever opens the file.
 
 ---
 
@@ -258,11 +317,29 @@ claims to support v1.
 - removing a value from an enumerated list;
 - changing a default.
 
-Unknown keys are **ignored by the parser** but **rejected by the JSON Schemas**
-(`additionalProperties: false`). That is on purpose: the engine must stay
-tolerant so a v1 tool survives a v1.1 catalog, while your editor should tell you
-that `skils:` does nothing. If a schema flags a key you believe in, the key is
-not in the contract — check this page.
+Unknown keys are **ignored by the parser**, **rejected by the JSON Schemas**
+(`additionalProperties: false`), and **reported by `dsoxlab
+validate-structure`**. That combination is on purpose, and each part answers a
+different need:
+
+- the **engine** stays tolerant, so a v1 tool survives a v1.1 catalog. That
+  will not change: it is what makes the version scheme work at all;
+- your **editor** underlines `skils:` as you type it;
+- `validate-structure` fails on it, because tolerated is not the same as
+  intended. Four keys written in good faith lived in the real catalogs and were
+  read by nobody, including an `exam_passing_score` in eleven exam labs: their
+  author believed they were setting a pass mark, and nothing set one. At the
+  root of a `lab.yaml`, an unknown key is a typo or a disappointed expectation,
+  almost never a deliberate extension.
+
+The check covers `meta.yml`, `lab.yaml` and their translation files, and it
+descends into every block the contract describes. It does **not** descend into
+the free-form mappings — `runtime.targets[].roles`,
+`runtime.services[].env`, `infra.providers.<provider>` — whose keys belong to
+the catalog.
+
+If a schema or `validate-structure` flags a key you believe in, the key is not
+in the contract — check this page.
 
 ---
 

--- a/fuzz/corpus/lab_yaml/capstone-exam-score.yaml
+++ b/fuzz/corpus/lab_yaml/capstone-exam-score.yaml
@@ -1,0 +1,22 @@
+id: rhcsa-mock-exam
+title: RHCSA mock exam
+level: l2
+section: capstones
+lab_type: capstone
+exam_passing_score: 70
+skills: [lvm, selinux, systemd]
+distros: [almalinux10]
+doc_url: https://blog.stephane-robert.info/docs/linux/rhcsa/
+runtime:
+  type: vm
+  session: local
+  default: server
+  targets:
+    - name: server
+      host: alma-rhcsa-1.lab
+      roles:
+        client: alma-rhcsa-2.lab
+validation:
+  functional: true
+  security: true
+  persistence_after_reboot: true

--- a/fuzz/dict/yaml_contract.dict
+++ b/fuzz/dict/yaml_contract.dict
@@ -76,6 +76,10 @@ track="track:"
 difficulty="difficulty:"
 estimated_time="estimated_time:"
 certification_tags="certification_tags:"
+exam_passing_score="exam_passing_score:"
+# Le seuil est un entier borné 1..100 : les deux bords et un type refusé.
+exam_passing_score_70="exam_passing_score: 70"
+exam_passing_score_bad="exam_passing_score: \x22oui\x22"
 bloc="bloc:"
 bloc_order="bloc_order:"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.53"
+version = "0.1.54"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/lab.schema.json
+++ b/schemas/lab.schema.json
@@ -81,6 +81,13 @@
       "default": "lab",
       "description": "Kind of exercise. Enumerated and enforced by validate-structure."
     },
+    "exam_passing_score": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100,
+      "default": 0,
+      "description": "Pass mark of a mock exam, as a PERCENTAGE of the lab scale (the points of challenge/hints.yaml, 100 by default). dsoxlab submit renders a verdict against it and dsoxlab scores shows it. 0, or the field left out, means the lab is not an exam and no verdict is rendered."
+    },
     "bloc": {
       "type": "integer",
       "description": "Position of the teaching bloc. Normally NOT written here: it is derived from meta.yml sections[].labs[]. Declaring it forces an exception and duplicates information that already lives elsewhere."

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -1184,6 +1184,22 @@ def submit(
     else:
         info(_("submit_partial", passed=result.passed, total=result.total, score=score, max_score=max_score))
 
+    # Un lab qui déclare un seuil est un examen blanc, et un examen rend un
+    # verdict. Sans lui, un apprenant qui rendait 40/100 sur un mock RHCSA ne
+    # lisait nulle part qu'il avait échoué : la note s'affichait, jamais son
+    # sens. Un lab ordinaire n'en déclare pas et n'affiche donc rien.
+    from .services.progress_service import exam_percentage, exam_verdict
+
+    verdict = exam_verdict(score, max_score, lab.exam_passing_score)
+    if verdict is not None:
+        cle = "exam_passed" if verdict else "exam_failed"
+        rendu = success if verdict else error
+        rendu(_(
+            cle,
+            pct=exam_percentage(score, max_score),
+            threshold=lab.exam_passing_score,
+        ))
+
     set_active_lab(root, None)
     console.print()
     # CTA "tape exit" uniquement si on est dans le sous-shell ouvert
@@ -1209,7 +1225,15 @@ def scores(
     ctx = read_context(root)
     effective_section = section or ctx.section
     results = get_results(root, lab_id=lab_id, section=effective_section, limit=top)
-    print_scores_table(results)
+    # Les seuils vivent dans le catalogue, les notes dans la base : le verdict
+    # d'un examen demande les deux. On ne balaie que pour les labs affichés.
+    affiches = {r["lab_id"] for r in results}
+    seuils = {
+        lab.id: lab.exam_passing_score
+        for lab in _catalogue(root, _lang(root))
+        if lab.exam_passing_score and lab.id in affiches
+    }
+    print_scores_table(results, seuils)
 
 
 # ── progress ──────────────────────────────────────────────────────────────────
@@ -1372,9 +1396,15 @@ def validate_structure_cmd(
         validate_solutions_encrypted,
         validate_targets,
     )
-    from .validators.contract import validate_schema_versions
+    from .validators.contract import validate_schema_versions, validate_unknown_keys
 
     root = _root(lab_home)
+
+    def _rendu(chemin: Path) -> Path:
+        try:
+            return chemin.relative_to(root)
+        except ValueError:
+            return chemin
 
     # D'ABORD, et à la source : un `schema_version` illisible ou trop récent
     # empêche le fichier d'être découvert, donc TOUS les contrôles suivants
@@ -1384,12 +1414,9 @@ def validate_structure_cmd(
     if not contract.ok:
         console.print(_("contract_issues_header"))
         for anomalie in contract.issues:
-            try:
-                rendu = anomalie.path.relative_to(root)
-            except ValueError:
-                rendu = anomalie.path
             console.print(
-                f"  [red]✘[/red] {rendu}: {_(anomalie.key, **anomalie.params)}"
+                f"  [red]✘[/red] {_rendu(anomalie.path)}: "
+                f"{_(anomalie.key, **anomalie.params)}"
             )
         # Le meta.yml décrit tout le catalogue : illisible, il rend chaque
         # contrôle suivant douteux, et la découverte lèverait de toute façon.
@@ -1397,6 +1424,19 @@ def validate_structure_cmd(
         if contract.meta_is_unreadable:
             error(_("labs_have_issues"))
             raise typer.Exit(1)
+
+    # Ensuite, toujours à la source : les clés que le moteur n'ira jamais lire.
+    # Le parseur les ignore et continuera de le faire — c'est une garantie de
+    # la v1 — mais « toléré » n'est pas « voulu » : onze labs d'examen ont posé
+    # un seuil de réussite que personne ne lisait, sans que rien ne le dise.
+    unknown = validate_unknown_keys(root)
+    if not unknown.ok:
+        console.print(_("unknown_keys_header"))
+        for anomalie in unknown.issues:
+            console.print(
+                f"  [red]✘[/red] {_rendu(anomalie.path)}: "
+                f"{_(anomalie.key, **anomalie.params)}"
+            )
 
     structure_reports = validate_all_structure(root)
     metadata_reports = validate_all_metadata(root)
@@ -1468,6 +1508,7 @@ def validate_structure_cmd(
 
     all_ok = (
         contract.ok
+        and unknown.ok
         and all(r.ok for r in structure_reports)
         and not issues
         and not content_issues

--- a/src/dsoxlab/discovery/repo.py
+++ b/src/dsoxlab/discovery/repo.py
@@ -32,7 +32,11 @@ def find_meta_yml(start: Path) -> Path | None:
         current = parent
 
 
-def read_repo_metadata(root: Path | None = None) -> RepoMetadata | None:
+def read_repo_metadata(
+    root: Path | None = None,
+    *,
+    lang: str = "en",
+) -> RepoMetadata | None:
     """Lit le ``meta.yml`` du dépôt fournisseur.
 
     Le provider courant est résolu en cascade :
@@ -43,6 +47,9 @@ def read_repo_metadata(root: Path | None = None) -> RepoMetadata | None:
     Args:
         root: Si fourni, cherche ``<root>/meta.yml``. Sinon, remonte
               depuis le CWD vers les parents.
+        lang: Langue préférée pour les surcharges ``meta.<lang>.yml``.
+              Seuls les titres et descriptions en dépendent ; aucun
+              appelant qui ne les affiche pas n'a à s'en soucier.
 
     Returns:
         ``RepoMetadata`` chargé, ou ``None`` si aucun ``meta.yml``
@@ -72,7 +79,7 @@ def read_repo_metadata(root: Path | None = None) -> RepoMetadata | None:
 
     try:
         return RepoMetadata.from_yaml(
-            meta_path, context_provider=context_provider
+            meta_path, context_provider=context_provider, lang=lang
         )
     except (ValueError, KeyError) as exc:
         # Erreur de résolution provider : on remonte le message

--- a/src/dsoxlab/discovery/scanner.py
+++ b/src/dsoxlab/discovery/scanner.py
@@ -5,8 +5,13 @@ l'ordre des sections, scanne les ``lab.yaml`` du système de fichiers,
 et trie selon ``meta.sections.*.labs``.
 
 Mode legacy (compat) : si aucun ``meta.yml`` racine, infère la section
-depuis la position du ``lab.yaml`` dans l'arborescence (ancien
-``linux-training`` pré-extraction).
+depuis la position du ``lab.yaml`` dans l'arborescence (arborescences
+d'avant l'extraction du framework, qui n'avaient pas de ``meta.yml``).
+
+Dans les deux modes, la section **déclarée** par un ``lab.yaml`` gagne. La
+sentinelle « rien de déclaré » est ``None`` : aucun nom de domaine ne sert de
+valeur par défaut ici, sans quoi le moteur saurait quelque chose d'un domaine
+et écraserait la déclaration d'un auteur qui emploie ce nom-là.
 """
 
 from __future__ import annotations
@@ -26,6 +31,11 @@ logger = logging.getLogger(__name__)
 
 # Niveaux connus utilisés en mode legacy uniquement, pour distinguer
 # ``labs/<section>/<level>/<lab>`` de ``labs/<level>/<lab>``.
+#
+# Heuristique **figée** : ce sont les répertoires de la seule arborescence qui
+# ait jamais existé sans ``meta.yml``. Ce ne sont pas des valeurs du contrat, et
+# rien ne doit s'y ajouter : un catalogue d'aujourd'hui déclare son ordre dans
+# son ``meta.yml`` et ne passe jamais par ce chemin de code.
 _KNOWN_LEVELS = {"l1", "l2", "l3", "lfcs", "rhcsa", "capstones"}
 
 
@@ -69,7 +79,10 @@ def scan_catalog(
             l'erreur remonte au lieu d'être collectée.
     """
     if repo_meta is None:
-        repo_meta = read_repo_metadata(root)
+        # `lang` compte ici : les titres de section du meta.yml deviennent les
+        # noms de blocs affichés par `progress`, et ils se traduisent par
+        # fichier (meta.<lang>.yml), comme les titres de lab.
+        repo_meta = read_repo_metadata(root, lang=lang)
 
     scan = CatalogScan()
 
@@ -134,11 +147,16 @@ def _assign_section(
       défaut quand le ``lab.yaml`` n'override pas la section.
     - Sinon (mode legacy) : infère depuis le chemin
       ``labs/<section>/<level>/<lab>``.
+
+    Dans les deux cas, « le ``lab.yaml`` n'override pas » veut dire
+    ``section is None``, et **rien d'autre**. Comparer à un nom de domaine,
+    comme le faisait ce code, revenait à décréter qu'une valeur déclarée par
+    l'auteur n'en était pas une.
     """
     if repo_meta is not None:
         # En mode framework, le lab.yaml peut surcharger via ``section:`` ;
         # par défaut on prend la catégorie du dépôt.
-        if not lab.section or lab.section == "linux":
+        if lab.section is None:
             lab.section = repo_meta.category
         # Rattache le lab à sa section pédagogique du meta.yml (l1, l2, …) pour
         # que ``dsoxlab progress`` affiche un nom de bloc clair au lieu de « ? ».
@@ -164,24 +182,25 @@ def _assign_section(
 
     # Mode legacy : inférence depuis le chemin (compat ancienne
     # arborescence sans meta.yml racine).
-    if lab.section == "linux":
-        inferred = _infer_section_legacy(yaml_path, root)
-        if inferred != "linux":
-            lab.section = inferred
+    if lab.section is None:
+        lab.section = _infer_section_legacy(yaml_path, root)
 
 
-def _infer_section_legacy(yaml_path: Path, root: Path) -> str:
-    """Infère la section depuis la position du lab.yaml (mode legacy)."""
+def _infer_section_legacy(yaml_path: Path, root: Path) -> str | None:
+    """Infère la section depuis la position du lab.yaml (mode legacy).
+
+    Rend ``None`` quand le chemin ne porte pas de section : il n'y a alors
+    rien à en déduire, et inventer une valeur — c'était ``"linux"`` — ne
+    ferait que déguiser l'absence en déclaration.
+    """
     try:
         parts = yaml_path.relative_to(root / "labs").parts
     except ValueError:
-        return "linux"
-    if not parts:
-        return "linux"
+        return None
     # ``labs/<section>/<level>/<lab>/lab.yaml`` → parts[0] = section
     if len(parts) >= 3 and parts[0] not in _KNOWN_LEVELS:
         return parts[0]
-    return "linux"
+    return None
 
 
 def _sort_labs(
@@ -208,4 +227,7 @@ def _sort_labs(
 
         return sorted(labs, key=sort_key)
 
-    return sorted(labs, key=lambda lab: (lab.section, lab.level, lab.id))
+    # `or ""` : un lab qu'aucune règle n'a rattaché garde ``section = None``,
+    # que Python refuse de comparer à une chaîne. Il se range en tête, ce qui
+    # est le bon endroit pour ce qui n'appartient à aucune section.
+    return sorted(labs, key=lambda lab: (lab.section or "", lab.level, lab.id))

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -345,13 +345,16 @@ Each lab exposes:
 
   [cyan]submit[/cyan] [dim][<id>][/dim]        Final submission: run tests, save score, then type [bold]exit[/bold] to end the session.
                        Use this when you are done with the lab.
+                       On a lab declaring [bold]exam_passing_score[/bold], also renders a
+                       [yellow]pass / fail verdict[/yellow] against that mark.
                        [dim]<id>[/dim] is optional if a lab is active in the session.
 
   [cyan]progress[/cyan]             Bloc-by-bloc progression summary (labs done, score, challenge, capstone).
 
   [cyan]next[/cyan]                 Recommend the next lab to complete in the active context.
 
-  [cyan]scores[/cyan]               Show score history.
+  [cyan]scores[/cyan]               Show score history. A [bold]Verdict[/bold] column appears when the
+                       catalog holds at least one lab with an exam pass mark.
     [dim]--section / -s[/dim]       Filter by section.
     [dim]--lab     / -l[/dim]       Filter by lab.
     [dim]--top     / -n[/dim]       Limit number of results.
@@ -869,4 +872,24 @@ silent.
     "err_template_cloud_init_missing":
         "No cloud-init template for distribution '{distro}'. "
         "Packaged distros: {available}",
+
+    # ── exam_passing_score — the verdict of a mock exam ───────────────────────
+    "field_exam_score": "[bold]Pass mark:[/bold]",
+    "col_verdict":   "Verdict",
+    "verdict_pass":  "passed",
+    "verdict_fail":  "failed",
+    "exam_passed":
+        "Exam passed: {pct}% of the scale, for a pass mark of {threshold}%.",
+    "exam_failed":
+        "Exam failed: {pct}% of the scale, below the {threshold}% pass mark. "
+        "Replay the lab: dsoxlab reset, then dsoxlab run.",
+
+    # ── unknown keys in a contract file ───────────────────────────────────────
+    "unknown_keys_header": "\n[bold red]Keys nothing reads:[/bold red]",
+    "unknown_key":
+        "'{field}' is not part of the contract. dsoxlab ignores it, so whatever "
+        "you meant by it never happens. Remove it, or check docs/contract-v1.md.",
+    "unknown_key_suggest":
+        "'{field}' is not part of the contract, and dsoxlab ignores it. "
+        "The closest key it does read at that level is '{suggestion}'.",
 }

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -348,11 +348,14 @@ Chaque lab expose :
 
   [cyan]submit[/cyan] [dim][<id>][/dim]        Soumission finale : joue les tests, sauvegarde le score, puis tapez [bold]exit[/bold] pour terminer la session.
                        À utiliser quand vous avez fini le lab.
+                       Sur un lab qui déclare [bold]exam_passing_score[/bold], rend aussi un
+                       [yellow]verdict reçu / recalé[/yellow] face à ce seuil.
                        [dim]<id>[/dim] est optionnel si un lab est actif en session.
   [cyan]progress[/cyan]             Résumé de progression par bloc (labs faits, score, challenge, capstone).
 
   [cyan]next[/cyan]                 Recommande le prochain lab à compléter dans le contexte actif.
-  [cyan]scores[/cyan]               Affiche l'historique des scores.
+  [cyan]scores[/cyan]               Affiche l'historique des scores. Une colonne [bold]Verdict[/bold] apparaît
+                       si le catalogue porte au moins un lab à seuil d'examen.
     [dim]--section / -s[/dim]       Filtre par section.
     [dim]--lab     / -l[/dim]       Filtre par lab.
     [dim]--top     / -n[/dim]       Limite le nombre de résultats.
@@ -873,4 +876,26 @@ hors ligne, elle se tait.
     "err_template_cloud_init_missing":
         "Template cloud-init absent pour la distribution « {distro} ». "
         "Distros packagées : {available}",
+
+    # ── exam_passing_score — le verdict d'un examen blanc ─────────────────────
+    "field_exam_score": "[bold]Seuil de réussite :[/bold]",
+    "col_verdict":   "Verdict",
+    "verdict_pass":  "reçu",
+    "verdict_fail":  "recalé",
+    "exam_passed":
+        "Examen réussi : {pct} % du barème, pour un seuil de {threshold} %.",
+    "exam_failed":
+        "Examen échoué : {pct} % du barème, sous le seuil de {threshold} %. "
+        "Rejoue le lab : dsoxlab reset, puis dsoxlab run.",
+
+    # ── clés inconnues dans un fichier du contrat ─────────────────────────────
+    "unknown_keys_header": "\n[bold red]Clés que personne ne lit :[/bold red]",
+    "unknown_key":
+        "« {field} » ne fait pas partie du contrat. dsoxlab l'ignore, donc ce que "
+        "tu voulais déclarer ne se produit jamais. Retire-la, ou consulte "
+        "docs/contract-v1.fr.md.",
+    "unknown_key_suggest":
+        "« {field} » ne fait pas partie du contrat, et dsoxlab l'ignore. "
+        "La clé la plus proche qu'il lit vraiment, à ce niveau, est "
+        "« {suggestion} ».",
 }

--- a/src/dsoxlab/models/lab.py
+++ b/src/dsoxlab/models/lab.py
@@ -37,7 +37,20 @@ class LabDefinition:
     doc_url: str
     validation: ValidationConfig
     path: Path = field(default_factory=Path)
-    section: str = "linux"
+
+    section: str | None = None
+    """Section déclarée par le ``lab.yaml``, ou ``None`` s'il n'en déclare pas.
+
+    La sentinelle est ``None``, jamais un nom de domaine. Le défaut était
+    ``"linux"``, ce qui rendait « non déclaré » et « déclaré à linux »
+    indiscernables : un lab qui écrivait ``section: linux`` dans un catalogue
+    d'une autre catégorie voyait sa déclaration écrasée en silence, et le
+    moteur portait un nom de domaine dans son code.
+
+    ``discovery/scanner.py`` remplace la sentinelle par ``repo.category`` (ou
+    par la section inférée du chemin en mode legacy). Elle ne survit donc que
+    pour un lab qu'aucune des deux règles ne rattache."""
+
     description: str = ""
     track: list[str] = field(default_factory=list)
     difficulty: str = "beginner"
@@ -51,6 +64,19 @@ class LabDefinition:
     :mod:`dsoxlab.models.schema_version`."""
 
     lab_type: str = "lab"       # "lab" | "challenge" | "capstone"
+
+    exam_passing_score: int = 0
+    """Pourcentage du barème à atteindre pour réussir, ou 0 s'il n'y a pas de seuil.
+
+    Un ``lab_type: capstone`` est un examen blanc, et un examen sans seuil de
+    réussite n'en est pas un : onze labs d'examen déclaraient ce champ, aucun
+    ne le posait. ``submit`` en rend désormais un verdict et ``scores``
+    l'affiche.
+
+    Un **pourcentage**, pas un nombre de points : le barème d'un lab est celui
+    de son ``challenge/hints.yaml`` (100 par défaut, mais libre), et un seuil
+    en points absolus voudrait dire autre chose d'un lab à l'autre."""
+
     bloc: int = 0               # bloc number 1-8; 0 = unassigned
     bloc_order: int = 0         # position within the bloc; 0 = unassigned
     bloc_name: str = ""         # nom lisible du bloc (section meta.yml), ex. "Fondamentaux (l1)"
@@ -163,6 +189,12 @@ class LabDefinition:
             services=services,
         )
 
+        # `None` — pas une chaîne — quand la clé est absente : c'est ce qui
+        # distingue « non déclaré » de « déclaré », y compris quand la valeur
+        # déclarée est le nom d'un domaine.
+        section_raw = data.get("section")
+        section = str(section_raw) if section_raw is not None else None
+
         validation_data = as_mapping(data.get("validation"), "validation", lab_yaml)
         validation = ValidationConfig(
             functional=validation_data.get("functional", True),
@@ -181,7 +213,7 @@ class LabDefinition:
             doc_url=data.get("doc_url", ""),
             validation=validation,
             path=lab_yaml.parent,
-            section=data.get("section", "linux"),
+            section=section,
             description=data.get("description", ""),
             track=as_str_list(data.get("track"), "track", lab_yaml),
             difficulty=data.get("difficulty", "beginner"),
@@ -190,6 +222,9 @@ class LabDefinition:
                 data.get("certification_tags"), "certification_tags", lab_yaml
             ),
             lab_type=data.get("lab_type", "lab"),
+            exam_passing_score=as_int(
+                data.get("exam_passing_score"), 0, "exam_passing_score", lab_yaml
+            ),
             bloc=as_int(data.get("bloc"), 0, "bloc", lab_yaml),
             bloc_order=as_int(data.get("bloc_order"), 0, "bloc_order", lab_yaml),
         )

--- a/src/dsoxlab/models/repo.py
+++ b/src/dsoxlab/models/repo.py
@@ -27,6 +27,10 @@ Schéma :
         description: <courte>
         labs:
           - <chemin-relatif-depuis-labs/>
+
+Un ``meta.<lang>.yml`` posé à côté surcharge les titres et descriptions dans
+cette langue — même convention que ``lab.<lang>.yaml``. Voir
+:func:`_apply_translation`.
 """
 
 from __future__ import annotations
@@ -40,6 +44,69 @@ import yaml
 
 from ._contract import as_int, as_mapping, as_mapping_list, as_str_list
 from .schema_version import DEFAULT_SCHEMA_VERSION, read_schema_version
+
+#: Champs qu'un ``meta.<lang>.yml`` peut surcharger, et eux seuls.
+#:
+#: Le contrat traduit **par fichier** : ``lab.fr.yaml`` à côté de ``lab.yaml``,
+#: ``course.fr.yaml`` à côté de ``course.yaml``. Le ``meta.yml`` était le seul
+#: document sans équivalent, d'où les ``title_en`` / ``description_en``
+#: apparus dans un catalogue — écrits par un auteur, lus par personne. La
+#: surcharge par fichier est le mécanisme cohérent avec le reste du contrat ;
+#: un suffixe de langue par champ ne l'aurait pas été, et aurait grandi d'une
+#: colonne à chaque langue.
+_TRANSLATABLE_REPO = ("title", "description")
+_TRANSLATABLE_SECTION = ("title", "description")
+
+
+def _apply_translation(data: dict[str, Any], meta_path: Path, lang: str) -> None:
+    """Fusionne ``meta.<lang>.yml`` dans ``data``, sur place.
+
+    Même contrat que ``lab.<lang>.yaml`` : le fichier de base est l'anglais,
+    la surcharge ne porte que sur les champs traduisibles, et tout le reste y
+    est ignoré. Un fichier de traduction illisible ne fait jamais échouer la
+    lecture du catalogue — on garde les valeurs de base, comme pour un lab.
+
+    Les sections sont appariées par ``id``, jamais par position : une section
+    insérée dans ``meta.yml`` décalerait sinon toutes les traductions
+    suivantes, en silence et sans qu'aucun contrôle ne puisse le voir.
+    """
+    if not lang or lang == "en":
+        return
+    lang_path = meta_path.parent / f"meta.{lang[:2].lower()}.yml"
+    if not lang_path.is_file():
+        return
+    try:
+        overrides = yaml.safe_load(lang_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return
+    if not isinstance(overrides, dict):
+        return
+
+    base_repo = data.get("repo")
+    over_repo = overrides.get("repo")
+    if isinstance(base_repo, dict) and isinstance(over_repo, dict):
+        for champ in _TRANSLATABLE_REPO:
+            if champ in over_repo:
+                base_repo[champ] = over_repo[champ]
+
+    base_sections = data.get("sections")
+    over_sections = overrides.get("sections")
+    if not isinstance(base_sections, list) or not isinstance(over_sections, list):
+        return
+    traductions = {
+        str(s["id"]): s
+        for s in over_sections
+        if isinstance(s, dict) and s.get("id") is not None
+    }
+    for section in base_sections:
+        if not isinstance(section, dict):
+            continue
+        traduite = traductions.get(str(section.get("id")))
+        if traduite is None:
+            continue
+        for champ in _TRANSLATABLE_SECTION:
+            if champ in traduite:
+                section[champ] = traduite[champ]
 
 
 def _provider_overrides(value: object, meta_path: Path) -> dict[str, dict[str, Any]]:
@@ -298,6 +365,7 @@ class RepoMetadata:
         meta_path: Path,
         *,
         context_provider: str | None = None,
+        lang: str = "en",
     ) -> RepoMetadata:
         """Charge RepoMetadata depuis un fichier meta.yml.
 
@@ -308,6 +376,9 @@ class RepoMetadata:
                 Utilisé en fallback si ``meta.yml`` déclare plusieurs
                 providers candidats et que ``DSOXLAB_PROVIDER`` n'est
                 pas posé.
+            lang: langue préférée. Si elle n'est pas ``en`` et qu'un
+                ``meta.<lang>.yml`` existe à côté, ses titres et
+                descriptions surchargent ceux du ``meta.yml``.
 
         Lève ``ValueError`` si ``repo.id``/``repo.category`` manquent.
 
@@ -332,6 +403,11 @@ class RepoMetadata:
         # ce bloc. Réclamer d'abord un champ dont on ignore s'il existe encore
         # dans cette version enverrait l'auteur sur une fausse piste.
         schema_version = read_schema_version(data, meta_path)
+
+        # Après la version, avant toute lecture de champ : la traduction ne
+        # décide de rien, elle ne fait que remplacer des libellés déjà
+        # structurés par le fichier de base.
+        _apply_translation(data, meta_path, lang)
 
         repo = data.get("repo") or {}
         if not isinstance(repo, dict):

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import zlib
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -21,7 +22,7 @@ from ..i18n import _
 from ..models.course import CourseManifest, CourseSection
 from ..models.lab import LabDefinition
 from ..services.doctor import Check, DoctorReport
-from ..services.progress_service import build_progress
+from ..services.progress_service import build_progress, exam_verdict
 from ..validators.structure import StructureReport
 
 console = Console()
@@ -112,8 +113,38 @@ def paged(*, enabled: bool = True) -> Iterator[None]:
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
+#: Palette employée pour teinter les valeurs LIBRES du contrat (`section`,
+#: `level`). Elle ne connaît aucune valeur : la couleur est tirée du nom, pas
+#: d'une table qui nommerait des domaines.
+_FREE_FIELD_PALETTE = (
+    "green", "yellow", "cyan", "magenta", "blue", "orange3", "purple4", "red",
+)
+
+
+def _stable_color(value: str, *, bold: bool = False) -> str:
+    """Une couleur stable pour une valeur libre du contrat.
+
+    ``section`` et ``level`` appartiennent au catalogue, pas au moteur : le
+    contrat les déclare libres et « dsoxlab ne connaît aucune liste de
+    domaines ». Ces deux fonctions portaient pourtant une table de noms —
+    ``linux``, ``ansible``, ``terraform``, ``kubernetes``, ``rhcsa`` — donc de
+    la connaissance de domaine dans le moteur, et une seule conséquence
+    visible : les catalogues de cette table étaient colorés, les autres
+    uniformément blancs.
+
+    La couleur vient donc du nom lui-même, par ``crc32`` : déterministe d'une
+    exécution à l'autre (là où ``hash()`` d'une ``str`` est randomisé par
+    ``PYTHONHASHSEED``), stable pour un catalogue donné, et disponible pour
+    tout nom, y compris celui d'un domaine que personne n'a prévu.
+    """
+    if not value:
+        return "white"
+    teinte = _FREE_FIELD_PALETTE[zlib.crc32(value.encode("utf-8")) % len(_FREE_FIELD_PALETTE)]
+    return f"bold {teinte}" if bold else teinte
+
+
 def _level_color(level: str) -> str:
-    return {"l1": "green", "l2": "yellow", "lfcs": "cyan", "rhcsa": "magenta"}.get(level, "white")
+    return _stable_color(level)
 
 
 def _difficulty_label(difficulty: str) -> str:
@@ -128,15 +159,8 @@ def _difficulty_label(difficulty: str) -> str:
     return difficulty if traduit == cle else traduit
 
 
-def _section_color(section: str) -> str:
-    return {
-        "linux": "bold green",
-        "ansible": "bold red",
-        "terraform": "bold purple4",
-        "docker": "bold blue",
-        "kubernetes": "bold cyan",
-        "git": "bold orange3",
-    }.get(section, "white")
+def _section_color(section: str | None) -> str:
+    return _stable_color(section or "", bold=True)
 
 
 def _type_badge(lab_type: str) -> str:
@@ -173,9 +197,10 @@ def print_labs_table(labs: list[LabDefinition], scores: dict[str, tuple[int, int
         # Une seule section affichée par groupe : les lignes suivantes du
         # même groupe laissent la cellule vide.
         section_display = Text("", style="")
-        if lab.section != current_section:
-            current_section = lab.section
-            section_display = Text(lab.section, style=_section_color(lab.section))
+        section = lab.section or ""
+        if section != current_section:
+            current_section = section
+            section_display = Text(section, style=_section_color(section))
 
         if scores and lab.id in scores:
             best, max_s = scores[lab.id]
@@ -203,7 +228,7 @@ def print_labs_table(labs: list[LabDefinition], scores: dict[str, tuple[int, int
 
 def print_lab_detail(lab: LabDefinition, status: str | None = None) -> None:
     lines = [
-        f"{_('field_section')}    [{_section_color(lab.section)}]{lab.section}[/{_section_color(lab.section)}]",
+        f"{_('field_section')}    [{_section_color(lab.section)}]{lab.section or ''}[/{_section_color(lab.section)}]",
         f"{_('field_title')}      {lab.title}",
         f"{_('field_type')}       {_type_badge(lab.lab_type)}"
         + (f"  —  bloc {lab.bloc}" if lab.bloc else ""),
@@ -215,6 +240,10 @@ def print_lab_detail(lab: LabDefinition, status: str | None = None) -> None:
         f"{_('field_skills')}     {', '.join(lab.skills)}",
         f"{_('field_doc')}        [link={lab.doc_url}]{lab.doc_url}[/link]",
     ]
+    # Le seuil d'un examen blanc se lit AVANT de le passer, pas après : c'est
+    # la barre que l'apprenant vise. Un lab ordinaire n'en déclare pas.
+    if lab.exam_passing_score:
+        lines.append(f"{_('field_exam_score')} {lab.exam_passing_score} %")
     if lab.track:
         lines.append(f"{_('field_track')}   {', '.join(lab.track)}")
     if lab.certification_tags:
@@ -428,15 +457,29 @@ def print_progress_table(
 
 # ── scores ────────────────────────────────────────────────────────────────────
 
-def print_scores_table(results: list[dict[str, Any]]) -> None:
+def print_scores_table(
+    results: list[dict[str, Any]],
+    exam_thresholds: dict[str, int] | None = None,
+) -> None:
+    """Le tableau des scores, et le verdict des labs qui sont des examens.
+
+    ``exam_thresholds`` associe un id de lab à son ``exam_passing_score``. La
+    colonne « verdict » n'apparaît que si au moins une ligne en relève : un
+    catalogue sans examen n'a pas à porter une colonne de tirets.
+    """
     if not results:
         console.print(f"[yellow]{_('no_scores')}[/yellow]")
         return
+
+    seuils = exam_thresholds or {}
+    avec_verdict = any(seuils.get(r["lab_id"], 0) > 0 for r in results)
 
     table = Table(title=_('scores_table_title'), show_lines=True)
     table.add_column(_('col_lab'), style="bold cyan", no_wrap=True)
     table.add_column(_('col_section'), justify="center")
     table.add_column(_('col_score'), justify="center")
+    if avec_verdict:
+        table.add_column(_('col_verdict'), justify="center")
     table.add_column(_('col_tests'), justify="center")
     table.add_column(_('col_hints'), justify="center")
     table.add_column(_('col_validated_at'))
@@ -451,16 +494,26 @@ def print_scores_table(results: list[dict[str, Any]]) -> None:
         tests = f"{r['passed_tests']}/{r['total_tests']}"
         validated_at = r["validated_at"][:16].replace("T", " ")
 
-        table.add_row(
+        cellules: list[str | Text] = [
             r["lab_id"],
             Text(r["section"], style=_section_color(r["section"])),
             score_text,
-            tests,
-            str(r["hints_used"]),
-            validated_at,
-        )
+        ]
+        if avec_verdict:
+            cellules.append(_verdict_cell(score, max_s, seuils.get(r["lab_id"], 0)))
+        cellules += [tests, str(r["hints_used"]), validated_at]
+        table.add_row(*cellules)
 
     console.print(table)
+
+
+def _verdict_cell(score: int, max_score: int, passing_score: int) -> Text:
+    """« reçu » / « recalé » et le seuil, ou un tiret si le lab n'est pas un examen."""
+    verdict = exam_verdict(score, max_score, passing_score)
+    if verdict is None:
+        return Text("—", style="dim")
+    libelle = _("verdict_pass") if verdict else _("verdict_fail")
+    return Text(f"{libelle} ({passing_score}%)", style="green" if verdict else "red")
 
 
 # ── fullhelp ──────────────────────────────────────────────────────────────────

--- a/src/dsoxlab/reporting/machine.py
+++ b/src/dsoxlab/reporting/machine.py
@@ -56,6 +56,10 @@ def lab_dict(
         "bloc_order": lab.bloc_order or None,
         "level": lab.level,
         "type": lab.lab_type,
+        # Le seuil de réussite d'un examen blanc, en pourcentage du barème.
+        # `or None` comme les autres champs facultatifs : un lab ordinaire n'en
+        # déclare pas, et 0 se lirait comme « réussi d'office ».
+        "exam_passing_score": lab.exam_passing_score or None,
         "difficulty": lab.difficulty or None,
         "estimated_time": lab.estimated_time or None,
         "skills": list(lab.skills),

--- a/src/dsoxlab/services/lab_service.py
+++ b/src/dsoxlab/services/lab_service.py
@@ -126,7 +126,10 @@ def evaluate_lab(root: Path, lab: LabDefinition, result: CheckResult) -> ScoreRe
     record_result(
         root,
         lab_id=lab.id,
-        section=lab.section,
+        # `or ""` : la colonne `section` est NOT NULL, et un lab qu'aucune
+        # règle n'a rattaché n'en a pas. Vide se filtre comme absent ; None
+        # ferait lever l'insertion.
+        section=lab.section or "",
         score=score,
         max_score=max_score,
         passed_tests=result.passed,

--- a/src/dsoxlab/services/progress_service.py
+++ b/src/dsoxlab/services/progress_service.py
@@ -52,6 +52,37 @@ class BlocProgress:
         return self.validated > 0
 
 
+def exam_percentage(score: int, max_score: int) -> int:
+    """Le score, ramené au pourcentage du barème. ``0`` si le barème est nul.
+
+    Un barème à zéro n'est pas une réussite parfaite : c'est un contrat
+    incomplet, et il vaut 0 % comme il vaut 0 point dans :func:`compute_score`.
+    """
+    if max_score <= 0:
+        return 0
+    return score * 100 // max_score
+
+
+def exam_verdict(score: int, max_score: int, passing_score: int) -> bool | None:
+    """Le lab est-il réussi au sens de son ``exam_passing_score`` ?
+
+    Rend ``None`` quand le lab ne déclare pas de seuil : la très grande
+    majorité des labs, qui ne sont pas des examens. ``None`` n'est pas un
+    échec, et distinguer les deux est tout l'intérêt de cette fonction — un
+    lab ordinaire ne doit jamais s'afficher « recalé ».
+
+    La comparaison est faite en entiers, sans passer par un pourcentage
+    arrondi : à 69,5 % d'un barème, l'arrondi rendrait 70 et déclarerait reçu
+    un apprenant qui ne l'est pas. Un seuil d'examen ne s'arrondit pas en
+    faveur du candidat.
+    """
+    if passing_score <= 0:
+        return None
+    if max_score <= 0:
+        return False
+    return score * 100 >= passing_score * max_score
+
+
 def pedagogical_sort_key(lab: LabDefinition) -> tuple[int, int, int, str]:
     """Ordre dans lequel un apprenant doit rencontrer les labs.
 

--- a/src/dsoxlab/templates/demo/meta.fr.yml
+++ b/src/dsoxlab/templates/demo/meta.fr.yml
@@ -1,0 +1,15 @@
+# Traduction française du `meta.yml` voisin.
+#
+# Même convention que `lab.fr.yaml` : seuls `repo.title`, `repo.description`,
+# `sections[].title` et `sections[].description` sont lus. Tout autre champ y
+# est ignoré, et les sections sont appariées par `id`, jamais par position.
+repo:
+  title: Démonstration dsoxlab
+  description: |
+    Un lab unique pour prendre en main la boucle de travail de dsoxlab.
+    Aucune infrastructure requise.
+
+sections:
+  - id: demo
+    title: Prise en main
+    description: La boucle de travail, de bout en bout.

--- a/src/dsoxlab/templates/demo/meta.yml
+++ b/src/dsoxlab/templates/demo/meta.yml
@@ -8,17 +8,21 @@
 # C'est ce qui le distingue d'un catalogue Linux ou Terraform embarqué, ce que
 # le projet s'interdit : ici, le sujet EST la boucle run / course / challenge /
 # hint / check.
+#
+# Les libellés sont en anglais, comme le veut le contrat : c'est `meta.fr.yml`,
+# à côté, qui porte leur traduction française. Le catalogue de démonstration
+# est aussi l'exemple de référence du mécanisme.
 repo:
   id: dsoxlab-demo
   category: demo
-  title: Démonstration dsoxlab
+  title: dsoxlab demonstration
   description: |
-    Un lab unique pour prendre en main la boucle de travail de dsoxlab.
-    Aucune infrastructure requise.
+    A single lab to get a feel for the dsoxlab working loop.
+    No infrastructure required.
 
 sections:
   - id: demo
-    title: Prise en main
-    description: La boucle de travail, de bout en bout.
+    title: Getting started
+    description: The working loop, end to end.
     labs:
       - demo/premiers-pas

--- a/src/dsoxlab/validators/__init__.py
+++ b/src/dsoxlab/validators/__init__.py
@@ -10,7 +10,12 @@ from .content import (
     validate_solutions_encrypted,
     validate_targets,
 )
-from .contract import ContractIssue, ContractReport, validate_schema_versions
+from .contract import (
+    ContractIssue,
+    ContractReport,
+    validate_schema_versions,
+    validate_unknown_keys,
+)
 from .metadata import MetadataReport, validate_metadata
 from .structure import StructureReport, validate_structure
 
@@ -30,4 +35,5 @@ __all__ = [
     "validate_solutions_encrypted",
     "validate_structure",
     "validate_targets",
+    "validate_unknown_keys",
 ]

--- a/src/dsoxlab/validators/contract.py
+++ b/src/dsoxlab/validators/contract.py
@@ -1,4 +1,4 @@
-"""Contrôle de la version du contrat, lue **à la source**.
+"""Contrôles du contrat lus **à la source** : version, et clés inconnues.
 
 Les autres validators itèrent sur ``discover_labs()``, donc sur ce qui a déjà
 été chargé avec succès : un ``lab.yaml`` qui lève au parsing traverse toute la
@@ -10,6 +10,17 @@ Ce contrôle-ci relit donc les fichiers du catalogue directement, avant toute
 découverte, et ne regarde qu'une chose : le numéro de version du contrat. Il
 voit ce que les autres ne peuvent pas voir.
 
+Le second contrôle, :func:`validate_unknown_keys`, relève **les clés que le
+moteur n'ira jamais lire**. Le parseur les ignore en silence — c'est une
+garantie de la v1, et elle doit le rester : un outil v1 doit survivre à un
+catalogue v1.1. Mais « toléré par le moteur » n'est pas « voulu par l'auteur ».
+Quatre clés écrites de bonne foi dans les catalogues réels ne servaient à
+personne, dont un ``exam_passing_score`` dans onze labs d'examen : leur auteur
+croyait poser un seuil de réussite, et rien ne le posait. Une clé inconnue à
+ce niveau est une faute de frappe ou une attente déçue, presque jamais une
+extension délibérée — d'où un contrôle de lint, là où le parseur reste
+tolérant.
+
 Il ne compose aucune phrase : chaque anomalie porte une **clé i18n** et ses
 paramètres, que la CLI rend dans la langue de l'apprenant. Un validator qui
 écrirait ses messages en dur les afficherait dans une seule langue.
@@ -17,6 +28,8 @@ paramètres, que la CLI rend dans la langue de l'apprenant. Un validator qui
 
 from __future__ import annotations
 
+import difflib
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -117,6 +130,185 @@ def validate_schema_versions(root: Path) -> ContractReport:
                     "got": repr(data.get("schema_version")),
                     "supported": SUPPORTED_SCHEMA_VERSION,
                 },
+            ))
+
+    return report
+
+
+# ── Clés inconnues ────────────────────────────────────────────────────────────
+#
+# Les ensembles ci-dessous décrivent le contrat en **chemins pointés** :
+# ``runtime.targets[].host`` désigne la clé ``host`` d'un élément de la liste
+# ``targets`` du bloc ``runtime``. Ils sont l'exact reflet des ``properties``
+# des schémas JSON publiés, et ``tests/test_json_schemas.py`` en fait foi : il
+# dérive le même ensemble depuis ``schemas/*.json`` et exige l'égalité. Les
+# schémas restent la référence publiée ; ces constantes sont ce que l'outil
+# embarque, puisque ``schemas/`` ne fait pas partie de la roue.
+#
+# Un nœud SANS enfant déclaré ici est **opaque** : le contrôle n'y descend pas.
+# C'est ce qui laisse passer les mappings libres du contrat —
+# ``runtime.targets[].roles`` (rôle → FQDN), ``runtime.services[].env``
+# (variables d'environnement) et ``infra.providers.<provider>`` (variables du
+# module Terraform) — dont les clés appartiennent au catalogue, pas au moteur.
+
+KNOWN_LAB_KEYS: frozenset[str] = frozenset({
+    "schema_version",
+    "id", "title", "level", "skills", "distros", "doc_url",
+    "section", "description", "track", "difficulty", "estimated_time",
+    "certification_tags", "lab_type", "exam_passing_score", "bloc", "bloc_order",
+    "runtime", "validation",
+    "runtime.type", "runtime.targets", "runtime.default",
+    "runtime.snapshot_required", "runtime.session", "runtime.workdir",
+    "runtime.fixtures", "runtime.services", "runtime.topology",
+    "runtime.targets[].name", "runtime.targets[].host",
+    "runtime.targets[].label_en", "runtime.targets[].label_fr",
+    "runtime.targets[].roles",
+    "runtime.services[].name", "runtime.services[].image",
+    "runtime.services[].ports", "runtime.services[].run_args",
+    "runtime.services[].env", "runtime.services[].ready_tcp",
+    "runtime.services[].ready_exec", "runtime.services[].ready_timeout",
+    "runtime.services[].post_start",
+    "validation.functional", "validation.security",
+    "validation.persistence_after_reboot",
+})
+
+KNOWN_META_KEYS: frozenset[str] = frozenset({
+    "schema_version",
+    "repo", "infra", "sections",
+    "repo.id", "repo.category", "repo.title", "repo.blog_url", "repo.description",
+    "infra.provider", "infra.network", "infra.cidr", "infra.hosts", "infra.providers",
+    "infra.hosts[].name", "infra.hosts[].distro", "infra.hosts[].role",
+    "infra.hosts[].ram_mb", "infra.hosts[].vcpu", "infra.hosts[].disk_gb",
+    "infra.hosts[].extra_disk_gb", "infra.hosts[].ip",
+    "sections[].id", "sections[].title", "sections[].description", "sections[].labs",
+})
+
+#: Ce qu'un ``lab.<lang>.yaml`` peut porter. La surcharge ne vaut que pour
+#: ``title`` et ``description`` ; ``id`` est accepté parce qu'il nomme le lab
+#: pour qui relit le fichier, et les 284 traductions des catalogues réels le
+#: portent déjà. Tout autre champ y serait ignoré, ce qui est exactement le
+#: défaut qu'on répare ailleurs.
+KNOWN_LAB_LANG_KEYS: frozenset[str] = frozenset({"id", "title", "description"})
+
+#: Ce qu'un ``meta.<lang>.yml`` peut porter. ``sections[].id`` n'est pas une
+#: traduction : c'est la clé d'appariement, sans laquelle la surcharge ne
+#: saurait pas quelle section elle traduit.
+KNOWN_META_LANG_KEYS: frozenset[str] = frozenset({
+    "repo", "sections",
+    "repo.title", "repo.description",
+    "sections[].id", "sections[].title", "sections[].description",
+})
+
+_LAB_LANG = re.compile(r"^lab\.[a-z]{2}\.yaml$")
+_META_LANG = re.compile(r"^meta\.[a-z]{2}\.yml$")
+
+
+def _has_children(known: frozenset[str], prefix: str) -> bool:
+    """Le contrat décrit-il quelque chose SOUS ``prefix`` ?
+
+    Non veut dire « nœud opaque » : ses clés appartiennent au catalogue et
+    aucune ne peut donc être inconnue. C'est le cas des mappings libres.
+    """
+    depart = f"{prefix}."
+    return any(cle.startswith(depart) for cle in known)
+
+
+def _unknown_paths(noeud: Any, known: frozenset[str], prefix: str = "") -> list[str]:
+    """Les chemins pointés que ``noeud`` porte et que le contrat ne décrit pas."""
+    trouves: list[str] = []
+    if isinstance(noeud, dict):
+        for cle, valeur in noeud.items():
+            chemin = f"{prefix}.{cle}" if prefix else str(cle)
+            if chemin not in known:
+                trouves.append(chemin)
+                continue  # inutile de fouiller sous une clé qui n'existe pas
+            if _has_children(known, chemin) or _has_children(known, f"{chemin}[]"):
+                trouves += _unknown_paths(valeur, known, chemin)
+    elif isinstance(noeud, list):
+        for element in noeud:
+            if isinstance(element, dict):
+                trouves += _unknown_paths(element, known, f"{prefix}[]")
+    return trouves
+
+
+def _suggestion(cle: str, known: frozenset[str]) -> str:
+    """La clé connue la plus proche **au même niveau**, ou une chaîne vide.
+
+    Chercher dans tout le contrat proposerait ``runtime.session`` pour un
+    ``sesion`` écrit à la racine : une piste fausse coûte plus cher que pas
+    de piste du tout.
+
+    Le message qui l'emploie dit « la clé la plus proche est X », et non
+    « voulais-tu écrire X ». La nuance est mesurée : ``title_en`` → ``title``
+    (0,77) et ``hosts_required`` → ``snapshot_required`` (0,77) ont le même
+    score, alors que la première est l'intention de l'auteur et la seconde
+    une coïncidence. Aucun seuil ne les sépare ; énoncer un fait plutôt que
+    prêter une intention reste vrai dans les deux cas.
+    """
+    prefixe, _sep, feuille = cle.rpartition(".")
+    voisines = [
+        candidate.rpartition(".")[2]
+        for candidate in known
+        if candidate.rpartition(".")[0] == prefixe
+    ]
+    proches = difflib.get_close_matches(feuille, voisines, n=1, cutoff=0.7)
+    if not proches:
+        return ""
+    return f"{prefixe}.{proches[0]}" if prefixe else proches[0]
+
+
+def _keyed_documents(root: Path) -> list[tuple[Path, frozenset[str]]]:
+    """Chaque document du contrat, avec l'ensemble de clés qui le décrit."""
+    documents: list[tuple[Path, frozenset[str]]] = []
+
+    meta = root / "meta.yml"
+    if meta.is_file():
+        documents.append((meta, KNOWN_META_KEYS))
+    documents += [
+        (chemin, KNOWN_META_LANG_KEYS)
+        for chemin in sorted(root.glob("meta.*.yml"))
+        if _META_LANG.match(chemin.name)
+    ]
+
+    candidats: list[Path] = []
+    if (root / "labs").exists():
+        candidats += sorted((root / "labs").glob("**/*.yaml"))
+    candidats += sorted(root.glob("tp-*/*.yaml"))
+    for chemin in candidats:
+        if chemin.name == "lab.yaml":
+            documents.append((chemin, KNOWN_LAB_KEYS))
+        elif _LAB_LANG.match(chemin.name):
+            documents.append((chemin, KNOWN_LAB_LANG_KEYS))
+
+    return documents
+
+
+def validate_unknown_keys(root: Path) -> ContractReport:
+    """Signale toute clé qu'aucun champ du contrat ne décrit.
+
+    Parcourt les quatre familles de documents du contrat — ``meta.yml``,
+    ``lab.yaml`` et leurs fichiers de traduction — et confronte chaque chemin
+    pointé à l'ensemble connu. Un document illisible n'est **pas** rapporté
+    ici : ce n'est pas le sujet de ce contrôle, et les autres le signalent.
+
+    Le moteur, lui, continue d'ignorer ces clés sans broncher : c'est une
+    garantie du contrat v1, et ce contrôle est un lint, pas le parseur.
+    """
+    report = ContractReport()
+
+    for chemin, connues in _keyed_documents(root):
+        try:
+            data = yaml.safe_load(chemin.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        for inconnue in sorted(set(_unknown_paths(data, connues))):
+            proche = _suggestion(inconnue, connues)
+            report.issues.append(ContractIssue(
+                path=chemin,
+                key="unknown_key_suggest" if proche else "unknown_key",
+                params={"field": inconnue, "suggestion": proche},
             ))
 
     return report

--- a/src/dsoxlab/validators/metadata.py
+++ b/src/dsoxlab/validators/metadata.py
@@ -55,5 +55,18 @@ def validate_metadata(lab: LabDefinition) -> MetadataReport:
                 f"Invalid value '{lab.lab_type}'. Expected one of: {', '.join(sorted(_VALID_LAB_TYPES))}",
             )
         )
+    # Le seuil est un POURCENTAGE du barème. Hors de 1..100, il ne veut rien
+    # dire : un examen qu'on ne peut jamais réussir, ou qu'on ne peut jamais
+    # rater. Le champ absent vaut 0, ce qui est « pas un examen », pas un
+    # seuil hors bornes.
+    if lab.exam_passing_score and not 1 <= lab.exam_passing_score <= 100:
+        report.issues.append(
+            MetadataIssue(
+                "exam_passing_score",
+                f"Invalid value '{lab.exam_passing_score}'. Expected a percentage "
+                f"of the lab scale, between 1 and 100 (omit the field for a lab "
+                f"that is not an exam).",
+            )
+        )
 
     return report

--- a/tests/test_contrat_honore.py
+++ b/tests/test_contrat_honore.py
@@ -1,0 +1,542 @@
+"""Le moteur fait-il ce que le contrat déclare ?
+
+Deux défauts de la même famille, et c'est pourquoi ils sont testés ensemble :
+l'auteur d'un catalogue écrit quelque chose, et le moteur en fait autre chose.
+
+* **Une section déclarée était écrasée** (#87). Le défaut par défaut de
+  ``LabDefinition.section`` était ``"linux"``, et le scanner s'en servait comme
+  sentinelle « rien de déclaré ». La valeur ``linux`` devenait donc
+  indiscernable de l'absence, et un nom de domaine vivait dans le moteur — ce
+  que la règle d'architecture la plus stricte du projet interdit.
+
+* **Quatre clés étaient écrites et jamais lues** (#126), dont un
+  ``exam_passing_score`` dans onze labs d'examen. Un apprenant qui rendait
+  40/100 sur un examen blanc ne lisait nulle part qu'il avait échoué.
+
+Le vrai livrable du second n'est pas de solder quatre clés : c'est qu'une
+cinquième ne puisse plus s'installer en silence. D'où les tests du garde-fou,
+qui vérifient surtout qu'il *mord*.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from dsoxlab.discovery.scanner import discover_labs
+from dsoxlab.models.lab import LabDefinition
+from dsoxlab.models.repo import RepoMetadata
+from dsoxlab.services.progress_service import exam_percentage, exam_verdict
+from dsoxlab.validators.contract import validate_unknown_keys
+from dsoxlab.validators.metadata import validate_metadata
+
+LAB_SANS_SECTION = """\
+id: {id}
+title: {id}
+level: l1
+skills: [demo]
+distros: [any]
+doc_url: https://example.test/docs/{id}/
+runtime:
+  type: shell
+  workdir: challenge/work
+"""
+
+
+def _catalogue(racine: Path, *, category: str = "terraform") -> None:
+    (racine / "meta.yml").write_text(
+        f"repo:\n  id: catalogue-test\n  category: {category}\n",
+        encoding="utf-8",
+    )
+
+
+def _lab(racine: Path, lab_id: str, extra: str = "") -> Path:
+    dossier = racine / "labs" / "bloc" / lab_id
+    dossier.mkdir(parents=True)
+    (dossier / "lab.yaml").write_text(
+        LAB_SANS_SECTION.format(id=lab_id) + extra, encoding="utf-8"
+    )
+    return dossier
+
+
+# ── #87 : la section déclarée est la section retenue ─────────────────────────
+
+
+class TestSectionDeclaree:
+    def test_le_modele_ne_pose_aucune_section_par_defaut(self, tmp_path: Path) -> None:
+        """La sentinelle est None, jamais un nom de domaine."""
+        (tmp_path / "lab.yaml").write_text(
+            LAB_SANS_SECTION.format(id="sans-section"), encoding="utf-8"
+        )
+        assert LabDefinition.from_yaml(tmp_path / "lab.yaml").section is None
+
+    def test_section_linux_survit_dans_un_catalogue_terraform(
+        self, tmp_path: Path
+    ) -> None:
+        """Le cas exact de l'issue : deux labs, une seule déclaration honorée.
+
+        Avant correction, `lab-a` ressortait en `terraform` parce que sa valeur
+        déclarée était celle qui servait de sentinelle.
+        """
+        _catalogue(tmp_path, category="terraform")
+        _lab(tmp_path, "lab-a", extra="section: linux\n")
+        _lab(tmp_path, "lab-b", extra="section: reseau\n")
+        _lab(tmp_path, "lab-c")
+
+        sections = {lab.id: lab.section for lab in discover_labs(tmp_path)}
+        assert sections == {
+            "lab-a": "linux",
+            "lab-b": "reseau",
+            "lab-c": "terraform",
+        }
+
+    def test_le_mode_legacy_infere_encore_depuis_le_chemin(
+        self, tmp_path: Path
+    ) -> None:
+        """Sans meta.yml, la section vient du chemin — comportement conservé."""
+        dossier = tmp_path / "labs" / "reseau" / "l1" / "lab-x"
+        dossier.mkdir(parents=True)
+        (dossier / "lab.yaml").write_text(
+            LAB_SANS_SECTION.format(id="lab-x"), encoding="utf-8"
+        )
+        assert discover_labs(tmp_path)[0].section == "reseau"
+
+    def test_le_mode_legacy_ne_devine_rien_quand_il_ne_sait_pas(
+        self, tmp_path: Path
+    ) -> None:
+        """Le chemin ne porte pas de section : None, et surtout pas « linux »."""
+        dossier = tmp_path / "labs" / "l1" / "lab-y"
+        dossier.mkdir(parents=True)
+        (dossier / "lab.yaml").write_text(
+            LAB_SANS_SECTION.format(id="lab-y"), encoding="utf-8"
+        )
+        assert discover_labs(tmp_path)[0].section is None
+
+
+#: Modules qui *interprètent le catalogue* : ils lisent le contrat, en tirent
+#: des décisions et l'affichent. Un nom de domaine ne peut y être qu'une valeur
+#: métier — jamais le nom d'un outil qu'on invoque, ce qui est le cas légitime
+#: qu'on trouve ailleurs (`infra/terraform.py`, `services/doctor.py`).
+_MODULES_DU_CATALOGUE = ("models/", "discovery/", "reporting/", "validators/")
+
+#: Ces deux-là ne sont le nom d'aucun outil que dsoxlab lance : leur présence
+#: en littéral, où que ce soit dans le paquet, est forcément une valeur métier.
+_DOMAINES_JAMAIS_OUTILS = frozenset({"linux", "kubernetes"})
+
+_DOMAINES = frozenset({"linux", "ansible", "kubernetes", "terraform", "docker"})
+
+
+def _litteraux(source: str) -> set[str]:
+    """Les chaînes écrites en dur, docstrings exclues.
+
+    Les commentaires et les docstrings ont le droit de nommer un domaine : ils
+    donnent des exemples, et le contrat en a besoin pour être lisible. C'est la
+    chaîne que le code manipule qui est en cause, jamais celle qui l'explique.
+    """
+    import ast
+
+    arbre = ast.parse(source)
+    docstrings = {
+        noeud.body[0].value
+        for noeud in ast.walk(arbre)
+        if isinstance(
+            noeud, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        )
+        and noeud.body
+        and isinstance(noeud.body[0], ast.Expr)
+        and isinstance(noeud.body[0].value, ast.Constant)
+    }
+    return {
+        noeud.value
+        for noeud in ast.walk(arbre)
+        if isinstance(noeud, ast.Constant)
+        and isinstance(noeud.value, str)
+        and noeud not in docstrings
+    }
+
+
+def _sources_du_paquet() -> list[tuple[str, str]]:
+    import dsoxlab
+
+    racine = Path(dsoxlab.__file__).parent
+    return [
+        (chemin.relative_to(racine).as_posix(), chemin.read_text(encoding="utf-8"))
+        for chemin in sorted(racine.rglob("*.py"))
+    ]
+
+
+class TestMoteurAgnostique:
+    def test_aucun_domaine_dans_ce_qui_lit_le_catalogue(self) -> None:
+        coupables = [
+            f"{nom}: {sorted(_DOMAINES & _litteraux(source))}"
+            for nom, source in _sources_du_paquet()
+            if nom.startswith(_MODULES_DU_CATALOGUE)
+            and _DOMAINES & _litteraux(source)
+        ]
+        assert not coupables, (
+            "Un nom de domaine sert de valeur métier dans le moteur :\n  "
+            + "\n  ".join(coupables)
+        )
+
+    def test_deux_domaines_sont_bannis_du_paquet_entier(self) -> None:
+        """`linux` et `kubernetes` ne sont le nom d'aucun outil qu'on lance."""
+        coupables = [
+            f"{nom}: {sorted(_DOMAINES_JAMAIS_OUTILS & _litteraux(source))}"
+            for nom, source in _sources_du_paquet()
+            if _DOMAINES_JAMAIS_OUTILS & _litteraux(source)
+        ]
+        assert not coupables, "\n  ".join(coupables)
+
+    def test_le_garde_fou_mord_et_ignore_les_docstrings(self) -> None:
+        """Un test qui ne peut pas échouer ne prouve rien."""
+        assert _DOMAINES & _litteraux('section = "linux"\n')
+        assert not _DOMAINES & _litteraux('"""Exemple : category: linux."""\n')
+        assert not _DOMAINES & _litteraux("# category: linux\nx = 1\n")
+
+
+# ── #126 : `exam_passing_score`, un examen rend un verdict ───────────────────
+
+
+class TestVerdictDExamen:
+    def test_sous_le_seuil_le_verdict_est_un_echec(self) -> None:
+        assert exam_verdict(40, 100, 70) is False
+
+    def test_au_seuil_exact_le_verdict_est_une_reussite(self) -> None:
+        assert exam_verdict(70, 100, 70) is True
+
+    def test_le_seuil_ne_s_arrondit_pas_en_faveur_du_candidat(self) -> None:
+        """139/200 = 69,5 %, qu'un arrondi rendrait à 70 : c'est un échec."""
+        assert exam_verdict(139, 200, 70) is False
+        assert exam_verdict(140, 200, 70) is True
+
+    def test_un_lab_ordinaire_ne_rend_aucun_verdict(self) -> None:
+        """None, pas False : « pas un examen » n'est pas « recalé »."""
+        assert exam_verdict(0, 100, 0) is None
+
+    def test_un_bareme_nul_ne_vaut_pas_une_reussite(self) -> None:
+        assert exam_verdict(0, 0, 70) is False
+        assert exam_percentage(0, 0) == 0
+
+    def test_le_seuil_est_lu_depuis_le_lab_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / "lab.yaml").write_text(
+            LAB_SANS_SECTION.format(id="capstone")
+            + "lab_type: capstone\nexam_passing_score: 70\n",
+            encoding="utf-8",
+        )
+        assert LabDefinition.from_yaml(tmp_path / "lab.yaml").exam_passing_score == 70
+
+    def test_un_lab_sans_seuil_vaut_zero(self, tmp_path: Path) -> None:
+        (tmp_path / "lab.yaml").write_text(
+            LAB_SANS_SECTION.format(id="ordinaire"), encoding="utf-8"
+        )
+        assert LabDefinition.from_yaml(tmp_path / "lab.yaml").exam_passing_score == 0
+
+    @pytest.mark.parametrize("valeur", [101, -5])
+    def test_un_seuil_hors_bornes_est_signale(
+        self, tmp_path: Path, valeur: int
+    ) -> None:
+        """Un pourcentage hors 1..100 décrit un examen impossible à passer."""
+        (tmp_path / "lab.yaml").write_text(
+            LAB_SANS_SECTION.format(id="capstone")
+            + f"exam_passing_score: {valeur}\n",
+            encoding="utf-8",
+        )
+        rapport = validate_metadata(LabDefinition.from_yaml(tmp_path / "lab.yaml"))
+        assert [i.field for i in rapport.issues] == ["exam_passing_score"]
+
+
+# ── #126 : `meta.<lang>.yml`, la traduction par fichier ──────────────────────
+
+
+class TestTraductionDuMetaYml:
+    META = """\
+repo:
+  id: catalogue-test
+  category: demo
+  title: Demo catalogue
+sections:
+  - id: bloc-un
+    title: First bloc
+  - id: bloc-deux
+    title: Second bloc
+"""
+
+    def test_sans_fichier_de_traduction_le_meta_yml_gagne(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "meta.yml").write_text(self.META, encoding="utf-8")
+        meta = RepoMetadata.from_yaml(tmp_path / "meta.yml", lang="fr")
+        assert meta.sections[0].title == "First bloc"
+
+    def test_les_titres_sont_traduits_dans_la_langue_demandee(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "meta.yml").write_text(self.META, encoding="utf-8")
+        (tmp_path / "meta.fr.yml").write_text(
+            "repo:\n  title: Catalogue de démonstration\n"
+            "sections:\n  - id: bloc-un\n    title: Premier bloc\n",
+            encoding="utf-8",
+        )
+        meta = RepoMetadata.from_yaml(tmp_path / "meta.yml", lang="fr")
+        assert meta.title == "Catalogue de démonstration"
+        assert meta.sections[0].title == "Premier bloc"
+        # Section non traduite : l'anglais reste, il ne disparaît pas.
+        assert meta.sections[1].title == "Second bloc"
+
+    def test_l_anglais_ignore_le_fichier_de_traduction(self, tmp_path: Path) -> None:
+        (tmp_path / "meta.yml").write_text(self.META, encoding="utf-8")
+        (tmp_path / "meta.fr.yml").write_text(
+            "sections:\n  - id: bloc-un\n    title: Premier bloc\n", encoding="utf-8"
+        )
+        meta = RepoMetadata.from_yaml(tmp_path / "meta.yml", lang="en")
+        assert meta.sections[0].title == "First bloc"
+
+    def test_les_sections_sont_appariees_par_id_pas_par_position(
+        self, tmp_path: Path
+    ) -> None:
+        """Une section insérée en tête décalerait sinon toutes les traductions."""
+        (tmp_path / "meta.yml").write_text(self.META, encoding="utf-8")
+        (tmp_path / "meta.fr.yml").write_text(
+            "sections:\n  - id: bloc-deux\n    title: Second bloc en français\n",
+            encoding="utf-8",
+        )
+        meta = RepoMetadata.from_yaml(tmp_path / "meta.yml", lang="fr")
+        assert meta.sections[0].title == "First bloc"
+        assert meta.sections[1].title == "Second bloc en français"
+
+    def test_une_traduction_illisible_ne_casse_pas_le_catalogue(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "meta.yml").write_text(self.META, encoding="utf-8")
+        (tmp_path / "meta.fr.yml").write_text("repo: [non fermé\n", encoding="utf-8")
+        meta = RepoMetadata.from_yaml(tmp_path / "meta.yml", lang="fr")
+        assert meta.sections[0].title == "First bloc"
+
+
+# ── #126 : le garde-fou contre la cinquième clé ──────────────────────────────
+
+
+class TestClesInconnues:
+    def test_un_catalogue_conforme_ne_dit_rien(self, tmp_path: Path) -> None:
+        _catalogue(tmp_path)
+        _lab(tmp_path, "lab-a")
+        assert validate_unknown_keys(tmp_path).ok
+
+    def test_les_quatre_cles_mortes_de_l_issue_sont_vues(
+        self, tmp_path: Path
+    ) -> None:
+        """Les quatre clés réelles, chacune à son niveau du contrat."""
+        (tmp_path / "meta.yml").write_text(
+            "repo:\n  id: catalogue-test\n  category: demo\n"
+            "sections:\n  - id: bloc\n    title: Bloc\n"
+            "    title_en: Bloc\n    description_en: A bloc\n",
+            encoding="utf-8",
+        )
+        # `hosts_required` continue le bloc runtime ; la clé racine vient après.
+        _lab(
+            tmp_path,
+            "lab-a",
+            extra="  hosts_required: 2\nexam_passing_score_typo: 70\n",
+        )
+
+        rapport = validate_unknown_keys(tmp_path)
+        assert not rapport.ok
+        assert {i.params["field"] for i in rapport.issues} == {
+            "sections[].title_en",
+            "sections[].description_en",
+            "exam_passing_score_typo",
+            "runtime.hosts_required",
+        }
+
+    def test_la_faute_de_frappe_est_nommee_avec_sa_correction(
+        self, tmp_path: Path
+    ) -> None:
+        _catalogue(tmp_path)
+        _lab(tmp_path, "lab-a", extra="skils: [demo]\n")
+        anomalie = validate_unknown_keys(tmp_path).issues[0]
+        assert anomalie.key == "unknown_key_suggest"
+        assert anomalie.params["suggestion"] == "skills"
+
+    def test_la_suggestion_reste_au_meme_niveau(self, tmp_path: Path) -> None:
+        """`snapshot_required` n'existe que sous `runtime` : à la racine, pas de piste.
+
+        Proposer `runtime.snapshot_required` à quelqu'un qui a écrit la clé au
+        mauvais niveau serait juste ; la proposer sans le dire, avec la même
+        phrase qu'une faute de frappe, enverrait sur une fausse piste dès que
+        la ressemblance est fortuite. Le contrôle se tait plutôt que d'inventer.
+        """
+        _catalogue(tmp_path)
+        _lab(tmp_path, "lab-a", extra="snapshot_required: true\n")
+        anomalie = validate_unknown_keys(tmp_path).issues[0]
+        assert anomalie.key == "unknown_key"
+        assert anomalie.params["suggestion"] == ""
+
+    def test_les_mappings_libres_du_contrat_restent_libres(
+        self, tmp_path: Path
+    ) -> None:
+        """`roles`, `env` et `infra.providers` appartiennent au catalogue."""
+        (tmp_path / "meta.yml").write_text(
+            "repo:\n  id: catalogue-test\n  category: demo\n"
+            "infra:\n  hosts:\n    - name: a.lab\n"
+            "  providers:\n    kvm:\n      storage_pool: pool\n"
+            "      nimporte_quoi: 3\n",
+            encoding="utf-8",
+        )
+        _lab(
+            tmp_path,
+            "lab-a",
+            extra=(
+                "  targets:\n    - name: t\n      host: a.lab\n"
+                "      roles:\n        server: a.lab\n"
+                "  services:\n    - name: s\n      image: img:1\n"
+                "      env:\n        UN_NOM_LIBRE: valeur\n"
+            ),
+        )
+        assert validate_unknown_keys(tmp_path).ok
+
+    def test_une_traduction_de_lab_ne_peut_porter_que_ses_champs(
+        self, tmp_path: Path
+    ) -> None:
+        """`skills` dans un lab.fr.yaml serait ignoré : c'est le même défaut."""
+        _catalogue(tmp_path)
+        dossier = _lab(tmp_path, "lab-a")
+        (dossier / "lab.fr.yaml").write_text(
+            "id: lab-a\ntitle: Titre\ndescription: Desc\nskills: [demo]\n",
+            encoding="utf-8",
+        )
+        rapport = validate_unknown_keys(tmp_path)
+        assert [i.params["field"] for i in rapport.issues] == ["skills"]
+
+    def test_une_traduction_de_meta_ne_peut_pas_reordonner(
+        self, tmp_path: Path
+    ) -> None:
+        """`labs:` dans meta.fr.yml serait ignoré : l'ordre vit dans meta.yml."""
+        _catalogue(tmp_path)
+        (tmp_path / "meta.fr.yml").write_text(
+            "sections:\n  - id: bloc\n    title: Bloc\n    labs:\n      - bloc/lab-a\n",
+            encoding="utf-8",
+        )
+        rapport = validate_unknown_keys(tmp_path)
+        assert [i.params["field"] for i in rapport.issues] == ["sections[].labs"]
+
+    def test_un_fichier_illisible_n_est_pas_son_sujet(self, tmp_path: Path) -> None:
+        """Un YAML cassé est signalé ailleurs ; ici, il n'y a rien à en dire."""
+        _catalogue(tmp_path)
+        dossier = tmp_path / "labs" / "bloc" / "casse"
+        dossier.mkdir(parents=True)
+        (dossier / "lab.yaml").write_text("id: [non fermé\n", encoding="utf-8")
+        assert validate_unknown_keys(tmp_path).ok
+
+
+# ── #126 : le verdict arrive jusqu'à l'apprenant ─────────────────────────────
+#
+# Les tests ci-dessus prouvent le calcul ; ceux-ci prouvent le câblage. Une
+# fonction juste que personne n'appelle laisse le défaut d'origine intact.
+
+
+@pytest.fixture
+def anglais(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Fige la langue du rendu, que la machine soit francophone ou non.
+
+    `get_lang()` retombe sur `$LANG` : sans ce verrou, ces tests passeraient
+    ici et échoueraient sur un poste anglophone, ou l'inverse.
+    """
+    from dsoxlab.i18n import get_lang, set_lang
+
+    precedent = get_lang()
+    monkeypatch.setenv("DSOXLAB_LANG", "en")
+    set_lang("en")
+    yield
+    set_lang(precedent)
+
+
+@pytest.mark.usefixtures("anglais")
+class TestVerdictAffiche:
+    def _resultat(self, lab_id: str, score: int) -> dict[str, object]:
+        return {
+            "lab_id": lab_id,
+            "section": "demo",
+            "score": score,
+            "max_score": 100,
+            "passed_tests": 2,
+            "total_tests": 5,
+            "hints_used": 0,
+            "validated_at": "2026-08-21T10:00:00",
+        }
+
+    def _rendu(self, resultats: list[dict[str, object]], seuils: dict[str, int]) -> str:
+        from dsoxlab.reporting.console import console, print_scores_table
+
+        with console.capture() as capture:
+            print_scores_table(resultats, seuils)  # type: ignore[arg-type]
+        return " ".join(capture.get().split())
+
+    def test_le_tableau_des_scores_nomme_le_recale(self) -> None:
+        rendu = self._rendu([self._resultat("mock-exam", 40)], {"mock-exam": 70})
+        assert "Verdict" in rendu
+        assert "failed (70%)" in rendu
+
+    def test_le_tableau_des_scores_nomme_celui_qui_est_recu(self) -> None:
+        rendu = self._rendu([self._resultat("mock-exam", 85)], {"mock-exam": 70})
+        assert "passed (70%)" in rendu
+
+    def test_sans_examen_le_tableau_ne_porte_pas_la_colonne(self) -> None:
+        """Un catalogue sans examen n'a pas à afficher une colonne de tirets."""
+        rendu = self._rendu([self._resultat("lab-a", 100)], {})
+        assert "Verdict" not in rendu
+
+    def test_submit_dit_a_l_apprenant_qu_il_a_echoue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Le défaut d'origine, vu depuis la commande : 40/100 sans un mot.
+
+        `_run_check` est remplacé pour ne pas lancer pytest : ce qu'on éprouve
+        ici est le rendu du verdict, pas la notation, déjà couverte ailleurs.
+        """
+        from typer.testing import CliRunner
+
+        from dsoxlab import cli
+        from dsoxlab.services.lab_service import CheckResult
+
+        _catalogue(tmp_path, category="demo")
+        _lab(tmp_path, "mock-exam", extra="exam_passing_score: 70\n")
+
+        monkeypatch.setattr(
+            cli,
+            "_run_check",
+            lambda *a, **k: (CheckResult(False, "", 2, 5), 40, 100),
+        )
+        resultat = CliRunner().invoke(
+            cli.app, ["submit", "mock-exam", "--lab-home", str(tmp_path)]
+        )
+
+        assert resultat.exit_code == 0, resultat.output
+        sortie = " ".join(resultat.output.split())
+        assert "Exam failed" in sortie, sortie
+        assert "70%" in sortie, sortie
+
+    def test_submit_reste_muet_sur_un_lab_ordinaire(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Aucun seuil déclaré : pas de verdict, et surtout pas « recalé »."""
+        from typer.testing import CliRunner
+
+        from dsoxlab import cli
+        from dsoxlab.services.lab_service import CheckResult
+
+        _catalogue(tmp_path, category="demo")
+        _lab(tmp_path, "lab-a")
+
+        monkeypatch.setattr(
+            cli,
+            "_run_check",
+            lambda *a, **k: (CheckResult(False, "", 2, 5), 40, 100),
+        )
+        resultat = CliRunner().invoke(
+            cli.app, ["submit", "lab-a", "--lab-home", str(tmp_path)]
+        )
+
+        assert resultat.exit_code == 0, resultat.output
+        assert "Exam" not in resultat.output, resultat.output

--- a/tests/test_json_schemas.py
+++ b/tests/test_json_schemas.py
@@ -43,6 +43,7 @@ from dsoxlab.models.schema_version import (
     SCHEMA_VERSION_FIELD,
     SUPPORTED_SCHEMA_VERSION,
 )
+from dsoxlab.validators.contract import KNOWN_LAB_KEYS, KNOWN_META_KEYS
 from dsoxlab.validators.metadata import _VALID_LAB_TYPES
 
 RACINE = Path(__file__).resolve().parent.parent
@@ -246,6 +247,71 @@ def test_la_confrontation_echoue_dans_les_deux_sens() -> None:
 
     with pytest.raises(AssertionError, match="aucun nœud du schéma ne décrit"):
         _confronter(schema, noeuds, {"data": {"connu"}, "surprise": {"x"}}, "faux")
+
+
+# ── le garde-fou embarqué dit-il la même chose que le schéma publié ? ────────
+#
+# `validate-structure` refuse les clés inconnues, et il lui faut donc la liste
+# des clés connues À L'EXÉCUTION. Les schémas JSON la portent déjà — c'est le
+# sens de leur `additionalProperties: false` — mais `schemas/` ne fait pas
+# partie de la roue : le paquet ne peut pas les lire chez l'utilisateur. La
+# liste est donc recopiée dans `validators/contract.py`, et une copie non
+# tenue par un test aurait dérivé en trois versions, exactement comme les
+# schémas eux-mêmes avant ce module.
+
+
+def chemins_du_schema(schema: dict[str, Any], prefixe: str = "") -> set[str]:
+    """Les chemins pointés qu'un schéma décrit — `runtime.targets[].host`.
+
+    On descend dans `properties` et dans `items` (une liste ajoute `[]` au
+    chemin). On ne descend **pas** dans `additionalProperties` : un nœud qui
+    en porte un est ouvert, ses clés appartiennent au catalogue, et le
+    contrôle n'a rien à y dire. C'est ce qui laisse libres `targets[].roles`,
+    `services[].env` et `infra.providers.<provider>`.
+    """
+    chemins: set[str] = set()
+    proprietes = schema.get("properties")
+    if isinstance(proprietes, dict):
+        for cle, sous in proprietes.items():
+            chemin = f"{prefixe}.{cle}" if prefixe else str(cle)
+            chemins.add(chemin)
+            if isinstance(sous, dict):
+                chemins |= chemins_du_schema(sous, chemin)
+    items = schema.get("items")
+    if isinstance(items, dict):
+        chemins |= chemins_du_schema(items, f"{prefixe}[]")
+    return chemins
+
+
+@pytest.mark.parametrize(
+    ("nom", "constante"),
+    [
+        ("lab.schema.json", KNOWN_LAB_KEYS),
+        ("meta.schema.json", KNOWN_META_KEYS),
+    ],
+)
+def test_les_cles_connues_du_paquet_suivent_le_schema(
+    nom: str, constante: frozenset[str]
+) -> None:
+    assert chemins_du_schema(_charger(nom)) == set(constante), (
+        f"{nom} et validators/contract.py ne décrivent plus le même contrat. "
+        "Le schéma fait foi : aligne la constante."
+    )
+
+
+def test_la_derivation_voit_les_listes_et_saute_les_noeuds_ouverts() -> None:
+    """Une dérivation cassée rendrait le test précédent vert à vide."""
+    schema = {
+        "properties": {
+            "plat": {"type": "string"},
+            "bloc": {"properties": {"dedans": {"type": "string"}}},
+            "liste": {"items": {"properties": {"champ": {"type": "string"}}}},
+            "libre": {"additionalProperties": {"properties": {"cache": {}}}},
+        }
+    }
+    assert chemins_du_schema(schema) == {
+        "plat", "bloc", "bloc.dedans", "liste", "liste[].champ", "libre",
+    }
 
 
 # ── énumérés, versions, identité ─────────────────────────────────────────────

--- a/tests/test_yaml_contract.py
+++ b/tests/test_yaml_contract.py
@@ -81,6 +81,7 @@ def test_empty_validation_block_falls_back_to_defaults(tmp_path: Path) -> None:
         ("targets holds a scalar", VALID_LAB + "  targets:\n    - 42\n"),
         ("roles is a scalar", VALID_LAB + "  targets:\n    - name: a\n      host: h.lab\n      roles: nope\n"),
         ("bloc is not a number", VALID_LAB + "bloc: abc\n"),
+        ("exam_passing_score is not a number", VALID_LAB + "exam_passing_score: oui\n"),
         ("skills is a scalar", VALID_LAB.replace("skills: [demo]", "skills: 42")),
     ],
 )

--- a/tests_e2e/test_installation.py
+++ b/tests_e2e/test_installation.py
@@ -26,6 +26,10 @@ DONNEES_ATTENDUES = (
     "dsoxlab/py.typed",
     # Le catalogue de démonstration : le premier lab que voit un utilisateur.
     "dsoxlab/templates/demo/meta.yml",
+    # Sa traduction française. Le catalogue packagé est l'exemple de référence
+    # du mécanisme `meta.<langue>.yml` : absent de la roue, il l'enseignerait
+    # sans le montrer, et une session française lirait des titres anglais.
+    "dsoxlab/templates/demo/meta.fr.yml",
     "dsoxlab/templates/demo/labs/demo/premiers-pas/lab.yaml",
     "dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/hints.yaml",
     "dsoxlab/templates/demo/labs/demo/premiers-pas/challenge/tests/test_functional.py",

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.53"
+version = "0.1.54"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
# Summary

The same question asked twice: **does the engine do what the contract declares?**

**#87** — `linux` was hardcoded in the engine, so a lab declaring `section: linux`
had its section overwritten. That violates the project's first invariant.

**#126** — four fields authors write and the engine ignores entirely. The
expensive one is `exam_passing_score`, in **11 files** — the capstones and drills
— each with a comment explaining the chosen threshold. Eleven exam labs believed
they set a passing score. None did.

## ⚠️ This turns `validate-structure` red on two catalogues, on purpose

Verified after the change, exit codes measured without a pipe:

```
ansible-training        rc=0   113 labs   ✔ All labs are valid
linux-dsoxlab-training  rc=1    84 labs   ✘ runtime.hosts_required  (1 lab)
terraform-training      rc=1    87 labs   ✘ sections[].title_en, sections[].description_en
```

**That is the expected result, not a regression.** No other check family fires on
either repository, so both were green before and are red now solely because of
the dead keys #126 names. The message points at the fix:

```
✘ meta.yml: « sections[].description_en » ne fait pas partie du contrat, et
  dsoxlab l'ignore. La clé la plus proche qu'il lit vraiment, à ce niveau,
  est « sections[].description ».
```

The patches that make them green again are written in the issue thread and were
**not applied** — those repositories are not this PR's to modify, and they carry
uncommitted work. One is a single deleted line; the other is mechanical and was
verified on a copy (`rc=0`, 87 labs).

## The four fields, decided one by one

**`exam_passing_score` — honoured.** An integer **percentage** of the lab's scale,
not absolute points: the scale is free per lab, so an absolute bar would mean a
different thing from one lab to the next. All 11 real labs use a scale of 100, so
both readings coincide there. Read by `show` before the exam, turned into a
pass/fail verdict by `submit`, and shown as a *Verdict* column by `scores` — a
column that only appears when the catalogue actually holds an exam. Comparison is
exact integer arithmetic (`score × 100 ≥ threshold × scale`), so 139/200 fails a
70 % bar instead of rounding up into it.

**`runtime.hosts_required` — removed.** The lab that declares it already declares
two `targets[]`, each with a `host`. The count is derivable, and every FQDN is
already validated against `meta.yml: infra.hosts[]`. A second place to write the
same number can only drift from the first.

**`sections[].title_en` / `description_en` — removed, and given a real home.**
A **`meta.<lang>.yml`** beside `meta.yml` now overrides `repo.title`,
`repo.description`, `sections[].title` and `sections[].description`, matched by
`id` rather than by position. It mirrors `lab.<lang>.yaml` and `course.<lang>.yaml`,
where a per-field language suffix would have grown one column per language.

**This closed a real hole, not just a dead key.** All three catalogues write
French section titles, and those titles are the bloc names `progress` prints — so
an English session read French. Reproduced before the fix:

```console
$ DSOXLAB_LANG=en dsoxlab progress
┃ Bloc                     ┃ Done ┃
│ Découvrir Terraform      │ 0/8  │
```

## The guard, which is the actual deliverable

Fixing four fields takes an afternoon; a fifth would install itself next month.
`validate-structure` now re-reads `meta.yml`, `lab.yaml` and their translation
files from disk and names every key the engine will never read, with the closest
key it *does* read **at the same level**. It does not descend into the contract's
free-form mappings (`runtime.targets[].roles`, `runtime.services[].env`,
`infra.providers.<provider>`).

The parser stays tolerant — that is a v1 guarantee — so this is a lint, and the
docs say so. The known keys live as dotted-path frozensets in
`validators/contract.py`, and `tests/test_json_schemas.py` derives the same set
from `schemas/*.json` and demands equality, so the two cannot drift.

One wording call: the message says "the closest key it does read is X", never
"did you mean X". Measured, `title_en`→`title` and `hosts_required`→
`snapshot_required` both score 0.77 — the first is the author's intent, the
second a coincidence, and no cutoff separates them. Stating a fact stays true in
both cases.

## #87, proven mechanically rather than claimed

`LabDefinition.section` is `str | None`; the parser no longer substitutes a
domain name. A second, unlisted piece of domain logic went too:
`reporting/console.py` mapped `linux`/`ansible`/`terraform`/`kubernetes`/`docker`/
`git` and `l1`/`l2`/`lfcs`/`rhcsa` to colours. Colour now derives from the name
itself through `crc32` over a fixed palette — deterministic across runs, where
`hash()` of a `str` is not, and available to *every* catalogue instead of the six
on the list.

`TestMoteurAgnostique` parses the package and asserts no non-docstring literal in
`models/`, `discovery/`, `reporting/` or `validators/` equals a domain name, and
that `linux` and `kubernetes` — neither of which names a tool dsoxlab invokes —
appear nowhere as literals. A third test proves the guard bites and that it does
ignore docstrings.

Of the 284 live labs, all declare a `section` explicitly and none declares a
domain name, so no catalogue changes behaviour.

## Type of change

- [x] Bug fix
- [x] New feature

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — no issues in 57 source files
- [x] `uv run pytest` — **478 passed** (440 before, +38); `tests_e2e` — **16 passed**
- [x] The engine stays domain-agnostic — that is #87's subject, and a test holds it
- [x] No hardcoded personal path or host
- [x] Manually tested against the **three** lab repositories, read-only. Their
      `git status` is byte-identical to the state recorded before starting, and
      the three `meta.yml` mtimes are still weeks old.

### When behavior changes

- [x] Both CHANGELOG files updated; version **0.1.54**; `uv.lock` regenerated

### When a command or option is added, removed or changed

- [x] i18n keys appended to **both** string tables;
      `test_i18n_catalogs_share_the_same_keys` covers EN/FR parity
- [x] `fullhelp` renders the two new lines in both languages
- [x] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched — N/A

### When the declarative contract changes

- [x] Both READMEs and `docs/contract-v1.md` / `.fr.md` updated: new
      `exam_passing_score` and `meta.<lang>.yml` sections, rewritten unknown-keys
      paragraph
- [x] `schemas/lab.schema.json` updated; `fuzz/corpus/lab_yaml/capstone-exam-score.yaml`
      seed and three dictionary tokens added
- [x] A malformed value still raises inside the parser contract — a
      `test_yaml_contract` case proves a non-integer threshold stays within
      `(KeyError, ValueError, yaml.YAMLError)`

## Mutations played

Six, each injected, run, shown red, reverted. The one worth quoting reproduced
the original defect verbatim: disabling the submit verdict block brings back
*"Submission recorded: 40/100 pts"*, without a word about failing.

The schema-derivation helper has its own bite test, so the schema equality test
cannot pass on an empty derivation.

## A process note worth keeping

`_(anomalie.key, **anomalie.params)` raised `TypeError: _() got multiple values
for argument 'key'` because an issue parameter was itself named `key`. **The unit
tests passed** — they never went through `_()`. Only running a real catalogue
caught it. The parameter is now `field`.

## Decisions worth reviewing

1. **`submit` still exits 0 on a failed exam.** It never exited non-zero, even on
   failing tests, and changing that could break someone's script. But a mock exam
   is exactly where a CI-usable exit code would earn its keep. Left alone
   deliberately; easy to flip.
2. **`lab.<lang>.yaml` may carry an `id` nothing reads.** All 284 translation
   files carry one; flagging them would produce 265 issues for something
   harmless. The stricter move is to *use* it — refuse a translation whose `id`
   disagrees with its `lab.yaml`, catching a file copied from the wrong lab.
3. **A fifth dead field exists, of a different kind: `sections[].description`.**
   It is in the schema, parsed into `SectionDefinition`, and displayed by no
   command — read by the engine, used by nothing. Out of scope here; the next one
   to decide.
4. **The known-key sets are a copy of the schemas, not the schemas themselves.**
   Reading `schemas/*.json` at runtime would need them in the wheel, which means
   either moving them (breaking the published `raw.githubusercontent.com` URL
   every author's editor line points at) or a `force-include` absent in editable
   installs. A test holds the copy instead.
5. **JSON output changed without a `SCHEMA` bump** — additive only, following the
   document's existing convention.

## Related issues

Closes #87
Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
