### PR TITLE
fix(infra/snapshot): des points de reprise externes, et un « required » qui engage (0.1.56)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,67 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.56] - 2026-08-21
+
+### Corrigé
+
+- **Les snapshots ne fonctionnaient sur aucune VM dsoxlab, et l'échec était
+  muet.** Le template Terraform packagé démarre ses machines en UEFI — les
+  images cloud modernes n'embarquent plus de bootloader BIOS — et libvirt refuse
+  les snapshots **internes** sur un firmware pflash : `internal snapshots of a
+  VM with pflash based firmware are not supported`. C'est exactement ce que
+  demandait `infra/snapshot/kvm.py`. Il prend désormais un snapshot **externe**
+  (`--disk-only --atomic`), vérifié sur un domaine UEFI réel.
+
+- **Le chemin du fichier de recouvrement est passé, plus deviné.** Sur un disque
+  `type='volume'` — la forme que produit le template — libvirt refuse de le
+  déduire lui-même (`cannot generate external snapshot name for disk 'vda'
+  without source`), donc un snapshot externe naïf échouait tout autant que
+  l'interne. `create` passe maintenant un `--diskspec` par disque inscriptible.
+  Le cdrom cloud-init en est exclu : lui en donner un ferait échouer tout le
+  snapshot.
+
+- **`run` échoue désormais quand un point de reprise exigé ne peut pas être
+  pris.** C'est le changement qui compte le plus. `runtimes/vm.py` avalait
+  l'échec dans un `logger.warning`, et aucun `logging.basicConfig` n'existe dans
+  ce paquet : un lab qui déclare `snapshot_required: true` démarrait **sans le
+  filet qu'il réclame**, `run` sortait en 0, et l'apprenant l'apprenait au
+  moment d'en avoir besoin. C'est ce silence qui a laissé la fonctionnalité
+  cassée sans que personne ne le voie. Un lab qui se passe de filet déclare
+  toujours `snapshot_required: false`, qui est le défaut et ce que déclarent
+  aujourd'hui tous les labs de tous les catalogues.
+
+- **Le retour arrière est une autre opération, et il est écrit comme telle.**
+  libvirt refuse `snapshot-revert` sur un snapshot externe (`Invalid target
+  domain state 'disk-snapshot'`). `revert` arrête désormais la machine, vide le
+  fichier de recouvrement par l'API de stockage de libvirt et la redémarre : le
+  chemin du disque ne change pas, donc le XML du domaine n'est jamais réécrit et
+  le point de reprise reste utilisable. Il refuse d'agir quand le point de
+  reprise n'est plus la couche du dessus, plutôt que de jeter le mauvais fichier.
+
+- **`clean` et `destroy` connaissent le fichier de recouvrement.** Un snapshot
+  externe laisse un artefact dont Terraform n'a jamais entendu parler : il n'est
+  dans aucun state, et le volume qu'il recouvre est supprimé sous lui. `clean`
+  retire le point de reprise par `snapshot-delete`, qui refusionne le
+  recouvrement et efface le fichier ; `destroy` purge tous les points de reprise
+  **avant** que Terraform ne passe, parce qu'après l'`undefine` la métadonnée a
+  disparu avec le domaine et le fichier devient introuvable. Même famille de
+  défaut que les domaines orphelins de #107.
+
+### Ajouté
+
+- **`reset` donne enfin un effet observable à `snapshot_required`.** Sur un lab
+  qui le déclare, `dsoxlab reset` ramène la machine à son point de reprise au
+  lieu de rejouer le `cleanup.yaml`, puis rejoue le `setup.yaml`. Les labs qui
+  ne le déclarent pas gardent exactement le comportement précédent.
+
+- **Le contrat dit ce qu'un point de reprise capture, et ce qu'il ne capture
+  pas.** `docs/contract-v1.fr.md`, sa version anglaise et
+  `schemas/lab.schema.json` posent la frontière disque/mémoire : le retour
+  arrière redémarre depuis un état disque cohérent, il ne replace pas la machine
+  dans la seconde d'avant. Un lab dont l'exercice repose sur un processus en
+  cours doit le relancer.
+
 ## [0.1.53] - 2026-08-21
 
 ### Modifié

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.56] - 2026-08-21
+
+### Fixed
+
+- **Snapshots worked on no dsoxlab VM at all, and the failure was silent.** The
+  packaged Terraform template boots its machines in UEFI — modern cloud images
+  no longer ship a legacy BIOS bootloader — and libvirt refuses *internal*
+  snapshots on pflash firmware: `internal snapshots of a VM with pflash based
+  firmware are not supported`. `infra/snapshot/kvm.py` asked for exactly that.
+  It now takes an **external** snapshot (`--disk-only --atomic`), verified on a
+  real UEFI domain.
+
+- **The overlay path is passed, not guessed.** On a `type='volume'` disk — the
+  form the template produces — libvirt refuses to derive the name itself
+  (`cannot generate external snapshot name for disk 'vda' without source`), so
+  a naive external snapshot fails just as the internal one did. `create` now
+  passes one `--diskspec` per writable disk. The cloud-init cdrom is left out:
+  giving it a diskspec would fail the whole snapshot.
+
+- **`run` now fails when a required checkpoint cannot be taken.** This is the
+  change that matters most. `runtimes/vm.py` swallowed the failure in a
+  `logger.warning`, and no `logging.basicConfig` exists in this package: a lab
+  declaring `snapshot_required: true` started **without the safety net it asks
+  for**, `run` exited 0, and the learner found out when they needed it. That
+  silence is what let the feature stay broken unseen. A lab that can live
+  without a net still declares `snapshot_required: false`, which is the default
+  and what every lab in every catalogue declares today.
+
+- **Rolling back is a different operation, and it is implemented as one.**
+  libvirt refuses `snapshot-revert` on an external snapshot (`Invalid target
+  domain state 'disk-snapshot'`). `revert` now stops the machine, empties the
+  overlay through libvirt's own storage API and restarts it — the disk path
+  never changes, so the domain XML is never rewritten and the checkpoint stays
+  usable. It refuses to run when the checkpoint is no longer the disk's top
+  layer, rather than dropping the wrong file.
+
+- **`clean` and `destroy` know about the overlay file.** An external snapshot
+  leaves an artefact Terraform has never heard of: it is in no state file, and
+  the volume beneath it gets deleted from under it. `clean` drops the
+  checkpoint through `snapshot-delete`, which merges the overlay back and
+  removes the file; `destroy` purges every checkpoint **before** Terraform runs,
+  because after the `undefine` the metadata is gone with the domain and the file
+  becomes untraceable. Same defect family as the orphan domains of #107.
+
+### Added
+
+- **`reset` finally gives `snapshot_required` an observable effect.** On a lab
+  that declares it, `dsoxlab reset` rolls the machine back to its checkpoint
+  instead of replaying `cleanup.yaml`, then replays `setup.yaml`. Labs that do
+  not declare it keep the exact previous behaviour.
+
+- **The contract says what a checkpoint captures, and what it does not.**
+  `docs/contract-v1.md`, its French counterpart and `schemas/lab.schema.json`
+  now state the disk/memory boundary: rolling back reboots from a consistent
+  disk state, it does not put the machine back in the second before. A lab whose
+  exercise depends on a running process must replay it.
+
 ## [0.1.53] - 2026-08-21
 
 ### Changed

--- a/docs/contract-v1.fr.md
+++ b/docs/contract-v1.fr.md
@@ -169,7 +169,7 @@ publiable.
 | `type` | non | énuméré | `shell` | `shell`, `vm`, et les alias de rétro-compatibilité `kvm` et `incus`. Écrire `vm` dans les nouveaux labs. |
 | `targets` | pour `vm` | liste de mappings | `[]` | Ne doit pas être vide pour `vm`. |
 | `default` | non | chaîne | | Doit correspondre à un `targets[].name`. |
-| `snapshot_required` | non | booléen | `false` | |
+| `snapshot_required` | non | booléen | `false` | Engage l'outil, ne l'informe pas. Voir plus bas. |
 | `session` | non | énuméré | `target` | `target` : session SSH sur l'hôte. `local` : sous-shell local. N'a de sens que pour `vm`. |
 | `workdir` | pour `shell` | chaîne | `challenge/work` | Ne doit pas être vide pour `shell`. Ignoré pour `vm`. |
 | `fixtures` | non | liste de chaînes | `[]` | Chemins relatifs à `<lab>/fixtures/`, préservés sous `workdir`. |
@@ -179,6 +179,40 @@ publiable.
 Une fixture **non déclarée** n'est **pas copiée**, même présente dans
 `fixtures/`. Un chemin absolu, ou qui contient `..`, est refusé : une fixture
 n'écrit jamais hors du workdir.
+
+#### `runtime.snapshot_required`
+
+Ce champ **engage l'outil**. Déclarer `true` change trois commandes :
+
+| Commande | Avec `snapshot_required: true` |
+| --- | --- |
+| `run` | Prend un point de reprise **avant** le `setup.yaml`, et **échoue** s'il n'y arrive pas. Le lab ne démarre pas sans le filet qu'il réclame. |
+| `reset` | Ramène la machine au point de reprise au lieu de rejouer le `cleanup.yaml`, puis rejoue le `setup.yaml`. |
+| `clean` | Retire le point de reprise, et avec lui le fichier de recouvrement qu'il avait créé. |
+
+Un lab qui se passe de filet déclare `false`, ce qui est le défaut et ce que
+déclarent aujourd'hui tous les labs de tous les catalogues.
+
+**Ce qu'un point de reprise dsoxlab capture, et ce qu'il ne capture pas.** Sur
+le provider `kvm`, c'est un **snapshot externe de disque** (`virsh
+snapshot-create-as --disk-only --atomic`), jamais un snapshot interne : le
+template Terraform packagé démarre ses machines en UEFI, et libvirt refuse les
+snapshots internes sur un firmware pflash. Trois conséquences, écrites ici
+plutôt que laissées à découvrir :
+
+- **le disque est capturé, la mémoire ne l'est pas.** Le retour arrière
+  redémarre la machine depuis un état disque cohérent, il ne la replace pas
+  dans la seconde d'avant. Pour un lab c'est le bon compromis, mais un lab dont
+  l'exercice repose sur un processus en cours doit le relancer, pas l'attendre ;
+- **un point de reprise crée un fichier de recouvrement** à côté du disque.
+  `clean` et `destroy` le retirent, rien d'autre : un lab qui prend un point de
+  reprise et n'est jamais nettoyé en laisse un jusqu'à la destruction de
+  l'infrastructure ;
+- **revenir en arrière n'est pas un `virsh snapshot-revert`.** dsoxlab arrête la
+  machine, vide le recouvrement et la redémarre. Le point de reprise survit,
+  donc il resert ; mais il doit rester la couche du dessus du disque, et dsoxlab
+  refuse le retour arrière quand ce n'est plus le cas, plutôt que de jeter le
+  mauvais fichier.
 
 #### `runtime.targets[]`
 

--- a/docs/contract-v1.md
+++ b/docs/contract-v1.md
@@ -168,7 +168,7 @@ publishable.
 | `type` | no | enum | `shell` | `shell`, `vm`, and the backward-compatible aliases `kvm` and `incus`. Write `vm` in new labs. |
 | `targets` | for `vm` | list of mappings | `[]` | Must not be empty for `vm`. |
 | `default` | no | string | — | Must match one `targets[].name`. |
-| `snapshot_required` | no | boolean | `false` | |
+| `snapshot_required` | no | boolean | `false` | Binding, not informational. See below. |
 | `session` | no | enum | `target` | `target` = SSH session on the host; `local` = local subshell. Only meaningful for `vm`. |
 | `workdir` | for `shell` | string | `challenge/work` | Must not be empty for `shell`. Ignored for `vm`. |
 | `fixtures` | no | list of strings | `[]` | Paths relative to `<lab>/fixtures/`, preserved under `workdir`. |
@@ -178,6 +178,38 @@ publishable.
 A fixture **not listed** is **not copied**, even if it sits in `fixtures/`. An
 absolute path, or one containing `..`, is refused: a fixture never writes
 outside the workdir.
+
+#### `runtime.snapshot_required`
+
+This field **binds the tool**. Declaring `true` changes three commands:
+
+| Command | With `snapshot_required: true` |
+| --- | --- |
+| `run` | Takes a checkpoint **before** `setup.yaml`, and **fails** if it cannot. The lab does not start without the safety net it asks for. |
+| `reset` | Rolls the machine back to the checkpoint instead of replaying `cleanup.yaml`, then replays `setup.yaml`. |
+| `clean` | Drops the checkpoint, and the overlay file it created with it. |
+
+A lab that can live without a safety net declares `false`, which is the
+default and what every lab in every catalogue declares today.
+
+**What a dsoxlab checkpoint captures — and what it does not.** On the `kvm`
+provider it is an **external disk snapshot** (`virsh snapshot-create-as
+--disk-only --atomic`), never an internal one: the packaged Terraform template
+boots its machines in UEFI, and libvirt refuses internal snapshots on pflash
+firmware. Three consequences the contract states rather than leaves to be
+discovered:
+
+- **the disk is captured, the memory is not.** Rolling back reboots the
+  machine from a consistent disk state; it does not put it back in the second
+  before. For a lab that is the right trade-off, but a lab whose exercise
+  depends on a running process must replay it, not expect it back;
+- **a checkpoint creates an overlay file** next to the disk. `clean` and
+  `destroy` remove it; nothing else does, so a lab that takes a checkpoint and
+  is never cleaned leaves one behind until the infrastructure is destroyed;
+- **rolling back is not `virsh snapshot-revert`.** dsoxlab stops the machine,
+  empties the overlay and restarts it. The checkpoint survives, so it can be
+  used again; but it must still be the disk's top layer, and dsoxlab refuses to
+  roll back when it is not, rather than dropping the wrong file.
 
 #### `runtime.targets[]`
 

--- a/fuzz/corpus/lab_yaml/vm-snapshot-requis.yaml
+++ b/fuzz/corpus/lab_yaml/vm-snapshot-requis.yaml
@@ -1,0 +1,26 @@
+id: l4-selinux-booleans
+title: Recover a broken SELinux policy
+level: advanced
+lab_type: challenge
+section: linux
+description: A lab that breaks the machine on purpose, so it asks for a net.
+skills: [selinux, semanage, restorecon]
+distros: [alma10]
+doc_url: https://blog.stephane-robert.info/docs/linux/selinux/
+difficulty: advanced
+estimated_time: "45m"
+runtime:
+  type: vm
+  targets:
+    - name: rhel
+      host: alma-rhcsa-1.lab
+  default: rhel
+  session: target
+  # Engage l'outil : run échoue si le point de reprise ne peut pas être pris,
+  # reset y revient au lieu de rejouer le cleanup.yaml, clean le retire avec
+  # son fichier de recouvrement.
+  snapshot_required: true
+validation:
+  functional: true
+  security: true
+  persistence_after_reboot: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.53"
+version = "0.1.56"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/lab.schema.json
+++ b/schemas/lab.schema.json
@@ -136,7 +136,7 @@
         "snapshot_required": {
           "type": "boolean",
           "default": false,
-          "description": "Take a snapshot before setup.yaml, so the lab can be rolled back."
+          "description": "Take a disk checkpoint before setup.yaml. Binding, not informational: run FAILS if the checkpoint cannot be taken, reset rolls back to it instead of replaying cleanup.yaml, and clean removes it along with its overlay file. On kvm it is an external snapshot (--disk-only): the disk is captured, the memory is not."
         },
         "session": {
           "type": "string",

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -1832,6 +1832,7 @@ def destroy(
         typer.confirm(_("confirm_destroy", provider=provider), abort=True)
 
     info(_("destroy_starting", provider=provider))
+    _purge_snapshots_before_destroy(repo_meta)
     try:
         # init est rapide en destroy (provider déjà téléchargé) mais
         # nécessaire si l'utilisateur a fait un upgrade dsoxlab entre temps
@@ -1871,6 +1872,35 @@ def destroy(
         info(_("ssh_fragment_removed", repo=repo_meta.id))
 
     success(_("destroy_done"))
+
+
+def _purge_snapshots_before_destroy(repo_meta: RepoMetadata) -> None:
+    """Retire les points de reprise **avant** que Terraform ne passe.
+
+    Un snapshot externe laisse un fichier de recouvrement que Terraform ne
+    connaît pas : il n'est dans aucun state, et le volume qu'il recouvre est
+    supprimé sous lui. Il faut donc le retirer tant que l'hyperviseur sait
+    encore qu'il existe — après l'``undefine``, la métadonnée du snapshot a
+    disparu avec le domaine, et le fichier devient introuvable autrement qu'à
+    la main.
+
+    Best-effort : un dépôt sans labs ``vm``, un provider sans backend snapshot
+    ou un hyperviseur muet ne doivent pas empêcher une destruction.
+    """
+    from .infra import snapshot as snapshot_infra
+
+    hosts = snapshot_infra.host_names(repo_meta)
+    if not hosts:
+        return
+    try:
+        retires = snapshot_infra.purge(repo_meta, hosts)
+    except Exception as exc:  # noqa: BLE001 — la destruction prime sur le ménage
+        warn(_("snapshot_purge_failed", error=str(exc)))
+        return
+    if retires:
+        info(_("snapshot_purge_done", count=len(retires)))
+        for chemin in retires:
+            info(f"  − {chemin}")
 
 
 def _handle_orphans_after_destroy(

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -178,6 +178,12 @@ STRINGS: dict[str, str] = {
     "ssh_fragment_removed": "SSH fragment for [bold]{repo}[/bold] removed: it pointed at destroyed machines.",
     "destroy_done":        "Infrastructure destroyed.",
     "destroy_failed":      "Destruction failed: {error}",
+    "snapshot_purge_done":
+        "{count} snapshot overlay file(s) removed before destruction: Terraform "
+        "does not know about them and would have left them behind.",
+    "snapshot_purge_failed":
+        "Snapshots could not be purged ({error}). If this infrastructure had "
+        "any, their overlay files stay in the storage pool after destruction.",
     "status_no_hosts":     "meta.yml declares no hosts.",
     "status_no_key":       "SSH private key not found: {path}. Run 'dsoxlab instructor bootstrap' first.",
     "status_checking":     "Checking SSH connectivity on {count} host(s)…",
@@ -825,6 +831,25 @@ silent.
     "err_snapshot_provider_unsupported":
         "Snapshots are not implemented yet for provider '{provider}'. "
         "See src/dsoxlab/infra/snapshot/__init__.py to add a backend.",
+    "err_snapshot_no_disk":
+        "Snapshot '{snapshot}' of domain {domain} froze no disk: there is "
+        "nothing to roll back to. Take it again with dsoxlab run.",
+    "err_snapshot_no_base":
+        "Snapshot '{snapshot}' of domain {domain}: cannot tell which disk "
+        "'{disk}' overlays. Rolling back would throw away the wrong file.",
+    "err_snapshot_no_capacity":
+        "libvirt does not report the size of {path}: an overlay cannot be "
+        "recreated without it.",
+    "err_snapshot_not_top_layer":
+        "Snapshot '{snapshot}' is no longer the top layer of {domain} disk "
+        "'{disk}': it writes to {found}, the snapshot created {expected}. "
+        "Rolling back here would drop changes the snapshot never covered.",
+    "err_vm_snapshot_required":
+        "Lab {lab_id} declares snapshot_required: true and the checkpoint "
+        "could not be taken on {host}: {error}\n"
+        "The lab is NOT started, because it would run without the safety net "
+        "it asks for. Either fix the hypervisor, or declare "
+        "snapshot_required: false in its lab.yaml.",
     "err_runtime_unavailable":
         "Runtime '{runtime}' is not available on this machine. Install the "
         "dependencies (`dsoxlab instructor bootstrap`), or pick a lab that "

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -179,6 +179,13 @@ STRINGS: dict[str, str] = {
     "ssh_fragment_removed": "Fragment SSH de [bold]{repo}[/bold] retiré : il pointait des machines détruites.",
     "destroy_done":        "Infrastructure détruite.",
     "destroy_failed":      "Destruction échouée : {error}",
+    "snapshot_purge_done":
+        "{count} fichier(s) de recouvrement de snapshot retiré(s) avant la "
+        "destruction : Terraform ne les connaît pas et les aurait laissés.",
+    "snapshot_purge_failed":
+        "Purge des snapshots impossible ({error}). Si cette infrastructure en "
+        "portait, leurs fichiers de recouvrement resteront dans le pool de "
+        "stockage après la destruction.",
     "status_no_hosts":     "Aucun hôte déclaré dans meta.yml.",
     "status_no_key":       "Clé SSH privée introuvable : {path}. Lance 'dsoxlab instructor bootstrap' d'abord.",
     "status_checking":     "Vérification de la connectivité SSH sur {count} hôte(s)…",
@@ -829,6 +836,27 @@ hors ligne, elle se tait.
     "err_snapshot_provider_unsupported":
         "Snapshots non encore implémentés pour le provider « {provider} ». "
         "Voir src/dsoxlab/infra/snapshot/__init__.py pour ajouter un backend.",
+    "err_snapshot_no_disk":
+        "Le snapshot « {snapshot} » du domaine {domain} n'a figé aucun disque : "
+        "il n'y a rien où revenir. Le reprendre avec dsoxlab run.",
+    "err_snapshot_no_base":
+        "Snapshot « {snapshot} » du domaine {domain} : impossible de savoir "
+        "quel disque « {disk} » recouvre. Un retour arrière jetterait le "
+        "mauvais fichier.",
+    "err_snapshot_no_capacity":
+        "libvirt n'indique pas la taille de {path} : un fichier de "
+        "recouvrement ne peut pas être recréé sans elle.",
+    "err_snapshot_not_top_layer":
+        "Le snapshot « {snapshot} » n'est plus la couche du dessus du disque "
+        "« {disk} » de {domain} : le domaine écrit dans {found}, le snapshot a "
+        "créé {expected}. Revenir en arrière ici jetterait des écritures que "
+        "le snapshot n'a jamais couvertes.",
+    "err_vm_snapshot_required":
+        "Le lab {lab_id} déclare snapshot_required: true et le point de "
+        "reprise n'a pas pu être pris sur {host} : {error}\n"
+        "Le lab n'est PAS démarré, car il tournerait sans le filet qu'il "
+        "réclame. Réparer l'hyperviseur, ou déclarer snapshot_required: false "
+        "dans son lab.yaml.",
     "err_runtime_unavailable":
         "Le runtime « {runtime} » n'est pas disponible sur cette machine. "
         "Installe les dépendances (`dsoxlab instructor bootstrap`), ou "

--- a/src/dsoxlab/infra/snapshot/__init__.py
+++ b/src/dsoxlab/infra/snapshot/__init__.py
@@ -7,7 +7,13 @@ interface :
 - ``create(repo_meta, hosts, name) -> None``
 - ``revert(repo_meta, hosts, name) -> None``
 - ``delete(repo_meta, hosts, name) -> None``
+- ``purge(repo_meta, hosts) -> list[str]``
 - ``list_(repo_meta, host) -> list[str]``
+
+``purge`` est l'opération que réclame la destruction d'une infrastructure : un
+snapshot laisse derrière lui un artefact de stockage que l'outil de
+provisionnement ne connaît pas, et qui lui survivrait. Elle rend ce qu'elle a
+retiré, pour que l'appelant puisse le dire.
 
 Si un provider n'est pas encore implémenté,
 ``NotImplementedError`` est levée avec un message explicite.
@@ -26,6 +32,17 @@ from ...i18n import _
 from ...models.repo import RepoMetadata
 
 
+class SnapshotError(RuntimeError):
+    """Levée quand un snapshot existe mais ne peut pas servir de point de reprise.
+
+    Distincte de ``CommandError`` (``virsh`` a échoué) et de ``DomainNotFound``
+    (la machine n'existe pas) : ici l'hyperviseur répond, la machine est là, et
+    c'est **l'état du snapshot** qui interdit l'opération demandée. Les trois
+    appellent des gestes différents, les confondre ferait écrire un message
+    faux.
+    """
+
+
 class SnapshotBackend(Protocol):
     """Contrat à respecter par chaque module ``snapshot/<provider>.py``."""
 
@@ -40,6 +57,10 @@ class SnapshotBackend(Protocol):
     def delete(
         self, repo_meta: RepoMetadata, hosts: list[str], name: str
     ) -> None: ...
+
+    def purge(
+        self, repo_meta: RepoMetadata, hosts: list[str]
+    ) -> list[str]: ...
 
     def list_(
         self, repo_meta: RepoMetadata, host: str
@@ -77,6 +98,15 @@ def revert(repo_meta: RepoMetadata, hosts: list[str], name: str) -> None:
 def delete(repo_meta: RepoMetadata, hosts: list[str], name: str) -> None:
     """Supprime le snapshot ``name`` sur chaque host."""
     _backend(repo_meta).delete(repo_meta, hosts, name)
+
+
+def purge(repo_meta: RepoMetadata, hosts: list[str]) -> list[str]:
+    """Retire tout snapshot et tout artefact de stockage laissé sur ces hosts.
+
+    Returns:
+        Les artefacts réellement retirés, pour que l'appelant les nomme.
+    """
+    return _backend(repo_meta).purge(repo_meta, hosts)
 
 
 def list_(repo_meta: RepoMetadata, host: str) -> list[str]:

--- a/src/dsoxlab/infra/snapshot/kvm.py
+++ b/src/dsoxlab/infra/snapshot/kvm.py
@@ -1,73 +1,368 @@
-"""Backend snapshot KVM via ``virsh`` (libvirt).
+"""Backend snapshot KVM via ``virsh`` : **externe**, parce que l'UEFI l'impose.
 
-Note : Terraform ``dmacvicar/libvirt`` ne gère pas les snapshots
-libvirt. C'est une limitation connue ; on bypass en invoquant
-``virsh snapshot-*`` directement. Les snapshots sont stockés dans le
-state libvirt local — ils survivent au redémarrage de l'hôte.
+Ce module prenait des snapshots **internes** (``snapshot-create-as`` sans
+``--disk-only``). Sur les machines que ``dsoxlab provision`` crée réellement,
+cette commande ne peut pas aboutir : le template Terraform packagé ici impose
+``firmware = "efi"`` — les images cloud modernes n'embarquent plus de
+bootloader BIOS — et libvirt refuse le snapshot interne d'un domaine dont le
+firmware est en pflash ::
 
-**Le nom du domaine n'est pas déduit, il est résolu.** Le template Terraform
-packagé ici nomme le domaine avec le ``infra.hosts[].name`` du ``meta.yml``
-**tel quel**, c'est-à-dire un FQDN (``control-node.lab``). Ce module a
-longtemps supposé l'inverse — qu'il fallait couper le suffixe — et visait donc
-un domaine inexistant. La résolution passe désormais par
-``infra.libvirt.resolve_domain``, qui interroge libvirt et accepte le nom court
-en repli, pour les infrastructures créées par une version antérieure du
-template.
+    error: Operation not supported: internal snapshots of a VM with pflash
+           based firmware are not supported
+
+Le geste juste est donc le snapshot **externe** (``--disk-only --atomic``), qui
+fige le disque en le figeant : libvirt crée un fichier de **recouvrement**
+(overlay qcow2), y bascule le domaine, et le disque d'origine devient
+immuable. Trois conséquences, assumées ici plutôt que découvertes plus tard.
+
+**1. Le nom du fichier de recouvrement ne peut pas être laissé à libvirt.**
+Sur un disque ``type='volume'`` — la forme exacte que produit le template
+Terraform — libvirt refuse de le déduire ::
+
+    error: unsupported configuration: cannot generate external snapshot name
+           for disk 'vda' without source
+
+``create`` passe donc un ``--diskspec`` par disque inscriptible, avec un chemin
+qu'il calcule : ``<disque>.<nom du snapshot>``, à côté du disque.
+
+**2. Le retour arrière n'est pas un ``snapshot-revert``.** libvirt le refuse sur
+un snapshot externe (``Invalid target domain state 'disk-snapshot'``), et ce
+jusqu'à des versions récentes. Revenir en arrière, c'est **jeter le
+recouvrement** : on arrête le domaine, on supprime le fichier de recouvrement,
+on en recrée un vide adossé au même disque de base, on redémarre. Le chemin ne
+change pas, donc le XML du domaine n'est jamais réécrit — c'est ce qui rend
+l'opération rejouable et sans effet de bord.
+
+**3. L'état mémoire n'est pas capturé.** ``--disk-only`` fige le disque, pas la
+RAM : le retour arrière redémarre la machine depuis un état disque cohérent,
+il ne la replace pas dans la seconde d'avant. Pour un lab c'est le bon
+compromis, et c'est écrit dans le contrat pour que personne n'attende autre
+chose.
+
+Tout passe par ``virsh`` et par **lui seul**, y compris la manipulation des
+fichiers : ``vol-delete`` et ``vol-create-as`` s'exécutent dans libvirtd, donc
+avec ses droits. Un ``qemu-img`` lancé en direct échouerait sur la moitié des
+postes, ceux où ``virsh`` est joignable par appartenance au groupe ``libvirt``
+et non par ``sudo``, et où le pool n'est pas accessible en écriture à
+l'utilisateur.
+
+**Le nom du domaine n'est pas déduit, il est résolu** (voir ``infra.libvirt``).
 """
 
 from __future__ import annotations
 
 import logging
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import PurePosixPath
 
+from ...i18n import _
 from ...models.repo import RepoMetadata
 from ...utils.shell import CommandError
-from ..libvirt import DomainNotFound, list_domains, resolve_domain, run_virsh
+from ..libvirt import (
+    RUNNING_STATES,
+    DomainNotFound,
+    domain_state,
+    list_domains,
+    resolve_domain,
+    run_virsh,
+)
+from . import SnapshotError
 
 logger = logging.getLogger(__name__)
 
+#: La description posée sur chaque snapshot. Elle sert à un humain qui lit un
+#: ``virsh snapshot-list`` et se demande d'où sort ce point de reprise.
+DESCRIPTION = "dsoxlab checkpoint"
+
+#: Fusionner un recouvrement dans son disque de base recopie des données : sur
+#: un lab qui a beaucoup écrit, cela dépasse la minute. Le timeout des
+#: interrogations ne convient pas ici.
+_TIMEOUT_LONG = 900
+
+
+@dataclass(frozen=True)
+class Layer:
+    """Une couche de recouvrement, et le disque qu'elle recouvre.
+
+    ``base_pool`` peut être ``None`` : un disque déclaré par chemin de fichier
+    n'a pas de pool dans le XML, il faut le demander à libvirt.
+    """
+
+    target: str
+    overlay: str
+    base: str
+    base_format: str
+    base_pool: str | None = None
+
+
+# ── lecture du XML de libvirt ───────────────────────────────────────────────
+
+def _xml(args: list[str], *, timeout: int = 60) -> ET.Element:
+    """Rend la racine du document XML que ``virsh <args>`` produit."""
+    result = run_virsh(args, timeout=timeout)
+    return ET.fromstring(result.stdout)  # noqa: S314 — sortie de notre propre virsh
+
+
+def _source_path(element: ET.Element | None) -> str | None:
+    """Le chemin réel derrière un ``<source>``, quelle que soit sa forme.
+
+    libvirt en écrit deux : ``<source file='/chemin'/>`` et
+    ``<source pool='P' volume='V'/>``. Le template Terraform produit la
+    seconde, et c'est précisément celle que le code d'origine ne savait pas
+    lire.
+    """
+    if element is None:
+        return None
+    source = element if element.tag == "source" else element.find("source")
+    if source is None:
+        return None
+    fichier = source.get("file")
+    if fichier:
+        return fichier
+    pool, volume = source.get("pool"), source.get("volume")
+    if pool and volume:
+        return run_virsh(["vol-path", "--pool", pool, volume]).stdout.strip()
+    return None
+
+
+def _writable_disks(domain: str) -> dict[str, str]:
+    """Les disques que le snapshot doit figer : ``{cible: chemin actuel}``.
+
+    Écarte les périphériques qui ne sont pas des disques (le cdrom cloud-init)
+    et ceux en lecture seule : libvirt les ignore de toute façon, et leur
+    passer un ``--diskspec`` le ferait échouer.
+    """
+    racine = _xml(["dumpxml", domain])
+    disques: dict[str, str] = {}
+    for disque in racine.findall("./devices/disk"):
+        if disque.get("device") != "disk" or disque.find("readonly") is not None:
+            continue
+        cible = disque.find("target")
+        chemin = _source_path(disque)
+        if cible is None or not chemin:
+            continue
+        dev = cible.get("dev")
+        if dev:
+            disques[dev] = chemin
+    return disques
+
+
+def _snapshot_layers(domain: str, name: str) -> list[Layer]:
+    """Ce que le snapshot ``name`` a créé, et ce qu'il recouvre.
+
+    Tout se lit dans un seul document : ``snapshot-dumpxml`` porte à la fois
+    les fichiers de recouvrement (section ``<disks>``) et le domaine **tel
+    qu'il était** au moment du snapshot (section ``<domain>``), donc les
+    disques de base et leur pool.
+
+    Raises:
+        SnapshotError: si le snapshot n'a figé aucun disque, ou si un disque
+            figé n'a pas de base identifiable. Rendre une liste vide ferait
+            passer un retour arrière impossible pour un retour arrière réussi.
+    """
+    racine = _xml(["snapshot-dumpxml", domain, name])
+
+    recouvrements: dict[str, str] = {}
+    for disque in racine.findall("./disks/disk"):
+        if disque.get("snapshot") != "external":
+            continue
+        dev, chemin = disque.get("name"), _source_path(disque)
+        if dev and chemin:
+            recouvrements[dev] = chemin
+    if not recouvrements:
+        raise SnapshotError(_("err_snapshot_no_disk", snapshot=name, domain=domain))
+
+    couches: list[Layer] = []
+    for disque in racine.findall("./domain/devices/disk"):
+        cible = disque.find("target")
+        dev = cible.get("dev") if cible is not None else None
+        if dev is None or dev not in recouvrements:
+            continue
+        base = _source_path(disque)
+        if not base:
+            raise SnapshotError(
+                _("err_snapshot_no_base", snapshot=name, domain=domain, disk=dev)
+            )
+        pilote = disque.find("driver")
+        source = disque.find("source")
+        couches.append(Layer(
+            target=dev,
+            overlay=recouvrements[dev],
+            base=base,
+            base_format=(pilote.get("type") if pilote is not None else None) or "qcow2",
+            base_pool=source.get("pool") if source is not None else None,
+        ))
+
+    manquants = sorted(set(recouvrements) - {c.target for c in couches})
+    if manquants:
+        raise SnapshotError(
+            _("err_snapshot_no_base", snapshot=name, domain=domain,
+              disk=", ".join(manquants))
+        )
+    return couches
+
+
+def _snapshot_names(domain: str) -> list[str]:
+    """Les snapshots que libvirt connaît pour ce domaine."""
+    result = run_virsh(["snapshot-list", domain, "--name"], check=False)
+    if not result.ok:
+        return []
+    return [ligne.strip() for ligne in result.stdout.splitlines() if ligne.strip()]
+
+
+# ── manipulation des volumes, par libvirt et jamais en direct ───────────────
+
+def _pool_of(layer: Layer) -> str:
+    """Le pool où vit le disque de base, donc aussi son recouvrement.
+
+    Le XML le donne quand le disque est déclaré en ``pool``/``volume``. Sinon
+    on le demande à libvirt à partir du chemin.
+    """
+    if layer.base_pool:
+        return layer.base_pool
+    return run_virsh(["vol-pool", layer.base]).stdout.strip()
+
+
+def _capacity(pool: str, path: str) -> int:
+    """La taille virtuelle du disque de base, en octets.
+
+    Un recouvrement recréé doit la reprendre à l'identique : un qcow2 plus
+    petit que sa base tronquerait le disque vu par la machine.
+    """
+    racine = _xml(["vol-dumpxml", "--pool", pool, path])
+    capacite = racine.find("capacity")
+    octets = (capacite.text or "").strip() if capacite is not None else ""
+    if not octets:
+        raise SnapshotError(_("err_snapshot_no_capacity", path=path))
+    return int(octets)
+
+
+def _delete_volume(pool: str, path: str) -> bool:
+    """Retire un fichier de recouvrement du pool. Rend ``False`` s'il n'y était pas.
+
+    Le rafraîchissement n'est pas une précaution : libvirt tient un catalogue
+    en mémoire, et un fichier que ``snapshot-create-as`` vient de créer n'y
+    figure pas encore. Sans lui, ``vol-delete`` répond « volume introuvable »
+    sur un fichier bien présent sur le disque.
+    """
+    run_virsh(["pool-refresh", pool], check=False, timeout=120)
+    nom = PurePosixPath(path).name
+    result = run_virsh(["vol-delete", "--pool", pool, nom], check=False, timeout=120)
+    if not result.ok:
+        logger.warning(
+            "vol-delete sans effet pour %s dans %s : %s",
+            nom, pool, result.stderr.strip(),
+        )
+    return result.ok
+
+
+def _reset_overlay(layer: Layer) -> None:
+    """Rend le fichier de recouvrement vide, sans toucher au XML du domaine.
+
+    C'est **tout** le retour arrière : le domaine continue de pointer sur le
+    même chemin, qui ne contient plus rien, donc il relit le disque de base.
+    Recréer plutôt que réécrire garde le snapshot valide, donc rejouable.
+    """
+    pool = _pool_of(layer)
+    capacite = _capacity(pool, layer.base)
+    _delete_volume(pool, layer.overlay)
+    run_virsh(
+        [
+            "vol-create-as", pool, PurePosixPath(layer.overlay).name, str(capacite),
+            "--format", "qcow2",
+            "--backing-vol", layer.base,
+            "--backing-vol-format", layer.base_format,
+        ],
+        timeout=120,
+    )
+
+
+# ── l'interface du backend ──────────────────────────────────────────────────
 
 def create(repo_meta: RepoMetadata, hosts: list[str], name: str) -> None:
-    """Crée un snapshot ``name`` sur chaque domaine libvirt listé.
+    """Fige le disque de chaque domaine listé, sous le nom ``name``.
+
+    Rejouable : un snapshot du même nom est d'abord supprimé, de sorte qu'un
+    second ``dsoxlab run`` reparte d'un point de reprise à jour au lieu
+    d'échouer sur un nom déjà pris.
 
     Raises:
         DomainNotFound: si un hôte ne correspond à aucun domaine.
+        CommandError: si libvirt refuse le snapshot. **L'appelant doit laisser
+            remonter** quand le lab déclare ``snapshot_required: true`` : un
+            filet qu'on n'a pas tendu ne se signale pas par un avertissement.
     """
-    del repo_meta  # non utilisé — meta.yml accessible via host_fqdn → domain
+    del repo_meta  # le domaine se résout contre libvirt, pas contre le meta.yml
     known = list_domains()
     for fqdn in hosts:
         domain = resolve_domain(fqdn, known=known)
-        logger.info("virsh snapshot-create-as %s %s", domain, name)
-        run_virsh(
-            [
-                "snapshot-create-as",
-                "--domain", domain,
-                "--name", name,
-                "--description", "dsoxlab checkpoint",
-                "--atomic",
-            ],
-            timeout=120,
-        )
+        if name in _snapshot_names(domain):
+            logger.info("snapshot %s déjà présent sur %s : remplacé", name, domain)
+            _drop(domain, name)
+        args = [
+            "snapshot-create-as",
+            "--domain", domain,
+            "--name", name,
+            "--description", DESCRIPTION,
+            "--disk-only",
+            "--atomic",
+        ]
+        for cible, chemin in sorted(_writable_disks(domain).items()):
+            args += ["--diskspec", f"{cible},snapshot=external,file={chemin}.{name}"]
+        logger.info("virsh snapshot-create-as %s %s (externe)", domain, name)
+        run_virsh(args, timeout=300)
 
 
 def revert(repo_meta: RepoMetadata, hosts: list[str], name: str) -> None:
-    """Revert chaque domaine vers son snapshot ``name``.
+    """Ramène chaque domaine à l'état disque du snapshot ``name``.
+
+    La machine est arrêtée le temps de l'opération, puis redémarrée si elle
+    tournait. L'état mémoire n'est pas restauré : il n'a jamais été capturé.
 
     Raises:
         DomainNotFound: si un hôte ne correspond à aucun domaine.
+        SnapshotError: si le snapshot n'est plus la couche du dessus. Le cas
+            existe — un second snapshot posé par-dessus, une fusion faite à la
+            main — et jeter la mauvaise couche détruirait des données.
     """
     del repo_meta
     known = list_domains()
     for fqdn in hosts:
         domain = resolve_domain(fqdn, known=known)
-        logger.info("virsh snapshot-revert %s %s", domain, name)
-        run_virsh(
-            ["snapshot-revert", domain, name],
-            timeout=120,
-        )
+        couches = _snapshot_layers(domain, name)
+        _check_top_layer(domain, name, couches)
+
+        tournait = domain_state(domain) in RUNNING_STATES
+        if tournait:
+            run_virsh(["destroy", domain], timeout=120)
+        for couche in couches:
+            logger.info("retour arrière %s:%s → %s", domain, couche.target, couche.base)
+            _reset_overlay(couche)
+        if tournait:
+            run_virsh(["start", domain], timeout=300)
+
+
+def _check_top_layer(domain: str, name: str, couches: list[Layer]) -> None:
+    """Le domaine écrit-il bien dans les recouvrements de CE snapshot ?
+
+    Raises:
+        SnapshotError: sinon. C'est le garde-fou qui empêche de jeter une
+            couche qui porte autre chose que ce qu'on croit jeter.
+    """
+    actuels = _writable_disks(domain)
+    for couche in couches:
+        actuel = actuels.get(couche.target)
+        if actuel != couche.overlay:
+            raise SnapshotError(_(
+                "err_snapshot_not_top_layer",
+                snapshot=name, domain=domain, disk=couche.target,
+                expected=couche.overlay, found=actuel or "-",
+            ))
 
 
 def delete(repo_meta: RepoMetadata, hosts: list[str], name: str) -> None:
-    """Supprime le snapshot ``name`` sur chaque domaine.
+    """Supprime le point de reprise ``name``, en gardant l'état courant.
 
     Best-effort assumé : un snapshot déjà absent, comme un domaine déjà
     détruit, ne doit pas faire échouer un nettoyage. Les deux cas sont
@@ -81,17 +376,86 @@ def delete(repo_meta: RepoMetadata, hosts: list[str], name: str) -> None:
         except DomainNotFound as exc:
             logger.warning("snapshot-delete ignoré : %s", exc)
             continue
+        _drop(domain, name)
+
+
+def _drop(domain: str, name: str) -> None:
+    """Retire un snapshot externe : fusion du recouvrement, puis oubli.
+
+    ``virsh snapshot-delete`` fait les deux d'un coup sur un libvirt récent :
+    il recopie le recouvrement dans le disque de base, y repointe le domaine
+    et supprime le fichier. Sur un libvirt qui ne sait pas encore supprimer un
+    snapshot externe, on retombe sur ``--metadata`` : le point de reprise
+    disparaît, le recouvrement **reste le disque vif** du domaine. Ce n'est
+    pas un orphelin — rien ne le référence en trop — mais la chaîne gagne une
+    couche, et cela se dit.
+    """
+    try:
+        run_virsh(["snapshot-delete", domain, name], timeout=_TIMEOUT_LONG)
+        return
+    except CommandError as exc:
+        logger.warning(
+            "snapshot-delete a échoué pour %s/%s : %s",
+            domain, name, exc.result.stderr.strip(),
+        )
+    result = run_virsh(
+        ["snapshot-delete", domain, name, "--metadata"], check=False, timeout=120
+    )
+    if result.ok:
+        logger.warning(
+            "snapshot %s/%s oublié sans fusion : le recouvrement reste la "
+            "couche vive du disque", domain, name,
+        )
+    else:
+        logger.warning(
+            "snapshot %s/%s non supprimé : %s", domain, name, result.stderr.strip()
+        )
+
+
+def purge(repo_meta: RepoMetadata, hosts: list[str]) -> list[str]:
+    """Retire tout snapshot **et son fichier de recouvrement**, avant destruction.
+
+    Terraform ne détruit que ce qu'il a créé. Un fichier de recouvrement lui
+    est invisible : il n'est dans aucun state, et le volume qu'il recouvre est
+    supprimé sous lui. Sans ce passage, il survit à la machine qu'il servait —
+    le cousin exact des domaines orphelins de #107.
+
+    L'état courant est ici perdu volontairement : tout ce qui porte ces
+    disques est sur le point de disparaître.
+
+    Returns:
+        Les chemins des fichiers de recouvrement réellement retirés. Vide si
+        l'hyperviseur n'est pas interrogeable : une interrogation impossible
+        n'est jamais une absence, et l'appelant doit le dire plutôt que
+        conclure que rien ne traîne.
+    """
+    del repo_meta
+    retires: list[str] = []
+    try:
+        known = list_domains()
+    except CommandError as exc:
+        logger.warning("purge des snapshots impossible : %s", exc)
+        return retires
+
+    for fqdn in hosts:
         try:
+            domain = resolve_domain(fqdn, known=known)
+        except DomainNotFound:
+            continue
+        for name in _snapshot_names(domain):
+            try:
+                couches = _snapshot_layers(domain, name)
+            except (SnapshotError, CommandError) as exc:
+                logger.warning("snapshot %s/%s illisible : %s", domain, name, exc)
+                couches = []
             run_virsh(
-                ["snapshot-delete", domain, name],
-                timeout=60,
-                check=True,
+                ["snapshot-delete", domain, name, "--metadata"],
+                check=False, timeout=120,
             )
-        except CommandError as exc:
-            logger.warning(
-                "snapshot-delete a échoué pour %s/%s : %s",
-                domain, name, exc.result.stderr.strip(),
-            )
+            for couche in couches:
+                if _delete_volume(_pool_of(couche), couche.overlay):
+                    retires.append(couche.overlay)
+    return retires
 
 
 def list_(repo_meta: RepoMetadata, host: str) -> list[str]:
@@ -103,11 +467,4 @@ def list_(repo_meta: RepoMetadata, host: str) -> list[str]:
             « ce domaine n'existe pas », qui appellent des gestes opposés.
     """
     del repo_meta
-    domain = resolve_domain(host)
-    result = run_virsh(
-        ["snapshot-list", domain, "--name"],
-        check=False,
-    )
-    if not result.ok:
-        return []
-    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return _snapshot_names(resolve_domain(host))

--- a/src/dsoxlab/runtimes/vm.py
+++ b/src/dsoxlab/runtimes/vm.py
@@ -15,6 +15,19 @@ Contrat lab.yaml minimal pour ``runtime: vm`` ::
       default: rhel              # cible si l'apprenant ne précise pas
       snapshot_required: false
 
+``snapshot_required`` engage l'outil, il ne l'informe pas :
+
+- ``run`` prend un point de reprise du **disque** avant le ``setup.yaml``, et
+  **échoue** s'il n'y arrive pas — un lab qui réclame un filet ne démarre pas
+  sans lui ;
+- ``reset`` ramène la machine à ce point plutôt que de rejouer le
+  ``cleanup.yaml`` ;
+- ``clean`` retire le point de reprise, et avec lui le fichier de recouvrement
+  qu'il avait créé.
+
+L'état **mémoire** n'est pas capturé : la reprise repart d'un disque cohérent,
+pas de la seconde d'avant.
+
 Fichiers attendus à la racine du lab :
 
 - ``setup.yaml``   — playbook qui pose l'état initial
@@ -79,14 +92,20 @@ class VmRuntime(BaseRuntime):
             )
 
         if lab.runtime.snapshot_required:
-            snap_name = f"pre-{lab.id}"
+            # « required » veut dire required. Ce bloc avalait l'échec en
+            # `logger.warning`, et le journal n'est même pas configuré dans ce
+            # paquet : le lab démarrait sans le filet qu'il réclame, `run`
+            # sortait en 0, et l'apprenant l'apprenait au moment d'en avoir
+            # besoin. C'est ce silence qui a laissé la fonctionnalité cassée
+            # sans que personne ne le voie. Un lab qui tolère l'absence de
+            # filet a le droit de le déclarer : c'est snapshot_required: false.
             try:
-                snapshot_infra.create(repo_meta, [target.host], snap_name)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "Snapshot pré-setup non créé (%s). Le lab continue mais "
-                    "le rollback ne sera pas disponible.", exc,
-                )
+                snapshot_infra.create(repo_meta, [target.host], self._snap_name(lab))
+            except Exception as exc:  # on ne filtre pas : tout échec du filet est un échec du lab
+                raise RuntimeError(_(
+                    "err_vm_snapshot_required",
+                    lab_id=lab.id, host=target.host, error=str(exc),
+                )) from exc
 
         result = ansible_infra.run_playbook(
             playbook_path=setup,
@@ -111,6 +130,24 @@ class VmRuntime(BaseRuntime):
         *,
         on_event: EventCallback | None = None,
     ) -> None:
+        """Remet le lab à son état de départ.
+
+        Un lab qui déclare ``snapshot_required: true`` est **ramené à son point
+        de reprise** plutôt que nettoyé par son ``cleanup.yaml`` : c'est là que
+        le filet sert, et c'est ce qui donne enfin un effet observable à ce
+        champ du contrat. Le point de reprise ayant été pris **avant** le
+        ``setup.yaml``, il faut rejouer celui-ci derrière.
+
+        L'échec du retour arrière n'est pas rattrapé par un ``cleanup.yaml`` de
+        repli : ce serait remplacer une garantie par une approximation sans le
+        dire, exactement le défaut que ce runtime vient de solder.
+        """
+        if lab.runtime.snapshot_required:
+            target = self._resolve_target(lab, target_name)
+            repo_meta = self._repo_meta(lab)
+            snapshot_infra.revert(repo_meta, [target.host], self._snap_name(lab))
+            self.start(lab, target_name, on_event=on_event)
+            return
         self.clean(lab, target_name, on_event=on_event)
         self.start(lab, target_name, on_event=on_event)
 
@@ -140,6 +177,19 @@ class VmRuntime(BaseRuntime):
                 lab_id=lab.id, target=target.name, rc=result.rc,
                 status=result.status,
             ))
+
+        # Le point de reprise a fait son temps. Le laisser laisserait un
+        # fichier de recouvrement que Terraform ne connaît pas, et qui
+        # survivrait à la machine — le cousin des domaines orphelins de #107.
+        # Best-effort : un nettoyage ne doit pas échouer sur ce qui a déjà
+        # disparu, mais il dit ce qu'il n'a pas su retirer.
+        if lab.runtime.snapshot_required:
+            try:
+                snapshot_infra.delete(repo_meta, [target.host], self._snap_name(lab))
+            except Exception as exc:  # noqa: BLE001 — nettoyage best-effort
+                logger.warning(
+                    "Point de reprise %s non retiré : %s", self._snap_name(lab), exc
+                )
 
     def status(self, lab: LabDefinition, target_name: str | None = None) -> str:
         del lab, target_name
@@ -213,6 +263,17 @@ class VmRuntime(BaseRuntime):
         return SessionSpec(command=cmd)
 
     # ─── helpers ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def _snap_name(lab: LabDefinition) -> str:
+        """Le nom du point de reprise du lab, calculé en **un seul endroit**.
+
+        Il était recomposé sur place à chaque usage, ce qui ne se voyait pas
+        tant qu'un seul usage existait ; à trois, une divergence d'un caractère
+        aurait fait supprimer un snapshot qui n'existe pas et laissé le vrai
+        derrière.
+        """
+        return f"pre-{lab.id}"
 
     def _resolve_target(
         self, lab: LabDefinition, explicit_name: str | None

--- a/tests/test_snapshot_kvm.py
+++ b/tests/test_snapshot_kvm.py
@@ -1,25 +1,34 @@
-"""Le snapshot KVM visait un domaine qui n'existe pas.
+"""Les snapshots ne fonctionnaient sur aucune VM dsoxlab, et l'échec était muet.
 
-Le template Terraform packagé ici nomme le domaine libvirt avec le
-``infra.hosts[].name`` du ``meta.yml``, **tel quel**, donc un FQDN. Le backend
-de snapshot, lui, coupait ce FQDN au premier point. Les deux ont divergé sans
-bruit, parce qu'aucun lab n'active ``snapshot_required`` et qu'aucun test ne
-couvrait le module.
+Deux défauts, empilés, et le second cachait le premier.
 
-Ces tests ferment les deux causes de la divergence :
+**Le premier** : le backend prenait des snapshots **internes**. Le template
+Terraform packagé ici impose ``firmware = "efi"``, et libvirt refuse le
+snapshot interne d'un domaine dont le firmware est en pflash. La commande ne
+pouvait donc aboutir sur aucune machine que ``dsoxlab provision`` crée. Sur un
+disque ``type='volume'`` — la forme que produit ce même template — libvirt
+refuse en plus de déduire le nom du fichier de recouvrement, ce qui casse le
+snapshot externe naïf. Les deux refus sont rejoués ici par le simulateur, à
+l'identique.
 
-1. le nom du domaine est **résolu** contre ce que libvirt déclare, il n'est
-   plus reconstruit de tête ;
-2. les quatre opérations (``create``, ``revert``, ``delete``, ``list_``)
-   passent par cette résolution, et non plus chacune par sa propre supposition.
+**Le second** : ``runtimes/vm.py`` avalait l'échec en ``logger.warning``, et
+aucun ``logging.basicConfig`` n'existe dans ce paquet. Un lab qui déclare
+``snapshot_required: true`` démarrait donc **sans filet**, ``run`` sortait en
+0, et l'apprenant l'apprenait au moment d'en avoir besoin. C'est ce silence
+qui a laissé la fonctionnalité diverger sans que personne ne le voie ; c'est
+lui que le test le plus important de ce module ferme.
 
-Aucun test n'exige un libvirt réel : ``virsh`` est simulé au niveau du wrapper
-``run_command``, ce qui laisse le test décider de la sortie de chaque commande.
+Le simulateur n'est pas un enregistreur de commandes : il tient un **état** —
+domaines, volumes, chaîne de recouvrement, et ce que chaque couche contient.
+Un test peut donc écrire dans une machine, revenir en arrière, et vérifier que
+l'écriture a disparu, ce qu'aucune assertion sur une ligne de commande ne
+prouve. Aucun test n'exige un libvirt réel.
 """
 
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -27,7 +36,7 @@ import pytest
 from dsoxlab import i18n
 from dsoxlab.infra import libvirt
 from dsoxlab.infra.libvirt import DomainNotFound
-from dsoxlab.infra.snapshot import kvm
+from dsoxlab.infra.snapshot import SnapshotError, kvm
 from dsoxlab.models.repo import RepoMetadata
 from dsoxlab.utils.shell import CommandError, CommandResult
 
@@ -36,6 +45,13 @@ DOMAINES_FQDN = "web1.lab\ncontrol-node.lab\ndb1.lab\n"
 
 #: Ce que rend une infrastructure créée par une version antérieure du template.
 DOMAINES_COURTS = "web1\ncontrol-node\ndb1\n"
+
+#: Le pool et le répertoire que le template Terraform utilise.
+POOL = "default"
+REPERTOIRE = "/var/lib/libvirt/images"
+
+#: La taille virtuelle des disques du banc d'essai (10 Gio).
+CAPACITE = 10737418240
 
 
 class VirshSimule:
@@ -77,6 +93,282 @@ class VirshSimule:
         return vises
 
 
+class Hyperviseur:
+    """Un libvirt de papier : il garde un état, et le fait évoluer.
+
+    Ce qu'il modélise, et pourquoi chaque point compte :
+
+    * **le refus du snapshot interne sur pflash**, qui est le défaut d'origine ;
+    * **le refus de déduire le nom d'un recouvrement** sur un disque
+      ``type='volume'``, qui est la forme que produit le template Terraform ;
+    * **la chaîne de recouvrement** : chaque couche porte son propre contenu,
+      et ce que la machine voit est l'union de la chaîne. C'est ce qui permet
+      d'écrire, de revenir en arrière et de vérifier une disparition ;
+    * **la suppression d'un snapshot externe**, que les libvirt anciens ne
+      savent pas faire (``supprime_externe=False`` rejoue ce cas).
+    """
+
+    def __init__(
+        self,
+        domaines: tuple[str, ...] = ("web1.lab", "control-node.lab", "db1.lab"),
+        *,
+        supprime_externe: bool = True,
+        refuse_snapshot: bool = False,
+    ) -> None:
+        self.supprime_externe = supprime_externe
+        self.refuse_snapshot = refuse_snapshot
+        self.commandes: list[list[str]] = []
+        #: chemin de la couche → ce qui y a été écrit
+        self.volumes: dict[str, set[str]] = {}
+        #: chemin d'une couche → la couche qu'elle recouvre
+        self.backing: dict[str, str] = {}
+        self.domaines: dict[str, dict[str, Any]] = {}
+        for nom in domaines:
+            disque = f"{REPERTOIRE}/{nom}.qcow2"
+            self.volumes[disque] = set()
+            self.domaines[nom] = {
+                "etat": "running",
+                "disques": {"vda": disque},
+                "snapshots": {},
+            }
+
+    # ── ce que le test manipule ─────────────────────────────────────────────
+
+    def ecrire(self, domaine: str, texte: str, dev: str = "vda") -> None:
+        """Écrit dans la machine : l'écriture atterrit dans la couche du dessus."""
+        self.volumes[self.domaines[domaine]["disques"][dev]].add(texte)
+
+    def contenu(self, domaine: str, dev: str = "vda") -> set[str]:
+        """Ce que la machine voit : l'union de sa chaîne de recouvrement."""
+        vu: set[str] = set()
+        couche: str | None = self.domaines[domaine]["disques"][dev]
+        while couche is not None:
+            vu |= self.volumes.get(couche, set())
+            couche = self.backing.get(couche)
+        return vu
+
+    def fichiers(self) -> set[str]:
+        """Les fichiers présents dans le pool, orphelins compris."""
+        return set(self.volumes)
+
+    @staticmethod
+    def _args(cmd: list[str]) -> list[str]:
+        """Les arguments de virsh, débarrassés du préfixe et de ``--connect``."""
+        return cmd[cmd.index("--connect") + 2:]
+
+    def verbes(self) -> list[str]:
+        """Les sous-commandes reçues, dans l'ordre."""
+        return [self._args(cmd)[0] for cmd in self.commandes]
+
+    def jouees(self, sous_commande: str) -> list[list[str]]:
+        """Les arguments reçus pour cette sous-commande, appel par appel."""
+        return [
+            args for cmd in self.commandes
+            if (args := self._args(cmd))[0] == sous_commande
+        ]
+
+    def cibles(self, sous_commande: str) -> list[str]:
+        """Le domaine visé par chaque appel à cette sous-commande."""
+        return [
+            args[args.index("--domain") + 1] if "--domain" in args else args[1]
+            for args in self.jouees(sous_commande)
+        ]
+
+    # ── le faux virsh ───────────────────────────────────────────────────────
+
+    def __call__(self, cmd: list[str], **kwargs: Any) -> CommandResult:
+        self.commandes.append(cmd)
+        args = cmd[cmd.index("--connect") + 2:]
+        try:
+            sortie = self._router(args)
+        except _Refus as refus:
+            resultat = CommandResult(returncode=1, stdout="", stderr=refus.raison)
+            if kwargs.get("check", True):
+                raise CommandError(cmd, resultat) from None
+            return resultat
+        return CommandResult(returncode=0, stdout=sortie, stderr="")
+
+    def _router(self, args: list[str]) -> str:
+        verbe = args[0]
+        if verbe == "list":
+            return "\n".join(self.domaines) + "\n"
+        if verbe == "domstate":
+            return self._domaine(args[1])["etat"] + "\n"
+        if verbe == "destroy":
+            self._domaine(args[1])["etat"] = "shut off"
+            return ""
+        if verbe == "start":
+            self._domaine(args[1])["etat"] = "running"
+            return ""
+        if verbe == "dumpxml":
+            return self._dumpxml(args[1])
+        if verbe == "snapshot-list":
+            return "\n".join(self._domaine(args[1])["snapshots"]) + "\n"
+        if verbe == "snapshot-dumpxml":
+            return self._snapshot_dumpxml(args[1], args[2])
+        if verbe == "snapshot-create-as":
+            return self._create(args)
+        if verbe == "snapshot-delete":
+            return self._delete(args)
+        if verbe == "vol-path":
+            return f"{REPERTOIRE}/{args[args.index('--pool') + 2]}\n"
+        if verbe == "vol-pool":
+            return POOL + "\n"
+        if verbe == "vol-dumpxml":
+            return f"<volume><capacity unit='bytes'>{CAPACITE}</capacity></volume>"
+        if verbe == "pool-refresh":
+            return ""
+        if verbe == "vol-delete":
+            return self._vol_delete(args)
+        if verbe == "vol-create-as":
+            return self._vol_create(args)
+        raise _Refus(f"error: unsupported command: {verbe}")
+
+    def _domaine(self, nom: str) -> dict[str, Any]:
+        if nom not in self.domaines:
+            raise _Refus(f"error: failed to get domain '{nom}'")
+        return self.domaines[nom]
+
+    def _disque_xml(self, dev: str, chemin: str) -> str:
+        """Le disque, sous la forme que libvirt lui donne à cet instant.
+
+        Terraform crée des disques ``type='volume'`` ; un snapshot externe les
+        remplace par un ``type='file'`` qui pointe le recouvrement. Le module
+        doit lire les deux, donc le simulateur produit les deux.
+        """
+        if chemin.endswith(".qcow2"):
+            source = f"<source pool='{POOL}' volume='{Path(chemin).name}'/>"
+        else:
+            source = f"<source file='{chemin}'/>"
+        return (
+            f"<disk type='file' device='disk'>"
+            f"<driver name='qemu' type='qcow2'/>{source}"
+            f"<target dev='{dev}' bus='virtio'/></disk>"
+        )
+
+    def _disques_xml(self, disques: dict[str, str]) -> str:
+        corps = "".join(self._disque_xml(dev, c) for dev, c in sorted(disques.items()))
+        # Le cdrom cloud-init : présent sur toute machine du template, et jamais
+        # à figer. S'il recevait un --diskspec, libvirt refuserait le snapshot.
+        corps += (
+            "<disk type='file' device='cdrom'>"
+            "<driver name='qemu' type='raw'/>"
+            "<source file='/var/lib/libvirt/images/seed.iso'/>"
+            "<target dev='sda' bus='sata'/><readonly/></disk>"
+        )
+        return corps
+
+    def _dumpxml(self, nom: str) -> str:
+        dom = self._domaine(nom)
+        return (
+            f"<domain type='kvm'><name>{nom}</name>"
+            f"<devices>{self._disques_xml(dom['disques'])}</devices></domain>"
+        )
+
+    def _snapshot_dumpxml(self, nom: str, snap: str) -> str:
+        dom = self._domaine(nom)
+        if snap not in dom["snapshots"]:
+            raise _Refus(f"error: Domain snapshot not found: {snap}")
+        etat = dom["snapshots"][snap]
+        disques = "".join(
+            f"<disk name='{dev}' snapshot='external' type='file'>"
+            f"<driver type='qcow2'/><source file='{chemin}'/></disk>"
+            for dev, chemin in sorted(etat["overlays"].items())
+        )
+        return (
+            f"<domainsnapshot><name>{snap}</name><state>disk-snapshot</state>"
+            f"<memory snapshot='no'/>"
+            f"<disks>{disques}<disk name='sda' snapshot='no'/></disks>"
+            f"<domain type='kvm'><name>{nom}</name>"
+            f"<devices>{self._disques_xml(etat['bases'])}</devices></domain>"
+            f"</domainsnapshot>"
+        )
+
+    def _create(self, args: list[str]) -> str:
+        nom = args[args.index("--domain") + 1]
+        snap = args[args.index("--name") + 1]
+        dom = self._domaine(nom)
+        if self.refuse_snapshot:
+            # Un hyperviseur qui ne sait pas prendre ce snapshot : firmware
+            # inattendu, disque en réseau, quota de stockage plein…
+            raise _Refus("error: Operation not supported: snapshot refusé par cet hyperviseur")
+        if snap in dom["snapshots"]:
+            raise _Refus(f"error: operation failed: domain snapshot {snap} already exists")
+        if "--disk-only" not in args:
+            # Le refus qui a rendu la fonctionnalité inopérante.
+            raise _Refus(
+                "error: Operation not supported: internal snapshots of a VM "
+                "with pflash based firmware are not supported"
+            )
+        specs: dict[str, str] = {}
+        for i, arg in enumerate(args):
+            if arg != "--diskspec":
+                continue
+            dev, *champs = args[i + 1].split(",")
+            specs[dev] = dict(c.split("=", 1) for c in champs)["file"]
+        for dev in dom["disques"]:
+            if dev not in specs:
+                # Le second refus : sur un disque type='volume', libvirt ne
+                # déduit pas le nom du recouvrement.
+                raise _Refus(
+                    "error: unsupported configuration: cannot generate external "
+                    f"snapshot name for disk '{dev}' without source"
+                )
+        bases = dict(dom["disques"])
+        for dev, chemin in specs.items():
+            self.volumes[chemin] = set()
+            self.backing[chemin] = dom["disques"][dev]
+            dom["disques"][dev] = chemin
+        dom["snapshots"][snap] = {"overlays": dict(specs), "bases": bases}
+        return f"Domain snapshot {snap} created"
+
+    def _delete(self, args: list[str]) -> str:
+        nom, snap = args[1], args[2]
+        dom = self._domaine(nom)
+        if snap not in dom["snapshots"]:
+            raise _Refus(f"error: Domain snapshot not found: {snap}")
+        etat = dom["snapshots"][snap]
+        if "--metadata" in args:
+            # Le point de reprise est oublié ; le recouvrement reste la couche
+            # vive du disque. Rien n'est orphelin, la chaîne gagne une couche.
+            del dom["snapshots"][snap]
+            return f"Domain snapshot {snap} deleted"
+        if not self.supprime_externe:
+            raise _Refus(
+                "error: unsupported configuration: deletion of external disk "
+                "snapshots is not supported by this libvirt"
+            )
+        for dev, recouvrement in etat["overlays"].items():
+            base = etat["bases"][dev]
+            self.volumes[base] |= self.volumes.pop(recouvrement, set())
+            self.backing.pop(recouvrement, None)
+            dom["disques"][dev] = base
+        del dom["snapshots"][snap]
+        return f"Domain snapshot {snap} deleted"
+
+    def _vol_delete(self, args: list[str]) -> str:
+        chemin = f"{REPERTOIRE}/{args[args.index('--pool') + 2]}"
+        if chemin not in self.volumes:
+            raise _Refus(f"error: failed to get vol '{chemin}'")
+        del self.volumes[chemin]
+        self.backing.pop(chemin, None)
+        return "Vol deleted"
+
+    def _vol_create(self, args: list[str]) -> str:
+        chemin = f"{REPERTOIRE}/{args[2]}"
+        self.volumes[chemin] = set()
+        self.backing[chemin] = args[args.index("--backing-vol") + 1]
+        return "Vol created"
+
+
+class _Refus(Exception):
+    """Ce que libvirt répond quand il refuse : un code non nul et un stderr."""
+
+    def __init__(self, raison: str) -> None:
+        self.raison = raison
+        super().__init__(raison)
+
+
 @pytest.fixture(autouse=True)
 def langue_en(monkeypatch: pytest.MonkeyPatch) -> None:
     """Les assertions portent sur le texte anglais.
@@ -92,6 +384,16 @@ def langue_en(monkeypatch: pytest.MonkeyPatch) -> None:
 def virsh(monkeypatch: pytest.MonkeyPatch) -> VirshSimule:
     faux = VirshSimule()
     monkeypatch.setattr(libvirt, "run_command", faux)
+    return faux
+
+
+@pytest.fixture
+def hyperviseur(monkeypatch: pytest.MonkeyPatch) -> Hyperviseur:
+    faux = Hyperviseur()
+    monkeypatch.setattr(libvirt, "run_command", faux)
+    # Le préfixe est mémorisé pour tout le processus : le figer évite qu'un
+    # sondage `virsh list` s'ajoute aux commandes que les tests comptent.
+    monkeypatch.setattr(libvirt, "_prefixe_retenu", [])
     return faux
 
 
@@ -219,87 +521,473 @@ def test_virsh_injoignable_n_est_pas_une_absence_de_domaine(
 # ── Les quatre opérations visent le domaine résolu ──────────────────────────
 
 def test_create_vise_le_domaine_qui_existe(
-    virsh: VirshSimule, meta: RepoMetadata
+    hyperviseur: Hyperviseur, meta: RepoMetadata
 ) -> None:
     kvm.create(meta, ["control-node.lab", "web1.lab"], "pre-lab")
-    assert virsh.domaines_vises("snapshot-create-as") == [
-        "control-node.lab",
-        "web1.lab",
-    ]
+    assert hyperviseur.cibles("snapshot-create-as") == ["control-node.lab", "web1.lab"]
 
 
 def test_revert_vise_le_domaine_qui_existe(
-    virsh: VirshSimule, meta: RepoMetadata
+    hyperviseur: Hyperviseur, meta: RepoMetadata
 ) -> None:
+    kvm.create(meta, ["control-node.lab"], "pre-lab")
     kvm.revert(meta, ["control-node.lab"], "pre-lab")
-    assert virsh.domaines_vises("snapshot-revert") == ["control-node.lab"]
+    assert hyperviseur.cibles("destroy") == ["control-node.lab"]
 
 
 def test_delete_vise_le_domaine_qui_existe(
-    virsh: VirshSimule, meta: RepoMetadata
+    hyperviseur: Hyperviseur, meta: RepoMetadata
 ) -> None:
+    kvm.create(meta, ["control-node.lab"], "pre-lab")
     kvm.delete(meta, ["control-node.lab"], "pre-lab")
-    assert virsh.domaines_vises("snapshot-delete") == ["control-node.lab"]
+    assert hyperviseur.cibles("snapshot-delete") == ["control-node.lab"]
 
 
 def test_list_vise_le_domaine_qui_existe(
-    virsh: VirshSimule, meta: RepoMetadata
+    hyperviseur: Hyperviseur, meta: RepoMetadata
 ) -> None:
     kvm.list_(meta, "control-node.lab")
-    assert virsh.domaines_vises("snapshot-list") == ["control-node.lab"]
+    assert hyperviseur.cibles("snapshot-list") == ["control-node.lab"]
 
 
 def test_list_rend_les_snapshots_existants(
-    monkeypatch: pytest.MonkeyPatch, meta: RepoMetadata
+    hyperviseur: Hyperviseur, meta: RepoMetadata
 ) -> None:
-    class AvecSnapshots(VirshSimule):
-        def __call__(self, cmd: list[str], **kwargs: Any) -> CommandResult:
-            resultat = super().__call__(cmd, **kwargs)
-            if "snapshot-list" in cmd:
-                return CommandResult(returncode=0, stdout="pre-lab\nautre\n", stderr="")
-            return resultat
+    kvm.create(meta, ["control-node.lab"], "pre-lab")
+    assert kvm.list_(meta, "control-node.lab") == ["pre-lab"]
 
-    faux = AvecSnapshots()
+
+# ── Le snapshot est externe, parce que l'UEFI l'impose ──────────────────────
+
+def test_le_snapshot_est_externe_faute_de_quoi_l_uefi_le_refuse(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Le défaut d'origine : sans ``--disk-only``, libvirt refuse sur pflash."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+
+    (commande,) = hyperviseur.jouees("snapshot-create-as")
+    assert "--disk-only" in commande
+    assert "--atomic" in commande
+
+
+def test_chaque_disque_recoit_le_chemin_de_son_recouvrement(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Sur un disque type='volume', libvirt refuse de le déduire lui-même."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+
+    (commande,) = hyperviseur.jouees("snapshot-create-as")
+    specs = [commande[i + 1] for i, a in enumerate(commande) if a == "--diskspec"]
+    assert specs == [
+        f"vda,snapshot=external,file={REPERTOIRE}/web1.lab.qcow2.pre-lab"
+    ]
+
+
+def test_le_cdrom_cloud_init_n_est_jamais_fige(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Lui passer un --diskspec ferait échouer tout le snapshot."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+
+    (commande,) = hyperviseur.jouees("snapshot-create-as")
+    assert not any(spec.startswith("sda,") for spec in commande)
+
+
+def test_reprendre_un_point_de_reprise_du_meme_nom_le_remplace(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Sinon le second ``dsoxlab run`` échouerait sur un nom déjà pris."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+    hyperviseur.ecrire("web1.lab", "travail-du-premier-run")
+
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+
+    assert kvm.list_(meta, "web1.lab") == ["pre-lab"]
+    assert len(hyperviseur.jouees("snapshot-create-as")) == 2
+
+
+# ── Le retour arrière, prouvé par ce qu'il efface ───────────────────────────
+
+def test_le_retour_arriere_efface_ce_qui_a_ete_ecrit_apres(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Le critère de l'issue, mesuré sur l'état et non sur un code retour."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+    hyperviseur.ecrire("web1.lab", "fichier-ecrit-apres-le-snapshot")
+    assert "fichier-ecrit-apres-le-snapshot" in hyperviseur.contenu("web1.lab")
+
+    kvm.revert(meta, ["web1.lab"], "pre-lab")
+
+    assert "fichier-ecrit-apres-le-snapshot" not in hyperviseur.contenu("web1.lab")
+
+
+def test_le_retour_arriere_garde_ce_qui_precedait_le_snapshot(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Un retour arrière qui viderait le disque de base ne serait pas un filet."""
+    hyperviseur.ecrire("web1.lab", "installe-par-le-provisionnement")
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+    hyperviseur.ecrire("web1.lab", "ecrit-par-l-apprenant")
+
+    kvm.revert(meta, ["web1.lab"], "pre-lab")
+
+    assert hyperviseur.contenu("web1.lab") == {"installe-par-le-provisionnement"}
+
+
+def test_le_retour_arriere_reste_rejouable(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Le snapshot survit au retour arrière : le filet sert plus d'une fois."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+    kvm.revert(meta, ["web1.lab"], "pre-lab")
+    hyperviseur.ecrire("web1.lab", "deuxieme-essai")
+
+    kvm.revert(meta, ["web1.lab"], "pre-lab")
+
+    assert hyperviseur.contenu("web1.lab") == set()
+    assert kvm.list_(meta, "web1.lab") == ["pre-lab"]
+
+
+def test_la_machine_est_arretee_puis_relancee_pour_le_retour_arriere(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Rejeter le recouvrement sous un qemu qui l'a ouvert ne marcherait pas."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+
+    kvm.revert(meta, ["web1.lab"], "pre-lab")
+
+    verbes = hyperviseur.verbes()
+    assert verbes.index("destroy") < verbes.index("vol-create-as") < verbes.index("start")
+    assert hyperviseur.domaines["web1.lab"]["etat"] == "running"
+
+
+def test_une_machine_eteinte_ne_se_reveille_pas_toute_seule(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Le retour arrière ne change pas l'état de marche, il le rétablit."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+    hyperviseur.domaines["web1.lab"]["etat"] = "shut off"
+
+    kvm.revert(meta, ["web1.lab"], "pre-lab")
+
+    assert hyperviseur.jouees("start") == []
+    assert hyperviseur.domaines["web1.lab"]["etat"] == "shut off"
+
+
+def test_le_retour_arriere_refuse_une_couche_qui_n_est_plus_du_dessus(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Jeter la mauvaise couche détruirait des écritures jamais couvertes."""
+    kvm.create(meta, ["web1.lab"], "pre-un")
+    kvm.create(meta, ["web1.lab"], "pre-deux")
+    hyperviseur.ecrire("web1.lab", "ecrit-sous-le-second-snapshot")
+
+    with pytest.raises(SnapshotError) as leve:
+        kvm.revert(meta, ["web1.lab"], "pre-un")
+
+    assert "pre-un" in str(leve.value)
+    assert "ecrit-sous-le-second-snapshot" in hyperviseur.contenu("web1.lab")
+
+
+def test_un_snapshot_sans_disque_fige_ne_passe_pas_pour_un_filet(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Une liste vide ferait passer un retour arrière impossible pour un succès."""
+    hyperviseur.domaines["web1.lab"]["snapshots"]["vide"] = {"overlays": {}, "bases": {}}
+
+    with pytest.raises(SnapshotError):
+        kvm.revert(meta, ["web1.lab"], "vide")
+
+
+# ── Supprimer le point de reprise, sans rien laisser derrière ───────────────
+
+def test_supprimer_le_point_de_reprise_garde_l_etat_courant(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Supprimer un snapshot n'est pas revenir en arrière."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+    hyperviseur.ecrire("web1.lab", "travail-de-l-apprenant")
+
+    kvm.delete(meta, ["web1.lab"], "pre-lab")
+
+    assert "travail-de-l-apprenant" in hyperviseur.contenu("web1.lab")
+    assert kvm.list_(meta, "web1.lab") == []
+
+
+def test_supprimer_ne_laisse_aucun_fichier_de_recouvrement(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Le cousin de #107 : l'artefact que Terraform ne connaît pas."""
+    avant = hyperviseur.fichiers()
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+    assert hyperviseur.fichiers() != avant
+
+    kvm.delete(meta, ["web1.lab"], "pre-lab")
+
+    assert hyperviseur.fichiers() == avant
+
+
+def test_un_libvirt_ancien_retombe_sur_l_oubli_de_la_metadonnee(
+    monkeypatch: pytest.MonkeyPatch,
+    meta: RepoMetadata,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Sans fusion possible, le recouvrement reste la couche vive : pas un orphelin."""
+    faux = Hyperviseur(supprime_externe=False)
     monkeypatch.setattr(libvirt, "run_command", faux)
-    assert kvm.list_(meta, "control-node.lab") == ["pre-lab", "autre"]
+    monkeypatch.setattr(libvirt, "_prefixe_retenu", [])
+
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+    faux.ecrire("web1.lab", "travail-de-l-apprenant")
+
+    with caplog.at_level(logging.WARNING, logger="dsoxlab.infra.snapshot.kvm"):
+        kvm.delete(meta, ["web1.lab"], "pre-lab")
+
+    assert kvm.list_(meta, "web1.lab") == []
+    assert "travail-de-l-apprenant" in faux.contenu("web1.lab")
+    assert faux.domaines["web1.lab"]["disques"]["vda"] in faux.fichiers()
+    assert "sans fusion" in caplog.text
+
+
+def test_delete_tolere_un_domaine_absent_mais_le_journalise(
+    hyperviseur: Hyperviseur,
+    meta: RepoMetadata,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Un nettoyage ne doit pas échouer sur ce qui a déjà disparu, mais il
+    doit dire ce qu'il n'a pas trouvé."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+
+    with caplog.at_level(logging.WARNING, logger="dsoxlab.infra.snapshot.kvm"):
+        kvm.delete(meta, ["absent.lab", "web1.lab"], "pre-lab")
+
+    assert "absent.lab" in caplog.text
+    # L'hôte suivant est tout de même traité : une absence n'interrompt pas.
+    assert hyperviseur.cibles("snapshot-delete") == ["web1.lab"]
+
+
+# ── La purge, avant que Terraform ne passe ──────────────────────────────────
+
+def test_la_purge_retire_le_snapshot_et_son_fichier(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Terraform ne connaît pas le recouvrement : il lui survivrait."""
+    avant = hyperviseur.fichiers()
+    kvm.create(meta, ["web1.lab", "db1.lab"], "pre-lab")
+
+    retires = kvm.purge(meta, ["web1.lab", "db1.lab"])
+
+    assert sorted(retires) == [
+        f"{REPERTOIRE}/db1.lab.qcow2.pre-lab",
+        f"{REPERTOIRE}/web1.lab.qcow2.pre-lab",
+    ]
+    assert hyperviseur.fichiers() == avant
+    assert kvm.list_(meta, "web1.lab") == []
+
+
+def test_la_purge_ignore_les_machines_deja_disparues(
+    hyperviseur: Hyperviseur, meta: RepoMetadata
+) -> None:
+    """Une destruction partielle ne doit pas bloquer sur ce qui n'est plus là."""
+    kvm.create(meta, ["web1.lab"], "pre-lab")
+
+    retires = kvm.purge(meta, ["absent.lab", "web1.lab"])
+
+    assert retires == [f"{REPERTOIRE}/web1.lab.qcow2.pre-lab"]
+
+
+def test_la_purge_ne_conclut_pas_a_l_absence_quand_virsh_est_muet(
+    monkeypatch: pytest.MonkeyPatch,
+    meta: RepoMetadata,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Une interrogation impossible n'est jamais une absence."""
+
+    def virsh_absent(cmd: list[str], **kwargs: Any) -> CommandResult:
+        raise CommandError(
+            cmd, CommandResult(returncode=-1, stdout="", stderr="Commande introuvable: virsh")
+        )
+
+    monkeypatch.setattr(libvirt, "run_command", virsh_absent)
+    monkeypatch.setattr(libvirt, "_prefixe_retenu", [])
+
+    with caplog.at_level(logging.WARNING, logger="dsoxlab.infra.snapshot.kvm"):
+        assert kvm.purge(meta, ["web1.lab"]) == []
+
+    assert "purge" in caplog.text
 
 
 # ── Ce que chaque opération fait d'un domaine absent ────────────────────────
 
 def test_create_leve_sur_un_domaine_absent(
-    virsh: VirshSimule, meta: RepoMetadata
+    hyperviseur: Hyperviseur, meta: RepoMetadata
 ) -> None:
     """Un snapshot silencieusement non pris rendrait le rollback illusoire."""
     with pytest.raises(DomainNotFound):
         kvm.create(meta, ["absent.lab"], "pre-lab")
-    assert virsh.domaines_vises("snapshot-create-as") == []
+    assert hyperviseur.jouees("snapshot-create-as") == []
 
 
 def test_revert_leve_sur_un_domaine_absent(
-    virsh: VirshSimule, meta: RepoMetadata
+    hyperviseur: Hyperviseur, meta: RepoMetadata
 ) -> None:
     with pytest.raises(DomainNotFound):
         kvm.revert(meta, ["absent.lab"], "pre-lab")
 
 
 def test_list_leve_sur_un_domaine_absent(
-    virsh: VirshSimule, meta: RepoMetadata
+    hyperviseur: Hyperviseur, meta: RepoMetadata
 ) -> None:
     """« Pas de snapshot » et « pas de domaine » appellent des gestes opposés."""
     with pytest.raises(DomainNotFound):
         kvm.list_(meta, "absent.lab")
 
 
-def test_delete_tolere_un_domaine_absent_mais_le_journalise(
-    virsh: VirshSimule,
-    meta: RepoMetadata,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Un nettoyage ne doit pas échouer sur ce qui a déjà disparu, mais il
-    doit dire ce qu'il n'a pas trouvé."""
-    with caplog.at_level(logging.WARNING, logger="dsoxlab.infra.snapshot.kvm"):
-        kvm.delete(meta, ["absent.lab", "web1.lab"], "pre-lab")
+# ── « required » veut dire required ─────────────────────────────────────────
+#
+# Le critère le plus important de l'issue #127, et le seul qui empêche la
+# fonctionnalité de se recasser en silence : un point de reprise qu'on n'a pas
+# pris doit faire échouer `dsoxlab run`. Avant, il sortait en 0.
 
-    assert "absent.lab" in caplog.text
-    # L'hôte suivant est tout de même traité : une absence n'interrompt pas.
-    assert virsh.domaines_vises("snapshot-delete") == ["web1.lab"]
+def _lab_vm(tmp_path: Path, *, filet: bool) -> Any:
+    """Un lab ``runtime: vm`` dont le setup.yaml existe, filet déclaré ou non."""
+    from dsoxlab.models.lab import LabDefinition, ValidationConfig
+    from dsoxlab.models.runtime import RuntimeConfig, RuntimeType, Target
+
+    racine = tmp_path / "labs" / "demo"
+    racine.mkdir(parents=True, exist_ok=True)
+    (racine / "setup.yaml").write_text("- hosts: lab_target\n")
+    (racine / "cleanup.yaml").write_text("- hosts: lab_target\n")
+    return LabDefinition(
+        id="demo-vm",
+        title="Demo VM",
+        level="l1",
+        skills=["s"],
+        runtime=RuntimeConfig(
+            type=RuntimeType.VM,
+            targets=[Target(name="t", host="web1.lab")],
+            snapshot_required=filet,
+        ),
+        distros=["alma9"],
+        doc_url="https://example.test/doc",
+        validation=ValidationConfig(),
+        path=racine,
+    )
+
+
+class PlaybooksJoues:
+    """Remplace ``ansible-runner`` : note quels playbooks auraient été joués."""
+
+    def __init__(self) -> None:
+        self.joues: list[str] = []
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.joues.append(Path(kwargs["playbook_path"]).name)
+        return type("R", (), {"ok": True, "rc": 0, "status": "successful", "stats": {}})()
+
+
+@pytest.fixture
+def runtime_vm(monkeypatch: pytest.MonkeyPatch, meta: RepoMetadata) -> Any:
+    """Un VmRuntime dont le meta.yml et l'inventaire sont neutralisés."""
+    from dsoxlab.infra import ansible as ansible_infra
+    from dsoxlab.runtimes.vm import VmRuntime
+
+    joues = PlaybooksJoues()
+    monkeypatch.setattr(ansible_infra, "run_playbook", joues)
+    runtime = VmRuntime()
+    monkeypatch.setattr(runtime, "_repo_meta", lambda lab: meta)
+    monkeypatch.setattr(runtime, "_inventory", lambda repo_meta, target: {})
+    runtime.playbooks = joues  # type: ignore[attr-defined]
+    return runtime
+
+
+@pytest.fixture
+def hyperviseur_qui_refuse(monkeypatch: pytest.MonkeyPatch) -> Hyperviseur:
+    """Un hyperviseur qui ne sait pas prendre le snapshot demandé."""
+    faux = Hyperviseur(refuse_snapshot=True)
+    monkeypatch.setattr(libvirt, "run_command", faux)
+    monkeypatch.setattr(libvirt, "_prefixe_retenu", [])
+    return faux
+
+
+def test_run_echoue_quand_le_point_de_reprise_exige_ne_peut_pas_etre_pris(
+    hyperviseur_qui_refuse: Hyperviseur, tmp_path: Path, runtime_vm: Any
+) -> None:
+    """Le défaut central : l'échec sortait en 0 et le lab démarrait sans filet."""
+    with pytest.raises(RuntimeError) as leve:
+        runtime_vm.start(_lab_vm(tmp_path, filet=True))
+
+    message = str(leve.value)
+    assert "snapshot_required" in message
+    assert "demo-vm" in message
+    assert "web1.lab" in message
+
+
+def test_le_setup_n_est_pas_joue_quand_le_filet_a_manque(
+    hyperviseur_qui_refuse: Hyperviseur, tmp_path: Path, runtime_vm: Any
+) -> None:
+    """Échouer après avoir modifié la machine ne vaudrait guère mieux que se taire."""
+    with pytest.raises(RuntimeError):
+        runtime_vm.start(_lab_vm(tmp_path, filet=True))
+
+    assert runtime_vm.playbooks.joues == []
+
+
+def test_un_lab_sans_filet_demarre_sans_toucher_a_l_hyperviseur(
+    hyperviseur: Hyperviseur, tmp_path: Path, runtime_vm: Any
+) -> None:
+    """``snapshot_required: false`` reste la déclaration de ceux qui s'en passent."""
+    runtime_vm.start(_lab_vm(tmp_path, filet=False))
+
+    assert runtime_vm.playbooks.joues == ["setup.yaml"]
+    assert hyperviseur.commandes == []
+
+
+def test_le_point_de_reprise_est_pris_avant_le_setup(
+    hyperviseur: Hyperviseur, meta: RepoMetadata, tmp_path: Path, runtime_vm: Any
+) -> None:
+    """Le prendre après figerait un état déjà modifié : le filet ne servirait à rien."""
+    runtime_vm.start(_lab_vm(tmp_path, filet=True))
+
+    assert runtime_vm.playbooks.joues == ["setup.yaml"]
+    assert kvm.list_(meta, "web1.lab") == ["pre-demo-vm"]
+
+
+def test_clean_retire_le_point_de_reprise_et_son_fichier(
+    hyperviseur: Hyperviseur, tmp_path: Path, runtime_vm: Any
+) -> None:
+    """Le laisser abandonnerait dans le pool un fichier que Terraform ignore."""
+    avant = hyperviseur.fichiers()
+    lab = _lab_vm(tmp_path, filet=True)
+    runtime_vm.start(lab)
+
+    runtime_vm.clean(lab)
+
+    assert runtime_vm.playbooks.joues == ["setup.yaml", "cleanup.yaml"]
+    assert hyperviseur.fichiers() == avant
+
+
+def test_reset_revient_au_point_de_reprise_au_lieu_du_cleanup(
+    hyperviseur: Hyperviseur, tmp_path: Path, runtime_vm: Any
+) -> None:
+    """C'est là que le filet sert, et ce qui donne enfin un effet à ce champ."""
+    lab = _lab_vm(tmp_path, filet=True)
+    runtime_vm.start(lab)
+    hyperviseur.ecrire("web1.lab", "degat-fait-par-l-apprenant")
+
+    runtime_vm.reset(lab)
+
+    assert "degat-fait-par-l-apprenant" not in hyperviseur.contenu("web1.lab")
+    assert runtime_vm.playbooks.joues == ["setup.yaml", "setup.yaml"]
+
+
+def test_reset_sans_filet_declare_rejoue_le_cleanup_comme_avant(
+    hyperviseur: Hyperviseur, tmp_path: Path, runtime_vm: Any
+) -> None:
+    """Les catalogues déclarent tous ``false`` : leur comportement ne bouge pas."""
+    lab = _lab_vm(tmp_path, filet=False)
+
+    runtime_vm.reset(lab)
+
+    assert runtime_vm.playbooks.joues == ["cleanup.yaml", "setup.yaml"]
+    assert hyperviseur.commandes == []

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.53"
+version = "0.1.56"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
# Summary

`snapshot_required: true` could not work on **any** dsoxlab VM. The template
imposes `firmware = "efi"` — correctly, since AlmaLinux 10 cloud images no longer
carry a BIOS bootloader — and libvirt refuses *internal* snapshots on pflash
firmware. Reproduced on a disposable UEFI domain shaped exactly like the ones the
packaged template produces:

```console
$ virsh snapshot-create-as --domain dsoxlab-snapprobe --name preuve-interne --atomic
error: Operation not supported: internal snapshots of a VM with pflash based
       firmware are not supported
```

Snapshots are now **external** (`--disk-only --atomic`), with the overlay
lifecycle handled end to end.

## The rollback, proven by behaviour and not by an exit code

Driven **through dsoxlab's own code** on a real domain. Three things were written
into the VM *after* the checkpoint: a file, a user account, and a disabled
`sshd`. Then `kvm.revert`:

```
--- the damage written after the checkpoint:
ls: cannot access '/etc/degat-issue-127.conf': No such file or directory
--- the user created after the checkpoint:
id: 'casse-tout': no such user
--- sshd, disabled after the checkpoint:
enabled
--- what preceded the checkpoint:
MARQUEUR-ISSUE-127-ECRIT-APRES-LE-SNAPSHOT
```

SSH coming back is itself the proof: `sshd` had been disabled before the
rollback. Pre-checkpoint content survived, and the checkpoint remained listed
afterwards, so it is replayable.

Two libvirt behaviours found the same way, and handled: `libvirt 10.0` refuses
`snapshot-revert` on an external snapshot (`Invalid target domain state
'disk-snapshot'`), and refuses to derive an overlay name on a `type='volume'`
disk (`cannot generate external snapshot name for disk 'vda' without source`) —
hence the explicit `--diskspec`.

## `run` now fails, and that is the point of the lot

Exit code measured without a pipe, since here it *is* the deliverable:

```
✘ Le lab filet-127 déclare snapshot_required: true et le point de reprise n'a
  pas pu être pris sur absent-de-libvirt.lab : …
  Le lab n'est PAS démarré, car il tournerait sans le filet qu'il réclame.
───── code de retour : 2 ─────
```

Before, the failure was swallowed into a `logger.warning` and `run` exited **0**
while announcing that rollback would not be available. **That silence is what let
the feature stay broken without anyone noticing.** A lab that tolerates running
without a net is entitled to say so: that is `snapshot_required: false`, which is
every existing lab.

A test also asserts `setup.yaml` is **not** played when the net fails — failing
after modifying the machine would be barely better than staying silent.

## Overlay files at `clean` and `destroy`

- **`clean`** → `snapshot-delete`: libvirt merges the overlay into the base,
  repoints the disk and deletes the file. Verified on real libvirt: disk back to
  `type='volume'`, only base + seed left in the pool, and the learner's
  post-checkpoint work preserved. On a libvirt too old to delete external
  snapshots, it falls back to `--metadata`: no orphan, one extra layer, logged.
- **`destroy`** → new `snapshot.purge()`, called **before** Terraform. Real run:
  `recouvrements retirés : ['…/dsoxlab-snapprobe.qcow2.pre-preuve-127']`, file
  gone, snapshot list empty. It must run before, because after the `undefine` the
  metadata leaves with the domain and the file becomes untraceable — the same
  orphan class as #107.

Everything goes through `virsh` (`vol-delete`, `vol-create-as`, `pool-refresh`),
never `qemu-img`, so it works whether virsh is reached through `libvirt` group
membership or through `sudo -n`.

## Type of change

- [x] Bug fix

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — no issues in 57 source files
- [x] `uv run pytest` — **464 passed** (440 before, +24); `tests_e2e` — **16 passed**
- [x] The engine stays domain-agnostic
- [x] No hardcoded personal path or host
- [x] Manually tested on **real libvirt**, on disposable objects only.
      `avant.txt` vs `final.txt` are byte-identical: **14 domains, 42 pools, 54
      volumes**, same names, same states, no nvram residue. **No lab repository
      was ever modified** — `snapshot_required: true` was set on a throwaway
      catalogue in the scratchpad, never on `ansible-training`.

### When behavior changes

- [x] Both CHANGELOG files updated; version **0.1.56**; `uv.lock` regenerated

### When a command or option is added, removed or changed

- [x] i18n keys added to **both** string tables
- [x] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched — N/A

### When the declarative contract changes

- [x] `snapshot_required`'s meaning is now documented: it **commits** the tool
      rather than informing it, and the **memory state is not captured** — a
      rollback restarts from a coherent disk, not from the second before. Only
      the field's description changed in `schemas/lab.schema.json`; no new key.

## Mutations played — seven, seven killed

The simulator is **stateful** (domains, volumes, overlay chain, and what each
layer contains), so the tests measure the disappearance of content rather than
the shape of a command:

| Mutation | Test that fell |
|---|---|
| snapshot goes back to internal | `test_create_vise_le_domaine_qui_existe` |
| overlay path no longer passed | idem |
| `run` swallows the failure again | `test_run_echoue_quand_le_point_de_reprise_exige_ne_peut_pas_etre_pris` |
| revert stops checking which layer it drops | `test_le_retour_arriere_refuse_une_couche_qui_n_est_plus_du_dessus` |
| revert no longer empties the overlay | `test_le_retour_arriere_efface_ce_qui_a_ete_ecrit_apres` |
| delete only forgets metadata | `test_supprimer_ne_laisse_aucun_fichier_de_recouvrement` |
| purge leaves the overlay | `test_la_purge_retire_le_snapshot_et_son_fichier` |

Verified independently before opening this PR: disabling the `snapshot_required`
block turns **4 tests red**; restored, 464 pass.

## Decisions worth reviewing

1. **`reset` now rolls back instead of replaying `cleanup.yaml`** when
   `snapshot_required: true`. Without it, `revert` stayed correct but
   unreachable — the field would have had no observable effect at all. No
   regression risk (no lab declares `true`), but it is a semantic addition beyond
   the issue's letter. A failed rollback is deliberately **not** caught by a
   `cleanup.yaml` fallback: that would swap a guarantee for an approximation
   without saying so.
2. **`delete` preserves the current state; `purge` discards it.** Two verbs, two
   meanings. Making `clean` roll back too is a one-line change.
3. **`purge` does not stop the domain** before removing the overlay. Terraform
   destroys it immediately after, and on Linux qemu keeps the deleted inode open.
   Correct, slightly unusual.
4. **Old-libvirt fallback keeps the overlay as the live disk.** Safe — no orphan,
   no data loss — but the chain deepens one layer per cycle on such hosts. Only a
   warning marks it.
5. **Version 0.1.56** was arbitrated in advance against two parallel branches
   (0.1.54, 0.1.55). If 0.1.55 lands after this one, the numbering has a gap;
   renumbering is mechanical.
6. The project `CLAUDE.md` (unversioned) still describes the old snapshot
   behaviour.

## Related issues

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
