### PR TITLE
feat(état): un verrou par dépôt, et une interruption qui se dit (0.1.55)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,99 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.55] - 2026-08-21
+
+### Ajouté
+
+- **Un verrou d'écriture par dépôt, pour que deux terminaux cessent de s'écraser
+  l'un l'autre.** Rien n'empêchait deux `dsoxlab` de travailler en même temps sur
+  le même dépôt, et deux terminaux ouverts, c'est le cas normal chez un
+  apprenant. L'état partagé est éparpillé : `.dsoxlab-context.json` est réécrit
+  *en entier* à chaque changement, donc la seconde écriture perdait la première
+  sans laisser de trace ; le state Terraform sous
+  `~/.local/state/dsoxlab/<repo-id>/` ; l'inventaire et le fragment `ssh_config`
+  régénérés ; les conteneurs de `runtime.services`, nommés par dépôt donc
+  partagés. Seule la base SQLite de progression était protégée, par SQLite.
+  `provision`, `destroy`, `run`, `check`, `submit`, `reset`, `clean` et `use`
+  prennent désormais le verrou. Une seconde invocation est refusée avec le code
+  de sortie **7** et un message traduit qui nomme la commande détentrice, son PID
+  et depuis combien de temps elle tourne.
+
+- **Les commandes de lecture ne sont jamais bloquées.** `list-labs`, `show`,
+  `scores`, `progress`, `next`, `status`, `doctor`, `course`, `challenge`,
+  `hint`, `guide`, `validate-structure` et `support` ne prennent pas le verrou :
+  consulter son catalogue pendant qu'un `provision` tourne dans un autre terminal
+  est un usage normal, pas un conflit.
+
+- **Un verrou périmé n'est jamais un fichier à supprimer à la main.** Le verrou
+  est un `flock` posé sur un fichier du répertoire d'état du dépôt, juste à côté
+  du state Terraform qu'il protège. Le noyau le relâche quand le descripteur se
+  ferme : un détenteur tué au `SIGKILL`, ou perdu dans un redémarrage, ne laisse
+  rien à nettoyer, et il n'y a donc aucun verrou à « reprendre », ce qui est la
+  vraie difficulté de tout verrou par fichier sentinelle. Le fichier, lui,
+  survit ; il est tronqué au relâchement pour ne jamais accuser une commande
+  terminée depuis longtemps, et il n'est jamais supprimé, parce que l'effacer est
+  la course classique où un processus retire l'inode sous les pieds d'un autre.
+  Sur un système de fichiers incapable de verrouiller (`ENOLCK`), la commande
+  travaille sans filet avec un avertissement au journal, plutôt que de refuser de
+  démarrer.
+
+- **`run` rend le verrou avant d'ouvrir la session.** Un verrou tenu « pour toute
+  la commande » couvrirait le sous-shell interactif, et c'est précisément là que
+  l'apprenant tape `dsoxlab check`, qui serait alors refusé par sa propre
+  session.
+
+### Corrigé
+
+- **Un Ctrl-C ne rend plus l'invite sans un mot.** Rien n'attrapait
+  `KeyboardInterrupt` en dehors du pager. Typer, tout en bas, en fait un
+  `Exit(130)` : le code de retour était donc déjà juste, et c'est précisément ce
+  qui rendait le défaut invisible. L'apprenant retrouvait son invite sans savoir
+  ce qui venait d'être interrompu, ce qui restait debout, ni quoi rejouer. Chaque
+  étape longue nomme désormais ces trois choses, et sort toujours en **130**
+  (`128 + SIGINT`, ce que le shell rend lui-même). Une étape mentait aussi sur le
+  code, et c'est l'entrée suivante.
+
+- **Terraform est arrêté en deux temps au lieu d'être pris de vitesse.** Il
+  tourne maintenant dans sa propre session (`start_new_session`). Dans le groupe
+  de processus partagé, le Ctrl-C du terminal atteignait dsoxlab et Terraform au
+  même instant : impossible de savoir si le fils avait déjà reçu son signal, et
+  lui en envoyer un risquait de compter pour le *second*, celui qui fait sortir
+  Terraform sans finir la ressource en cours. Isolé, le fils ne reçoit que ce que
+  dsoxlab lui envoie : le premier Ctrl-C lui transmet `SIGINT` et continue de
+  drainer sa sortie pour qu'il puisse finir et enregistrer son état, le second
+  escalade en `SIGTERM` puis `SIGKILL`. Avant, un second Ctrl-C sortait du
+  `finally: proc.wait()` et laissait Terraform continuer, orphelin, à créer des
+  machines que plus personne ne suivait.
+
+- **Un playbook interrompu n'est plus rendu comme un playbook en échec.** C'est
+  le seul chemin où le code de sortie lui-même était faux. `ansible-runner` pose
+  ses propres handlers `SIGINT` et `SIGTERM` dès qu'on ne lui fournit pas de
+  `cancel_callback`, et ne les restaure jamais. Deux conséquences, mesurées
+  toutes les deux sur la version installée : pendant un playbook, un Ctrl-C ne
+  levait aucun `KeyboardInterrupt`, l'exécution était annulée, et l'appelant
+  rendait le `rc=254, status=canceled` obtenu en « setup.yaml a échoué » avec le
+  code **2** ; et après le playbook, `SIGINT` *et* `SIGTERM` restaient détournés
+  pour le reste du processus, si bien qu'un `kill` sur dsoxlab n'avait plus
+  d'effet. dsoxlab fournit désormais le callback et restaure les handlers qu'il a
+  trouvés.
+
+- **Un `check` interrompu ne laisse plus pytest tourner derrière lui.** La boucle
+  de lecture était abandonnée sans attendre le fils : pytest continuait de
+  piloter la machine du lab pendant que l'apprenant croyait tout avoir arrêté, et
+  le processus restait zombie jusqu'à la sortie de la CLI. Il est maintenant tué,
+  et rien n'est enregistré, parce qu'une validation interrompue ne doit coûter
+  aucun point.
+
+- **Les autres points d'interruption sont nommés eux aussi** : le téléchargement
+  du provider Terraform, l'attente SSH après un provision (l'infrastructure, elle,
+  est en place, et rejouer `provision` est idempotent), les services
+  conteneurisés (l'un d'eux peut être debout sans avoir été initialisé, ce que le
+  prochain `run` répare en rejouant `post_start`) et la session interactive du
+  lab. Un Ctrl-C ailleurs est rattrapé par un filet de dernier recours posé sur
+  le groupe Click, dernier endroit capable de nommer l'interruption avant que
+  typer n'en fasse une sortie 130 muette.
+
 ## [0.1.53] - 2026-08-21
 
 ### Modifié

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,93 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.55] - 2026-08-21
+
+### Added
+
+- **A write lock per repository, so two terminals stop overwriting each other.**
+  Nothing prevented two `dsoxlab` from working at once on the same repository,
+  and two open terminals is the normal case for a learner. The shared state is
+  spread wide: `.dsoxlab-context.json` is rewritten *whole* on every change, so
+  the second write silently discarded the first; the Terraform state under
+  `~/.local/state/dsoxlab/<repo-id>/`; the regenerated inventory and `ssh_config`
+  fragment; the `runtime.services` containers, named per repository and therefore
+  shared. Only the SQLite progress database was protected, by SQLite itself.
+  `provision`, `destroy`, `run`, `check`, `submit`, `reset`, `clean` and `use`
+  now take the lock. A second invocation is refused with exit code **7** and a
+  translated message naming the holding command, its PID and how long it has been
+  running.
+
+- **Read commands are never blocked.** `list-labs`, `show`, `scores`, `progress`,
+  `next`, `status`, `doctor`, `course`, `challenge`, `hint`, `guide`,
+  `validate-structure` and `support` do not take the lock: consulting the
+  catalogue while a `provision` runs in another terminal is normal use, not a
+  conflict.
+
+- **A stale lock is never something to delete by hand.** The lock is a `flock`
+  held on a file in the repository's own state directory, right next to the
+  Terraform state it protects. The kernel releases it when the descriptor closes,
+  so a holder killed with `SIGKILL`, or lost in a reboot, leaves nothing to clean
+  up: there is no stale lock to "recover", which is the hard part of every
+  sentinel-file lock. The file survives and is truncated on release, so it can
+  never name a command that finished hours ago, and it is never unlinked, which
+  is the classic race where one process pulls the inode out from under another.
+  On a filesystem that cannot lock (`ENOLCK`), the command runs unprotected with
+  a warning in the journal rather than refusing to start.
+
+- **`run` hands the lock back before opening the session.** A lock held "for the
+  whole command" would cover the interactive sub-shell, and that is exactly where
+  the learner types `dsoxlab check`, which would then be refused by its own
+  session.
+
+### Fixed
+
+- **Ctrl-C no longer returns the prompt without a word.** Nothing caught
+  `KeyboardInterrupt` outside the pager. Typer turns it into `Exit(130)` at the
+  very bottom, so the exit code was already right, and that is exactly what made
+  the defect invisible: the learner got their prompt back with no idea what had
+  been interrupted, what was still standing, or what to replay. Every long step
+  now names those three things, and still exits **130** (`128 + SIGINT`, what the
+  shell itself returns). One step also lied about the code, and it is the next
+  entry.
+
+- **Terraform is stopped in two steps instead of being raced.** It now runs in
+  its own session (`start_new_session`). In the shared process group, the
+  terminal's Ctrl-C reached dsoxlab and Terraform at the same instant, so dsoxlab
+  could never know whether the child had already been signalled, and sending it
+  one risked counting as the *second* interrupt, the one that makes Terraform
+  exit without finishing the resource in flight. Isolated, the child receives
+  only what dsoxlab sends: the first Ctrl-C forwards `SIGINT` and keeps draining
+  its output so it can finish and save its state, and the second escalates to
+  `SIGTERM` then `SIGKILL`. Before, a second Ctrl-C broke out of the
+  `finally: proc.wait()` and left Terraform running, orphaned, still creating
+  machines nobody was watching.
+
+- **An interrupted playbook is no longer reported as a failed playbook.** This
+  is the one path where the exit code itself was wrong. `ansible-runner`
+  installs its own `SIGINT` and `SIGTERM` handlers whenever no `cancel_callback`
+  is given, and never restores them. Two consequences, both measured on the
+  installed version: during a playbook, Ctrl-C raised no `KeyboardInterrupt` at
+  all, the run was cancelled, and the caller turned the resulting `rc=254,
+  status=canceled` into "setup.yaml failed" and exit code **2**; and after the
+  playbook, `SIGINT` *and* `SIGTERM` stayed hijacked for the rest of the process,
+  so a `kill` on dsoxlab had no effect. dsoxlab now supplies the callback and
+  restores the handlers it found.
+
+- **An interrupted `check` no longer leaves pytest running behind it.** The read
+  loop was abandoned without waiting for the child: pytest kept driving the lab
+  machine while the learner believed everything had stopped, and the process
+  stayed a zombie until the CLI exited. It is now killed, and nothing is
+  recorded, because an interrupted validation must not cost a score.
+
+- **The remaining interruption points are named too**: the Terraform provider
+  download, the post-provision SSH wait (the infrastructure itself is up, and
+  replaying `provision` is idempotent), the container services (one may be up
+  without having been initialised, which the next `run` repairs by replaying
+  `post_start`), and the interactive lab session. A Ctrl-C anywhere else is
+  caught by a last-resort net installed on the Click group, the last place able
+  to give the interruption a name before Typer turns it into a silent exit 130.
+
 ## [0.1.53] - 2026-08-21
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.53"
+version = "0.1.55"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -49,6 +49,14 @@ from .config import (
 from .i18n import _, get_lang, set_lang
 from .infra import libvirt
 from .infra.inventory import InfraNotProvisioned
+from .interrupt import (
+    EVENT_INTERRUPT,
+    EXIT_INTERRUPTED,
+    Interrupted,
+    Stage,
+    interruptible,
+)
+from .locking import EXIT_LOCKED, RepoLock, RepoLocked
 from .logging_setup import configurer as configurer_journal
 from .models import (
     CourseManifest,
@@ -129,6 +137,30 @@ class _I18nGroup(TyperGroup):
         if opt is not None:
             opt.help = _("opt_help")
         return opt
+
+    def invoke(self, ctx: Any) -> Any:
+        """Traduit un Ctrl-C resté sans propriétaire en interruption nommée.
+
+        C'est le **seul** endroit qui puisse le faire. Typer attrape lui-même
+        ``KeyboardInterrupt`` tout en bas de son ``_main()`` et le change en
+        ``Exit(130)`` : le code de retour était déjà juste, mais l'interruption
+        y perdait toute identité, et un filet posé autour de ``app()`` ne voit
+        jamais rien passer. ``invoke`` s'exécute à l'intérieur de ce ``_main()``,
+        donc en amont : c'est le dernier moment où l'on peut encore dire à
+        l'apprenant ce qui vient d'être interrompu, au lieu de lui rendre son
+        invite sans un mot.
+
+        On convertit ici, et **jamais** à la source par un handler de signal :
+        ``KeyboardInterrupt`` descend de ``BaseException``, ce qui est
+        exactement ce qui lui permet de traverser les ``except Exception`` que
+        ce code pose autour des callbacks d'affichage. Une exception ordinaire
+        levée depuis un handler s'y ferait avaler en silence, et le flux
+        Terraform continuerait comme si de rien n'était.
+        """
+        try:
+            return super().invoke(ctx)
+        except KeyboardInterrupt:
+            raise Interrupted(Stage.UNKNOWN) from None
 
 
 app = typer.Typer(
@@ -266,6 +298,58 @@ def _require_provider(repo_meta: RepoMetadata) -> str:
         raise typer.Exit(1) from None
 
 
+def _verrou(root: Path, commande: str) -> RepoLock:
+    """Prend le verrou d'écriture du dépôt, ou sort en nommant qui le tient.
+
+    À n'appeler que dans les commandes qui **modifient** l'état. Les commandes
+    de lecture (``list-labs``, ``show``, ``scores``, ``progress``, ``next``,
+    ``status``, ``doctor``, ``course``, ``challenge``, ``hint``, ``guide``,
+    ``validate-structure``, ``support``, ``fullhelp``) ne passent pas par ici :
+    consulter son catalogue pendant qu'un ``provision`` tourne dans un autre
+    terminal est un usage normal, pas un conflit.
+
+    Le verrou rendu est **déjà pris**. L'appelant choisit sa portée :
+
+    - ``ctx.call_on_close(_verrou(...).release)`` pour toute la commande ;
+    - ``with _verrou(...):`` pour la seule phase qui écrit. C'est ce que fait
+      ``run``, qui doit rendre le verrou **avant** d'ouvrir la session
+      interactive, sinon le ``dsoxlab check`` que l'apprenant tape dans ce
+      sous-shell serait refusé par sa propre session.
+    """
+    verrou = RepoLock(root, commande)
+    try:
+        verrou.acquire()
+    except RepoLocked as exc:
+        detenteur = exc.holder
+        if detenteur is None:
+            error(_("lock_busy_anonymous", path=exc.path))
+        else:
+            error(_(
+                "lock_busy",
+                command=detenteur.command, pid=detenteur.pid,
+                age=detenteur.age_label,
+            ))
+        info(_("lock_busy_hint"))
+        raise typer.Exit(EXIT_LOCKED) from None
+    return verrou
+
+
+def _interrompu(exc: Interrupted, reprise: str) -> NoReturn:
+    """Rend une interruption : ce qui reste en place, puis comment reprendre.
+
+    Trois affirmations, dans cet ordre, et le code de sortie **130** qui les
+    confirme (``128 + SIGINT``) : ce qui a été interrompu, ce que ça laisse
+    derrière, et la commande qui reprend. Le code, typer le rendait déjà ; ce
+    qui manquait, c'était la phrase, et sur le chemin Ansible le code lui-même,
+    qui annonçait un échec (2) là où l'apprenant avait appuyé sur Ctrl-C.
+    """
+    warn(_(exc.message_key))
+    if exc.hard:
+        warn(_("interrupted_hard"))
+    info(_("interrupt_resume", cmd=reprise))
+    raise typer.Exit(EXIT_INTERRUPTED)
+
+
 def _services_repo_id(root: Path) -> str:
     """Slug du dépôt, pour namespacer les conteneurs de services.
 
@@ -295,11 +379,15 @@ def _ensure_services(lab: LabDefinition, root: Path) -> None:
     repo_id = _services_repo_id(root)
     for service in lab.runtime.services:
         info(_("service_starting", name=service.name, image=service.image))
-        try:
-            svc.start(service, repo_id)
-        except svc.ServiceError as exc:
-            error(_("service_failed", name=service.name, detail=str(exc)))
-            raise typer.Exit(2) from None
+        # Le démarrage attend les sondes du service, jusqu'à `ready_timeout`
+        # secondes : c'est le point d'attente le plus long d'un lab shell, donc
+        # celui où le Ctrl-C tombe.
+        with interruptible(Stage.SERVICES):
+            try:
+                svc.start(service, repo_id)
+            except svc.ServiceError as exc:
+                error(_("service_failed", name=service.name, detail=str(exc)))
+                raise typer.Exit(2) from None
         success(_("service_ready", name=service.name))
 
 
@@ -530,6 +618,7 @@ def install() -> None:
 
 @app.command("use", help=_("cmd_use_help"))
 def use(
+    ctx: typer.Context,
     context: Annotated[str | None, typer.Argument(help=_("cmd_use_arg"))] = None,
     lab_home: LabHomeOption = None,
     lang: Annotated[str | None, typer.Option("--lang", help=_("opt_lang"))] = None,
@@ -540,6 +629,9 @@ def use(
     reset: Annotated[bool, typer.Option("--reset", "-r", help=_("opt_use_reset"))] = False,
 ) -> None:
     root = _root(lab_home)
+    # `.dsoxlab-context.json` est réécrit EN ENTIER à chaque changement : deux
+    # `use` concurrents, et le premier est perdu sans laisser de trace.
+    ctx.call_on_close(_verrou(root, "use").release)
     if reset:
         clear_context(root)
         success(_("context_cleared"))
@@ -715,25 +807,32 @@ def run(
         raise typer.Exit(1) from None
 
     info(_("lab_starting", lab_id=lab.id, runtime=lab.runtime.type.value))
-    _ensure_services(lab, root)
-    try:
-        if lab.runtime.type.value in ("vm", "kvm", "incus"):
-            _run_ansible_with_progress(
-                lab.path / "setup.yaml",
-                lambda cb: run_lab(lab, target_name=target, on_event=cb),
-            )
-        else:
-            run_lab(lab, target_name=target)
-    except InfraNotProvisioned:
-        # Avant le except RuntimeError : InfraNotProvisioned en hérite, et
-        # mérite la phrase actionnable plutôt que son message technique.
-        error(_("infra_not_provisioned"))
-        raise typer.Exit(2) from None
-    except RuntimeError as exc:
-        error(str(exc))
-        raise typer.Exit(2) from None
+    # Le verrou ne couvre QUE la phase qui écrit : services, playbook de setup,
+    # contexte. Il est rendu avant la session interactive, sinon le `dsoxlab
+    # check` que l'apprenant tape dans ce sous-shell serait refusé par sa
+    # propre session, blocage que personne ne comprendrait.
+    with _verrou(root, "run"):
+        _ensure_services(lab, root)
+        try:
+            if lab.runtime.type.value in ("vm", "kvm", "incus"):
+                _run_ansible_with_progress(
+                    lab.path / "setup.yaml",
+                    lambda cb: run_lab(lab, target_name=target, on_event=cb),
+                )
+            else:
+                run_lab(lab, target_name=target)
+        except Interrupted as exc:
+            _interrompu(exc, f"dsoxlab run {lab.id}")
+        except InfraNotProvisioned:
+            # Avant le except RuntimeError : InfraNotProvisioned en hérite, et
+            # mérite la phrase actionnable plutôt que son message technique.
+            error(_("infra_not_provisioned"))
+            raise typer.Exit(2) from None
+        except RuntimeError as exc:
+            error(str(exc))
+            raise typer.Exit(2) from None
 
-    set_active_lab(root, lab.id)
+        set_active_lab(root, lab.id)
     # Dire où l'on atterrit vraiment. Le message historique annonçait
     # « challenge/work/ » quel que soit le runtime : faux pour tout lab vm,
     # qui ouvre une session SSH ou, désormais, un shell à la racine du dépôt.
@@ -754,7 +853,10 @@ def run(
 
     print_lab_welcome(lab)
 
-    open_lab_session(lab)   # bloquant : sous-shell interactif
+    try:
+        open_lab_session(lab)   # bloquant : sous-shell interactif
+    except Interrupted as exc:
+        _interrompu(exc, f"dsoxlab run {lab.id}")
 
     # Retour au shell parent : on garde active_lab posé pour que
     # ``dsoxlab check`` et ``dsoxlab submit`` (sans argument) sachent
@@ -1091,6 +1193,20 @@ def _run_check(
         if session_target and lab.runtime.target(session_target) is not None:
             target = session_target
 
+    # Le verrou couvre les services ET pytest. Les tests pilotent la machine
+    # du lab (ou ses conteneurs) : deux validations concurrentes se marchent
+    # dessus, et la seconde note un état que la première est en train de
+    # changer. Il est pris ICI, pas au début : tout ce qui précède ne fait que
+    # lire, et refuser une faute de frappe sur `--target` pour cause de verrou
+    # serait absurde.
+    with _verrou(root, "check"):
+        return _valider(root, lab, target, quiet=quiet)
+
+
+def _valider(
+    root: Path, lab: LabDefinition, target: str | None, *, quiet: bool,
+) -> tuple[CheckResult, int, int]:
+    """Joue les tests et enregistre la note. Appelé sous verrou."""
     # Les services conteneurisés (émulateur cloud, base…) doivent être debout
     # avant que pytest ne s'exécute : les tests pilotent l'API qu'ils exposent.
     _ensure_services(lab, root)
@@ -1140,7 +1256,10 @@ def check(
 ) -> None:
     root = _root(lab_home)
     lab = _resolve_lab(root, lab_id, _lang(root))
-    result, score, max_score = _run_check(root, lab, target, quiet=as_json)
+    try:
+        result, score, max_score = _run_check(root, lab, target, quiet=as_json)
+    except Interrupted as exc:
+        _interrompu(exc, f"dsoxlab check {lab.id}")
     if as_json:
         # La sortie brute de pytest est conservée : c'est là que l'appelant
         # trouve le détail des échecs, qu'aucun compteur ne résume.
@@ -1177,7 +1296,10 @@ def submit(
 ) -> None:
     root = _root(lab_home)
     lab = _resolve_lab(root, lab_id, _lang(root))
-    result, score, max_score = _run_check(root, lab, target)
+    try:
+        result, score, max_score = _run_check(root, lab, target)
+    except Interrupted as exc:
+        _interrompu(exc, f"dsoxlab submit {lab.id}")
 
     if result.ok:
         success(_("submit_success", score=score, max_score=max_score))
@@ -1287,6 +1409,7 @@ def next_lab(
 
 @app.command("reset", help=_("cmd_reset_help"))
 def reset(
+    ctx: typer.Context,
     lab_id: Annotated[str, typer.Argument(help=_("cmd_reset_arg"), autocompletion=_complete_lab_id)],
     target: Annotated[str | None, typer.Option("--target", "-t",
         help=_("opt_run_target"))] = None,
@@ -1300,6 +1423,7 @@ def reset(
         error(str(exc))
         raise typer.Exit(1) from None
 
+    ctx.call_on_close(_verrou(root, "reset").release)
     info(_("resetting", lab_id=lab.id))
     try:
         if lab.runtime.type.value in ("vm", "kvm", "incus"):
@@ -1311,6 +1435,8 @@ def reset(
             reset_lab(lab, target_name=target)
         reset_hints(root, lab.id)
         success(_("lab_reset"))
+    except Interrupted as exc:
+        _interrompu(exc, f"dsoxlab reset {lab.id}")
     except RuntimeError as exc:
         error(str(exc))
         raise typer.Exit(2) from None
@@ -1320,6 +1446,7 @@ def reset(
 
 @app.command("clean", help=_("cmd_clean_help"))
 def clean(
+    ctx: typer.Context,
     lab_id: Annotated[str, typer.Argument(help=_("cmd_clean_arg"), autocompletion=_complete_lab_id)],
     target: Annotated[str | None, typer.Option("--target", "-t",
         help=_("opt_run_target"))] = None,
@@ -1337,6 +1464,10 @@ def clean(
     if not yes:
         typer.confirm(_("confirm_clean", lab_id=lab.id), abort=True)
 
+    # Après la confirmation, jamais avant : tenir le verrou pendant qu'on
+    # attend une réponse au clavier bloquerait l'autre terminal sur une
+    # question que personne ne voit.
+    ctx.call_on_close(_verrou(root, "clean").release)
     info(_("cleaning", lab_id=lab.id))
     try:
         if lab.runtime.type.value in ("vm", "kvm", "incus"):
@@ -1348,6 +1479,8 @@ def clean(
             clean_lab(lab, target_name=target)
         _stop_services(lab, root)
         success(_("clean_done"))
+    except Interrupted as exc:
+        _interrompu(exc, f"dsoxlab clean {lab.id}")
     except RuntimeError as exc:
         error(str(exc))
         raise typer.Exit(2) from None
@@ -1598,6 +1731,7 @@ def _diagnostic_message(hote: dict[str, Any]) -> str:
 
 @app.command("provision", help=_("cmd_provision_help"))
 def provision(
+    ctx: typer.Context,
     host: Annotated[list[str] | None, typer.Option(
         "--host",
         help=_("opt_provision_host"),
@@ -1609,6 +1743,11 @@ def provision(
     from .infra.terraform import ProviderNotImplemented, TerraformNotInstalled, host_targets
 
     root = _root(lab_home)
+    # Le verrou est pris avant même de lire le contrat : ce qui suit interroge
+    # l'hyperviseur, puis écrit le state Terraform. Un `destroy` lancé dans un
+    # autre terminal pendant le scan des machines orphelines rendrait ce scan
+    # faux au moment où on s'en sert.
+    ctx.call_on_close(_verrou(root, "provision").release)
     repo_meta = _read_repo(root)
     if repo_meta is None:
         error(_("provision_no_meta", root=root))
@@ -1685,6 +1824,11 @@ def provision(
                 targets=targets or None, target_hosts=list(host) if host else None,
             ),
         )
+    except Interrupted as exc:
+        # AVANT le `except Exception` : une interruption n'est pas un échec de
+        # provisionnement, et sortir en 4 avec « provision failed » ferait
+        # chercher une panne là où l'apprenant a simplement appuyé sur Ctrl-C.
+        _interrompu(exc, "dsoxlab provision")
     except ProviderNotImplemented as exc:
         error(str(exc))
         raise typer.Exit(2) from None
@@ -1739,12 +1883,19 @@ def provision(
                 )
 
             try:
-                wait_for_hosts_ready(
-                    repo_meta, ready_hosts, on_attempt=_on_attempt
-                )
+                with interruptible(Stage.HOSTS_WAIT):
+                    wait_for_hosts_ready(
+                        repo_meta, ready_hosts, on_attempt=_on_attempt
+                    )
             except HostReadyTimeout as exc:
                 progress.stop()
                 warn(_("provision_ssh_timeout", error=str(exc)))
+            except Interrupted as exc:
+                # L'infrastructure existe déjà : c'est l'attente qui a été
+                # coupée, pas la création. Rejouer `provision` est idempotent
+                # et reprend exactement ici.
+                progress.stop()
+                _interrompu(exc, "dsoxlab provision")
 
     # Le fragment SSH, écrit à CHAQUE provision et non seulement quand des
     # machines viennent d'être créées : relancer un provision sur une infra
@@ -1784,6 +1935,7 @@ def provision(
 
 @app.command("destroy", help=_("cmd_destroy_help"))
 def destroy(
+    ctx: typer.Context,
     host: Annotated[list[str] | None, typer.Option(
         "--host",
         help=_("opt_destroy_host"),
@@ -1831,6 +1983,9 @@ def destroy(
     if not yes:
         typer.confirm(_("confirm_destroy", provider=provider), abort=True)
 
+    # Après la confirmation : tenir le verrou pendant l'attente d'une réponse
+    # au clavier bloquerait l'autre terminal sans rien protéger.
+    ctx.call_on_close(_verrou(root, "destroy").release)
     info(_("destroy_starting", provider=provider))
     try:
         # init est rapide en destroy (provider déjà téléchargé) mais
@@ -1845,6 +2000,10 @@ def destroy(
                 targets=targets or None, target_hosts=list(host) if host else None,
             ),
         )
+    except Interrupted as exc:
+        # Avant le `except Exception`, même raison qu'au provision : Terraform
+        # a écrit son state, ce qui reste debout est connu, et rejouer suffit.
+        _interrompu(exc, "dsoxlab destroy")
     except ProviderNotImplemented as exc:
         error(str(exc))
         raise typer.Exit(2) from None
@@ -1962,7 +2121,12 @@ def _run_ansible_with_progress(
             etype = event.get("event")
             data = event.get("event_data", {}) or {}
 
-            if etype == "playbook_on_task_start":
+            if etype == EVENT_INTERRUPT:
+                progress.console.print(_(
+                    "interrupt_notice_first" if event.get("count", 1) == 1
+                    else "interrupt_notice_second"
+                ))
+            elif etype == "playbook_on_task_start":
                 task_name = data.get("name") or data.get("task", "")
                 state["current_task"] = task_name
                 progress.update(task, description=_("progress_ansible_task", task=task_name))
@@ -2149,6 +2313,11 @@ def _run_terraform_with_progress(
                     diag = event.get("diagnostic", {})
                     summary = diag.get("summary", "")
                     progress.console.print(f"  [red]Error:[/red] {summary}")
+            elif etype == EVENT_INTERRUPT:
+                progress.console.print(_(
+                    "interrupt_notice_first" if event.get("count", 1) == 1
+                    else "interrupt_notice_second"
+                ))
 
         state["result"] = runner(on_event)
         # Une fois terminé, fixe la barre à 100 % avec un label final
@@ -2600,6 +2769,14 @@ def main() -> None:
     """
     try:
         app()
+    except Interrupted as exc:
+        # Interruption d'une commande qui n'avait pas de consigne de reprise à
+        # donner, ou survenue hors des étapes inventoriées. On dit au moins ce
+        # qui a été interrompu, et on sort en 130 plutôt qu'en 1.
+        warn(_(exc.message_key))
+        if exc.hard:
+            warn(_("interrupted_hard"))
+        raise SystemExit(EXIT_INTERRUPTED) from None
     except InfraNotProvisioned:
         error(_("infra_not_provisioned"))
         raise SystemExit(1) from None

--- a/src/dsoxlab/config.py
+++ b/src/dsoxlab/config.py
@@ -6,6 +6,8 @@ import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+from .utils.fichiers import ecrire_atomiquement
+
 logger = logging.getLogger(__name__)
 
 _CONTEXT_FILE = ".dsoxlab-context.json"
@@ -134,12 +136,17 @@ def read_context(root: Path) -> ActiveContext:
 
 
 def _persist(root: Path, ctx: ActiveContext) -> None:
-    """Écrit le contexte sur disque en omettant les champs vides/None."""
+    """Écrit le contexte sur disque en omettant les champs vides/None.
+
+    Écriture atomique : le fichier était tronqué avant d'être réécrit, et une
+    coupure entre les deux le laissait vide ou coupé au milieu. ``read_context``
+    rend alors un contexte vide, par sécurité et **sans un mot** : l'apprenant
+    perdait sa section, sa target et son lab actif sans jamais savoir pourquoi.
+    """
     raw = asdict(ctx)
     # On omet les champs qui sont None ou 0 pour rester lisible
     data = {k: v for k, v in raw.items() if v not in (None, "", 0)}
-    path = get_context_path(root)
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    ecrire_atomiquement(get_context_path(root), json.dumps(data, indent=2))
 
 
 def write_context(

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -869,4 +869,52 @@ silent.
     "err_template_cloud_init_missing":
         "No cloud-init template for distribution '{distro}'. "
         "Packaged distros: {available}",
+
+    # ── verrou d'écriture par dépôt (issue #81) ─────────────────────────────
+    "lock_busy":
+        "Another dsoxlab command is already working on this repository: "
+        "« {command} » (PID {pid}, running for {age}). Nothing was changed.",
+    "lock_busy_anonymous":
+        "Another dsoxlab command is already working on this repository "
+        "(lock: {path}). Nothing was changed.",
+    "lock_busy_hint":
+        "Wait for it to finish, or stop it. A lock left behind by a process "
+        "that died is released on its own: there is no file to delete by hand.",
+
+    # ── interruption d'une opération longue (issue #82) ─────────────────────
+    "interrupt_notice_first":
+        "Interruption requested. Letting the current step finish so nothing "
+        "is left half-written. Press Ctrl-C again to stop right now.",
+    "interrupt_notice_second":
+        "Second interruption: stopping now.",
+    "interrupt_resume":
+        "Replay to pick up where it stopped: {cmd}",
+    "interrupted_hard":
+        "You interrupted twice, so the operation was killed rather than "
+        "closed: what it left behind may be incomplete.",
+    "interrupted_terraform_init":
+        "Interrupted while downloading the Terraform provider. "
+        "No resource was created.",
+    "interrupted_terraform_apply":
+        "Interrupted: Terraform stopped and saved its state. What it had "
+        "already created is still there, and is known to the state.",
+    "interrupted_terraform_destroy":
+        "Interrupted: Terraform stopped and saved its state. Part of the "
+        "infrastructure is still up.",
+    "interrupted_ansible":
+        "Interrupted: the playbook stopped mid-run. The machine may be "
+        "partially configured; lab playbooks are idempotent.",
+    "interrupted_services":
+        "Interrupted while starting the lab services. A container may be up "
+        "without having been initialised.",
+    "interrupted_hosts_wait":
+        "Interrupted while waiting for the machines to answer over SSH. "
+        "The infrastructure itself is up.",
+    "interrupted_tests":
+        "Interrupted: the tests were stopped. Nothing was recorded, so this "
+        "run costs you no score.",
+    "interrupted_session":
+        "Interrupted: the lab session was closed. Your work is untouched.",
+    "interrupted_unknown":
+        "Interrupted by Ctrl-C.",
 }

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -873,4 +873,54 @@ hors ligne, elle se tait.
     "err_template_cloud_init_missing":
         "Template cloud-init absent pour la distribution « {distro} ». "
         "Distros packagées : {available}",
+
+    # ── verrou d'écriture par dépôt (issue #81) ─────────────────────────────
+    "lock_busy":
+        "Une autre commande dsoxlab travaille déjà sur ce dépôt : "
+        "« {command} » (PID {pid}, depuis {age}). Rien n'a été modifié.",
+    "lock_busy_anonymous":
+        "Une autre commande dsoxlab travaille déjà sur ce dépôt "
+        "(verrou : {path}). Rien n'a été modifié.",
+    "lock_busy_hint":
+        "Attends qu'elle se termine, ou arrête-la. Un verrou laissé par un "
+        "processus mort se relâche tout seul : il n'y a aucun fichier à "
+        "supprimer à la main.",
+
+    # ── interruption d'une opération longue (issue #82) ─────────────────────
+    "interrupt_notice_first":
+        "Interruption demandée. On laisse l'étape en cours se terminer pour "
+        "ne rien laisser à moitié écrit. Un second Ctrl-C arrête tout de suite.",
+    "interrupt_notice_second":
+        "Seconde interruption : arrêt immédiat.",
+    "interrupt_resume":
+        "Rejoue pour reprendre là où ça s'est arrêté : {cmd}",
+    "interrupted_hard":
+        "Tu as interrompu deux fois : l'opération a été tuée au lieu d'être "
+        "close, ce qu'elle laisse derrière elle peut être incomplet.",
+    "interrupted_terraform_init":
+        "Interrompu pendant le téléchargement du provider Terraform. "
+        "Aucune ressource n'a été créée.",
+    "interrupted_terraform_apply":
+        "Interrompu : Terraform s'est arrêté et a enregistré son état. Ce "
+        "qu'il avait déjà créé reste en place, et le state le connaît.",
+    "interrupted_terraform_destroy":
+        "Interrompu : Terraform s'est arrêté et a enregistré son état. Une "
+        "partie de l'infrastructure est encore debout.",
+    "interrupted_ansible":
+        "Interrompu : le playbook s'est arrêté en cours de route. La machine "
+        "peut être partiellement configurée ; les playbooks des labs sont "
+        "idempotents.",
+    "interrupted_services":
+        "Interrompu pendant le démarrage des services du lab. Un conteneur "
+        "peut être debout sans avoir été initialisé.",
+    "interrupted_hosts_wait":
+        "Interrompu pendant l'attente des machines en SSH. L'infrastructure, "
+        "elle, est en place.",
+    "interrupted_tests":
+        "Interrompu : les tests ont été arrêtés. Rien n'a été enregistré, "
+        "cette tentative ne te coûte aucun point.",
+    "interrupted_session":
+        "Interrompu : la session du lab s'est refermée. Ton travail est intact.",
+    "interrupted_unknown":
+        "Interrompu par Ctrl-C.",
 }

--- a/src/dsoxlab/infra/ansible.py
+++ b/src/dsoxlab/infra/ansible.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any
 
 from ..i18n import _
+from ..interrupt import EVENT_INTERRUPT, Interrupted, SignalRelay, Stage
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,12 @@ class PlaybookResult:
     """Code de retour (0 = succès)."""
 
     status: str
-    """``successful`` | ``failed`` | ``canceled`` | ``timeout`` | ``unknown``."""
+    """``successful`` | ``failed`` | ``timeout`` | ``unknown``.
+
+    ``canceled`` n'arrive jamais jusqu'ici : une annulation est une
+    interruption utilisateur, pas un résultat, et ``run_playbook`` lève
+    ``Interrupted`` plutôt que de la faire passer pour un échec.
+    """
 
     stats: dict[str, dict[str, int]] = field(default_factory=dict)
     """Stats agrégées par hôte : ``{ "ok": {host: n}, "changed": {...},
@@ -129,6 +135,9 @@ def run_playbook(
     Raises:
         AnsibleNotInstalled: Si ``ansible-runner`` n'est pas importable.
         FileNotFoundError: Si le playbook n'existe pas.
+        Interrupted: Si l'utilisateur a interrompu le playbook (Ctrl-C).
+            L'hôte peut alors être partiellement configuré : les playbooks
+            des labs sont idempotents, rejouer la commande suffit.
     """
     # Les deux moitiés manquent pour des raisons différentes et se réparent
     # différemment : les confondre dans un seul message envoyait l'utilisateur
@@ -188,17 +197,50 @@ def run_playbook(
 
             kwargs["event_handler"] = _safe_handler
 
-        runner = ansible_runner.run(
-            playbook=playbook_path.name,
-            private_data_dir=str(private_data_dir),
-            inventory=inventory if isinstance(inventory, dict) else str(inventory),
-            extravars=extra_vars or {},
-            cmdline=cmdline,
-            quiet=quiet,
-            timeout=timeout_s,
-            envvars=_env_overrides(),
-            **kwargs,
-        )
+        def _prevenir(rang: int) -> None:
+            """Fait remonter le Ctrl-C dans le flux d'events du playbook.
+
+            Passer par ``on_event`` plutôt qu'imprimer ici garde le texte
+            affiché dans ``cli.py``, traduit, et compatible avec la barre de
+            progression Rich qui possède le terminal à cet instant.
+            """
+            if on_event is None:
+                return
+            try:
+                on_event({"event": EVENT_INTERRUPT, "count": rang})
+            except Exception:  # un affichage ne casse pas un arrêt
+                logger.exception("on_event callback failed")
+
+        # Le relais **doit** fournir le cancel_callback : sans lui,
+        # ansible-runner installe ses propres handlers SIGINT/SIGTERM et ne les
+        # restaure jamais (cf. SignalRelay). Le Ctrl-C devenait alors invisible
+        # pour dsoxlab, et le playbook annulé ressortait en « échec ».
+        with SignalRelay(on_notice=_prevenir) as relais:
+            try:
+                runner = ansible_runner.run(
+                    playbook=playbook_path.name,
+                    private_data_dir=str(private_data_dir),
+                    inventory=inventory if isinstance(inventory, dict) else str(inventory),
+                    extravars=extra_vars or {},
+                    cmdline=cmdline,
+                    quiet=quiet,
+                    timeout=timeout_s,
+                    envvars=_env_overrides(),
+                    cancel_callback=relais.is_requested,
+                    **kwargs,
+                )
+            except KeyboardInterrupt:
+                # Second Ctrl-C : le relais l'a relancé pour que les `finally`
+                # jouent (verrou rendu, terminal restauré) plutôt que de mourir
+                # sur le signal.
+                raise Interrupted(Stage.ANSIBLE, hard=True) from None
+
+        # Un playbook annulé n'est pas un playbook en échec. Sans cette
+        # distinction, l'apprenant lisait « setup.yaml a échoué (rc=254,
+        # status=canceled) » là où il venait lui-même d'appuyer sur Ctrl-C, et
+        # la commande sortait avec le code d'un échec.
+        if relais.is_requested() or (runner.status or "") == "canceled":
+            raise Interrupted(Stage.ANSIBLE, hard=relais.count >= 2)
 
         return PlaybookResult(
             rc=runner.rc if runner.rc is not None else -1,

--- a/src/dsoxlab/infra/inventory.py
+++ b/src/dsoxlab/infra/inventory.py
@@ -31,6 +31,7 @@ from typing import Any
 
 from ..i18n import _
 from ..models.repo import RepoMetadata
+from ..utils.fichiers import ecrire_atomiquement
 
 logger = logging.getLogger(__name__)
 
@@ -274,8 +275,11 @@ def write_ssh_config(
         lines.append("")
 
     path = ssh_config_path(repo_meta)
-    path.write_text("\n".join(lines), encoding="utf-8")
-    path.chmod(0o600)
+    # Atomique, et le mode posé AVANT le remplacement : un ssh_config coupé
+    # au milieu d'un bloc « Host » fait échouer ssh, scp et le conftest d'un
+    # dépôt de labs sur une configuration incohérente, ce qui est plus dur à
+    # diagnostiquer qu'une configuration absente.
+    ecrire_atomiquement(path, "\n".join(lines), mode=0o600)
     return path
 
 
@@ -326,8 +330,7 @@ def write_user_ssh_config(
     cible = user_ssh_config_path(repo_meta)
     cible.parent.mkdir(parents=True, exist_ok=True)
     cible.parent.chmod(0o700)
-    cible.write_text(entete + contenu, encoding="utf-8")
-    cible.chmod(0o600)
+    ecrire_atomiquement(cible, entete + contenu, mode=0o600)
     return cible
 
 
@@ -534,7 +537,7 @@ def write_inventory_file(
     ``ini`` à générer programmatiquement.
     """
     path = inventory_path(repo_meta)
-    path.write_text(json.dumps(inventory, indent=2), encoding="utf-8")
+    ecrire_atomiquement(path, json.dumps(inventory, indent=2))
     return path
 
 

--- a/src/dsoxlab/infra/terraform.py
+++ b/src/dsoxlab/infra/terraform.py
@@ -36,14 +36,17 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from ..config import xdg_state_home
 from ..i18n import _
+from ..interrupt import EVENT_INTERRUPT, Interrupted, Stage, interruptible
 from ..models.repo import ProviderUnresolved, RepoMetadata
 from ..templates import terraform_template
 from ..utils.shell import CommandError, run_command
@@ -285,9 +288,13 @@ def init(
     cmd = ["terraform", f"-chdir={tf_dir}", "init", "-input=false"]
     if on_event is not None:
         cmd.append("-json")
-        _stream_terraform(cmd, env=_provider_env(repo_meta), on_event=on_event)
+        _stream_terraform(
+            cmd, env=_provider_env(repo_meta), on_event=on_event,
+            stage=Stage.TERRAFORM_INIT,
+        )
     else:
-        run_command(cmd, timeout=600, env=_provider_env(repo_meta))
+        with interruptible(Stage.TERRAFORM_INIT):
+            run_command(cmd, timeout=600, env=_provider_env(repo_meta))
 
 
 def _state_has_resources(state_file: Path) -> bool:
@@ -565,9 +572,13 @@ def apply(
         cmd += ["-var", f"target_hosts={json.dumps(target_hosts)}"]
     if on_event is not None:
         cmd.append("-json")
-        _stream_terraform(cmd, env=_provider_env(repo_meta), on_event=on_event)
+        _stream_terraform(
+            cmd, env=_provider_env(repo_meta), on_event=on_event,
+            stage=Stage.TERRAFORM_APPLY,
+        )
     else:
-        run_command(cmd, timeout=1800, env=_provider_env(repo_meta))
+        with interruptible(Stage.TERRAFORM_APPLY):
+            run_command(cmd, timeout=1800, env=_provider_env(repo_meta))
 
     # Un apply ``-target`` n'évalue pas les outputs racine (comportement
     # documenté de Terraform). Sans outputs, l'inventory (conftest de test,
@@ -577,7 +588,8 @@ def apply(
     # un refresh-only pour recalculer le map ``hosts`` sans recréer ni
     # détruire de ressource.
     if targets:
-        run_command(
+        with interruptible(Stage.TERRAFORM_APPLY):
+            run_command(
             [
                 "terraform",
                 f"-chdir={tf_dir}",
@@ -593,11 +605,62 @@ def apply(
     return _read_outputs(tf_dir, env=_provider_env(repo_meta))
 
 
+#: Délai laissé à Terraform pour mourir sur ``SIGTERM`` avant le ``SIGKILL``.
+#: Court : à ce stade l'utilisateur a déjà demandé deux fois l'arrêt.
+_DELAI_SIGKILL_S = 5
+
+def _signaler_interruption(
+    on_event: Callable[[dict[str, Any]], None], rang: int
+) -> None:
+    """Prévient l'appelant qu'un Ctrl-C a été reçu (1er ou 2e)."""
+    try:
+        on_event({"type": EVENT_INTERRUPT, "count": rang})
+    except Exception:  # un affichage ne casse pas un arrêt
+        logger.exception("on_event callback failed")
+
+
+def _arreter_terraform(
+    proc: subprocess.Popen[str],
+    drainer: Callable[[], None],
+    on_event: Callable[[dict[str, Any]], None],
+) -> bool:
+    """Arrête Terraform après un Ctrl-C, en deux temps. True si l'arrêt fut dur.
+
+    Premier temps : ``SIGINT`` au fils, et on continue de **drainer sa sortie**
+    jusqu'à EOF. Terraform, sur ``SIGINT``, termine la ressource en cours,
+    écrit son state et sort : c'est ce qui rend « rejouer la commande » suffisant.
+    Cesser de lire son tube au lieu de le drainer le bloquerait dès 64 Ko écrits,
+    exactement au moment où on lui demande de finir.
+
+    Second temps, si l'utilisateur insiste : ``SIGTERM`` puis ``SIGKILL``. Le
+    state peut alors être partiel, et l'appelant le dit.
+    """
+    _signaler_interruption(on_event, 1)
+    proc.send_signal(signal.SIGINT)
+    try:
+        drainer()
+        proc.wait()
+        return False
+    except KeyboardInterrupt:
+        pass
+
+    _signaler_interruption(on_event, 2)
+    proc.terminate()
+    try:
+        proc.wait(timeout=_DELAI_SIGKILL_S)
+    except (KeyboardInterrupt, subprocess.TimeoutExpired):
+        proc.kill()
+        with suppress(KeyboardInterrupt):
+            proc.wait()
+    return True
+
+
 def _stream_terraform(
     cmd: list[str],
     *,
     env: dict[str, str],
     on_event: Callable[[dict[str, Any]], None],
+    stage: Stage,
 ) -> None:
     """Lance terraform en mode -json et streame chaque event vers on_event.
 
@@ -610,7 +673,17 @@ def _stream_terraform(
     Terraform) sont ignorées par le parseur JSON mais conservées dans
     ``raw_log`` pour reporting d'erreur lisible.
 
-    Lève RuntimeError si rc != 0 (avec diagnostic + stderr brut).
+    **Terraform est lancé dans sa propre session** (``start_new_session``), et
+    c'est ce qui rend l'interruption pilotable. Dans le même groupe de processus,
+    le Ctrl-C du terminal frappait dsoxlab **et** Terraform en même temps :
+    impossible de savoir si le fils avait déjà reçu son signal, donc impossible
+    de lui en envoyer un second sans risquer de déclencher son arrêt *brutal*
+    (le second ``SIGINT`` fait sortir Terraform sans finir la ressource en
+    cours). Isolé, le fils ne reçoit que ce que dsoxlab lui envoie, et la
+    politique d'arrêt devient déterministe, donc testable.
+
+    Lève ``Interrupted`` si l'utilisateur a interrompu, ``RuntimeError`` si
+    rc != 0. Les deux ne se confondent pas : la première n'est pas un échec.
     """
     proc = subprocess.Popen(  # argv construit ici, jamais de shell
         cmd,
@@ -619,13 +692,18 @@ def _stream_terraform(
         text=True,
         bufsize=1,                  # line-buffered
         env=env,
+        start_new_session=True,     # cf. docstring : dsoxlab seul maître du signal
     )
     assert proc.stdout is not None  # nosec : Popen avec PIPE garantit non-None
+    sortie = proc.stdout
 
     last_diagnostic = ""
     raw_log_tail: list[str] = []
-    try:
-        for brute in proc.stdout:
+
+    def _consommer() -> None:
+        """Lit la sortie jusqu'à EOF. Rappelable : reprend là où elle s'arrête."""
+        nonlocal last_diagnostic
+        for brute in sortie:
             line = brute.rstrip("\n")
             if not line.strip():
                 continue
@@ -651,10 +729,13 @@ def _stream_terraform(
                 on_event(event)
             except Exception:  # le callback ne doit pas tuer Terraform
                 logger.exception("on_event callback failed")
-    finally:
-        # Laisse Terraform se terminer proprement même si la boucle a été
-        # interrompue (KeyboardInterrupt, etc.).
+
+    try:
+        _consommer()
         rc = proc.wait()
+    except KeyboardInterrupt:
+        dur = _arreter_terraform(proc, _consommer, on_event)
+        raise Interrupted(stage, hard=dur) from None
 
     if rc != 0:
         msg = last_diagnostic
@@ -700,9 +781,13 @@ def destroy(
         cmd += ["-var", f"target_hosts={json.dumps(target_hosts)}"]
     if on_event is not None:
         cmd.append("-json")
-        _stream_terraform(cmd, env=_provider_env(repo_meta), on_event=on_event)
+        _stream_terraform(
+            cmd, env=_provider_env(repo_meta), on_event=on_event,
+            stage=Stage.TERRAFORM_DESTROY,
+        )
     else:
-        run_command(cmd, timeout=1800, env=_provider_env(repo_meta))
+        with interruptible(Stage.TERRAFORM_DESTROY):
+            run_command(cmd, timeout=1800, env=_provider_env(repo_meta))
 
     # Nettoyage du tfvars généré : seulement si on a tout détruit
     # (sinon on garde le tfvars pour les prochains apply ciblés).

--- a/src/dsoxlab/interrupt.py
+++ b/src/dsoxlab/interrupt.py
@@ -1,0 +1,183 @@
+"""Interruption d'une opération longue : un vocabulaire et une politique.
+
+Un ``provision`` dure des minutes. L'apprenant qui perd patience fait Ctrl-C, et
+c'est exactement le moment où l'état peut diverger : une VM à moitié créée, un
+playbook arrêté au milieu d'un rôle, un conteneur démarré mais non initialisé.
+
+Ce que l'outil faisait avant, et pourquoi c'était le même défaut partout
+=======================================================================
+
+Rien n'attrapait ``KeyboardInterrupt`` en dehors du pager. Typer, tout en bas,
+en fait un ``Exit(130)`` (``typer/core.py``) : le code de retour était donc déjà
+juste, mais l'écran ne disait **rien**. L'apprenant retrouvait son invite sans
+savoir ce qui avait été interrompu, ce qui restait debout, ni quelle commande
+reprend. C'est la famille de défauts déjà soldée ailleurs dans ce dépôt : un
+état à moitié écrit qui ne se signale pas.
+
+Sur le chemin Ansible, le code mentait en plus du silence. Mesuré : un Ctrl-C
+pendant un playbook ne lève aucun ``KeyboardInterrupt``, ansible-runner annule
+et rend ``rc=254, status='canceled'``, que dsoxlab traduisait en « setup.yaml a
+échoué » avec le code de sortie d'un échec. Une interruption s'y présentait donc
+comme une panne de l'outil.
+
+La politique, en deux temps
+===========================
+
+**Premier Ctrl-C : on arrête proprement.** L'outil dit ce qu'il interrompt et
+laisse l'opération en cours se terminer là où c'est possible : Terraform reçoit
+son ``SIGINT`` et écrit son state, ansible-runner annule après la tâche
+courante. C'est ce qui rend la reprise possible : rejouer la commande suffit.
+
+**Second Ctrl-C : on arrête franchement.** L'outil ne doit jamais donner
+l'impression d'être bloqué. Le fils est terminé (``SIGTERM`` puis ``SIGKILL``),
+et le message dit que l'état peut être partiel.
+
+Le code de sortie est **130**, soit ``128 + SIGINT``, la convention des shells.
+Il dit la vérité, ce que ``1`` ne faisait pas.
+
+Ce que ce module ne fait pas
+============================
+
+Il ne compose aucune phrase : ``Interrupted`` porte une **étape**, et c'est la
+CLI qui la traduit et nomme la commande de reprise. Le modèle est celui de
+``ProviderUnresolved``, où une exception porte des données, pas du texte.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from enum import StrEnum
+from types import FrameType
+from typing import Any, Self
+
+logger = logging.getLogger(__name__)
+
+#: ``128 + SIGINT``. Le shell rend déjà ce code quand il tue lui-même un
+#: processus au Ctrl-C : l'outil dit donc la même chose que son environnement.
+EXIT_INTERRUPTED = 130
+
+#: Le seul événement que dsoxlab injecte lui-même dans le flux d'un outil
+#: externe (Terraform, ansible-runner) : « un Ctrl-C vient d'arriver »,
+#: avec son rang (1 ou 2). Passer par le flux d'events plutôt qu'imprimer
+#: depuis `infra/` garde le texte affiché dans `cli.py`, donc traduit, et
+#: le fait passer par la console Rich qui possède le terminal à cet instant.
+EVENT_INTERRUPT = "dsoxlab_interrupt"
+
+
+class Stage(StrEnum):
+    """Les points de rupture inventoriés, un par opération longue.
+
+    La valeur est **la clé i18n** du message qui décrit ce qui reste en place :
+    ``interrupted_<valeur>`` dans ``i18n/strings/{en,fr}.py``. Ajouter une étape
+    sans ajouter sa clé se voit dans ``tests/test_interruption.py``.
+    """
+
+    TERRAFORM_INIT = "terraform_init"
+    TERRAFORM_APPLY = "terraform_apply"
+    TERRAFORM_DESTROY = "terraform_destroy"
+    ANSIBLE = "ansible"
+    SERVICES = "services"
+    HOSTS_WAIT = "hosts_wait"
+    TESTS = "tests"
+    SESSION = "session"
+    UNKNOWN = "unknown"
+
+
+class Interrupted(Exception):
+    """Une opération longue a été interrompue par l'utilisateur.
+
+    Hérite d'``Exception`` et **pas** de ``RuntimeError``, délibérément : la CLI
+    est pleine de ``except RuntimeError as exc: error(str(exc))``, qui
+    afficherait ici le nom de l'étape comme s'il s'agissait d'un échec. Les
+    commandes qui ont un message dédié attrapent ``Interrupted`` en premier ;
+    les autres tombent dans le filet de ``cli.main()``.
+    """
+
+    def __init__(self, stage: Stage, *, hard: bool = False) -> None:
+        self.stage = stage
+        #: L'utilisateur a insisté (second Ctrl-C) : l'arrêt n'a pas été
+        #: gracieux, et l'état laissé peut être partiel.
+        self.hard = hard
+        super().__init__(stage.value)
+
+    @property
+    def message_key(self) -> str:
+        """Clé i18n décrivant ce que cette interruption a laissé derrière elle."""
+        return f"interrupted_{self.stage.value}"
+
+
+@contextmanager
+def interruptible(stage: Stage) -> Iterator[None]:
+    """Traduit un Ctrl-C survenu dans ce bloc en ``Interrupted(stage)``.
+
+    Pour les opérations dont dsoxlab ne pilote pas le processus fils (attente
+    SSH, sondes de conteneur, pytest) : il n'y a rien à arrêter proprement, mais
+    il y a tout à dire sur ce qui reste en place.
+    """
+    try:
+        yield
+    except KeyboardInterrupt:
+        raise Interrupted(stage) from None
+
+
+class SignalRelay:
+    """Prend la main sur ``SIGINT``/``SIGTERM`` le temps d'une opération.
+
+    Écrit pour ansible-runner, qui pose **ses propres** handlers dès qu'on ne
+    lui fournit pas de ``cancel_callback``, et ne les restaure jamais. Deux
+    conséquences mesurées dans ``ansible_runner.utils.signal_handler`` :
+
+    - pendant un playbook, un Ctrl-C ne lève **aucun** ``KeyboardInterrupt`` :
+      il arme un drapeau, le playbook s'annule, et l'appelant reçoit un
+      ``status='canceled'`` qu'il prenait pour un échec ;
+    - après le playbook, ``SIGINT`` **et** ``SIGTERM`` restent détournés pour le
+      reste du processus. Un ``kill`` sur dsoxlab n'avait alors plus d'effet.
+
+    En fournissant notre relais comme ``cancel_callback``, ansible-runner
+    n'installe rien, et ce gestionnaire de contexte restaure ce qu'il a trouvé.
+    """
+
+    def __init__(self, on_notice: Callable[[int], None] | None = None) -> None:
+        self._on_notice = on_notice
+        self.count = 0
+        # Valeur opaque rendue par `signal.getsignal` : son seul usage est
+        # d'être remise telle quelle, jamais inspectée.
+        self._precedents: dict[int, Any] = {}
+
+    def is_requested(self) -> bool:
+        """Un arrêt a-t-il été demandé ? Signature du ``cancel_callback``."""
+        return self.count > 0
+
+    def _handler(self, signum: int, frame: FrameType | None) -> None:
+        del frame
+        self.count += 1
+        logger.info("signal %d reçu (%d fois)", signum, self.count)
+        if self._on_notice is not None:
+            try:
+                self._on_notice(self.count)
+            except Exception:  # un affichage ne casse pas un arrêt
+                logger.exception("notification d'interruption en échec")
+        if self.count >= 2:
+            # Le premier signal a demandé l'annulation ; le second dit que
+            # l'utilisateur n'attend plus. On repasse par le chemin normal de
+            # Python pour que les `finally` (verrou, affichage Rich, terminal)
+            # jouent quand même : sortir par le signal laisserait le curseur
+            # caché et le verrou en place jusqu'à la mort du processus.
+            raise KeyboardInterrupt
+
+    def __enter__(self) -> Self:
+        if threading.current_thread() is threading.main_thread():
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                self._precedents[sig] = signal.getsignal(sig)
+                signal.signal(sig, self._handler)
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        del exc
+        for sig, precedent in self._precedents.items():
+            signal.signal(sig, precedent)
+        self._precedents.clear()

--- a/src/dsoxlab/locking.py
+++ b/src/dsoxlab/locking.py
@@ -1,0 +1,296 @@
+"""Verrou d'écriture par dépôt : une seule invocation modifie l'état à la fois.
+
+Deux terminaux ouverts, c'est le cas normal chez un apprenant. Rien n'empêchait
+jusqu'ici deux ``dsoxlab`` d'écrire en même temps sur le même état, et cet état
+est éparpillé :
+
+- ``<repo>/.dsoxlab-context.json``, réécrit **en entier** par ``config._persist``
+  (deux écritures concurrentes : la dernière gagne, la première est perdue sans
+  trace) ;
+- le state Terraform sous ``~/.local/state/dsoxlab/<repo-id>/terraform/`` ;
+- l'inventaire et le fragment ``ssh_config`` régénérés en cache ;
+- les conteneurs de ``runtime.services``, nommés par dépôt donc partagés.
+
+La SQLite ``<repo>/.dsoxlab.db`` est la seule pièce déjà protégée, par SQLite.
+
+Où se pose le verrou, et pourquoi pas dans le dépôt
+===================================================
+
+Sous ``~/.local/state/dsoxlab/<identité>/dsoxlab.lock``, c'est-à-dire **à la
+racine du répertoire d'état de ce dépôt**, celui-là même qui porte le state
+Terraform. Le poser dans le dépôt de labs aurait paru plus naturel (c'est là
+que vivent ``.dsoxlab.db`` et ``.dsoxlab-context.json``), mais chaque dépôt
+fournisseur ignore ces deux fichiers **nommément**, pas par un motif : un
+troisième fichier apparaîtrait en untracked chez tous, et il faudrait modifier
+trois dépôts pour livrer un verrou.
+
+L'identité est ``repo.id`` quand le ``meta.yml`` est lisible, sinon le nom du
+répertoire suffixé d'une empreinte de son chemin absolu. Prendre ``repo.id`` en
+premier n'est pas un détail : deux clones du même catalogue partagent le **même**
+work-dir Terraform, donc doivent partager le verrou. Les sérialiser inutilement
+ne coûte rien ; les laisser s'écrire dessus coûte un state corrompu.
+
+Un verrou périmé, et pourquoi il n'existe pas ici
+=================================================
+
+Le verrou est un ``flock`` (``LOCK_EX | LOCK_NB``). Le noyau le relâche **de
+lui-même** quand le descripteur se ferme, y compris si le processus meurt d'un
+``SIGKILL``, et il ne survit évidemment pas à un redémarrage. Il n'y a donc
+aucun verrou à « reprendre » : la question de la reprise, qui est la vraie
+difficulté des verrous par fichier-sentinelle, ne se pose pas.
+
+Ce qui survit, c'est le **fichier**, et le nom de son ancien détenteur. On le
+tronque en le relâchant pour qu'il ne raconte pas une invocation terminée, et on
+ne le supprime **jamais** : effacer un fichier de verrou est la course classique
+où un processus retire sous les pieds d'un autre l'inode qu'il tient déjà.
+
+Le verrou n'est pas hérité par les sous-processus : Python crée ses descripteurs
+non héritables (PEP 446), et ``exec`` les referme. Le sous-shell ouvert par
+``dsoxlab run`` ne tient donc rien, ce qui est indispensable, puisque
+l'apprenant y tape ``dsoxlab check``.
+"""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import hashlib
+import json
+import logging
+import os
+import re
+import socket
+import time
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Self
+
+import yaml
+
+from .config import xdg_state_home
+
+logger = logging.getLogger(__name__)
+
+#: Code de sortie d'une commande refusée parce qu'une autre tient le verrou.
+#: Distinct des codes déjà employés (1 à 6) : un script qui enchaîne des
+#: commandes doit pouvoir réessayer sur celui-ci et abandonner sur les autres.
+EXIT_LOCKED = 7
+
+#: Caractères tolérés dans un nom de répertoire dérivé d'une donnée du contrat.
+_HORS_SLUG = re.compile(r"[^A-Za-z0-9_.-]")
+
+#: Errnos qui disent « ce système de fichiers ne sait pas verrouiller ».
+#: On dégrade alors au lieu de refuser de travailler : un ``~/.local/state``
+#: monté sur un NFS sans lockd rendrait l'outil inutilisable, ce qui est un
+#: prix bien supérieur au risque qu'on couvre.
+_SANS_VERROU = frozenset({errno.ENOLCK, errno.ENOSYS, errno.EOPNOTSUPP, errno.EINVAL})
+
+
+class LockHolder:
+    """Ce que le détenteur du verrou a écrit de lui-même dans le fichier."""
+
+    __slots__ = ("command", "host", "pid", "since")
+
+    def __init__(self, command: str, pid: int, since: float, host: str) -> None:
+        self.command = command
+        self.pid = pid
+        self.since = since
+        self.host = host
+
+    @property
+    def age_seconds(self) -> int:
+        """Âge du verrou, jamais négatif même si l'horloge a reculé."""
+        return max(0, int(time.time() - self.since))
+
+    @property
+    def age_label(self) -> str:
+        """L'âge en ``12m03s`` : de la mise en forme, aucun mot à traduire."""
+        total = self.age_seconds
+        return f"{total // 60}m{total % 60:02d}s" if total >= 60 else f"{total}s"
+
+
+class RepoLocked(RuntimeError):
+    """Le verrou de ce dépôt est déjà tenu par une autre invocation.
+
+    Porte des **données** (le détenteur, le chemin), pas une phrase : c'est la
+    CLI qui compose le message traduit, comme le fait déjà ``ProviderUnresolved``.
+    """
+
+    def __init__(self, path: Path, holder: LockHolder | None) -> None:
+        self.path = path
+        self.holder = holder
+        super().__init__(str(path))
+
+
+def _repo_id(root: Path) -> str | None:
+    """``repo.id`` du ``meta.yml``, ou ``None`` s'il n'est pas lisible.
+
+    Lecture volontairement minimale et tolérante : le verrou se prend **avant**
+    tout le reste, et un ``meta.yml`` illisible ne doit pas empêcher de
+    verrouiller : il fait seulement retomber sur l'identité par chemin.
+    """
+    from .discovery.repo import find_meta_yml
+
+    chemin = find_meta_yml(root)
+    if chemin is None:
+        return None
+    try:
+        brut: Any = yaml.safe_load(chemin.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return None
+    if not isinstance(brut, dict):
+        return None
+    depot = brut.get("repo")
+    if not isinstance(depot, dict):
+        return None
+    ident = depot.get("id")
+    if isinstance(ident, str) and ident.strip():
+        return ident.strip()
+    return None
+
+
+def lock_identity(root: Path) -> str:
+    """Identité de dépôt sous laquelle le verrou est posé."""
+    ident = _repo_id(root)
+    if ident:
+        return _HORS_SLUG.sub("-", ident)
+    resolu = root.expanduser().resolve()
+    empreinte = hashlib.sha256(str(resolu).encode("utf-8")).hexdigest()[:12]
+    nom = _HORS_SLUG.sub("-", resolu.name) or "repo"
+    return f"{nom}-{empreinte}"
+
+
+def lock_path(root: Path) -> Path:
+    """Chemin du fichier de verrou de ce dépôt."""
+    return xdg_state_home() / "dsoxlab" / lock_identity(root) / "dsoxlab.lock"
+
+
+def _lire_detenteur(fd: int) -> LockHolder | None:
+    """Relit le fichier de verrou par son descripteur, sans jamais lever.
+
+    Un fichier vide (verrou relâché à l'instant), tronqué ou écrit par une
+    version antérieure rend ``None`` : la CLI dira alors qu'une autre invocation
+    travaille, sans pouvoir la nommer. C'est moins précis, jamais faux.
+    """
+    try:
+        os.lseek(fd, 0, os.SEEK_SET)
+        brut = os.read(fd, 4096).decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not brut.strip():
+        return None
+    try:
+        data = json.loads(brut)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    pid = data.get("pid")
+    since = data.get("since")
+    return LockHolder(
+        command=str(data.get("command") or "?"),
+        pid=pid if isinstance(pid, int) else 0,
+        since=float(since) if isinstance(since, int | float) else time.time(),
+        host=str(data.get("host") or ""),
+    )
+
+
+class RepoLock:
+    """Le verrou d'écriture d'un dépôt, pris pour la durée d'une commande.
+
+    S'utilise en gestionnaire de contexte. ``__enter__`` ne reprend pas un
+    verrou déjà tenu par cette instance : la CLI acquiert d'abord (pour traduire
+    le refus en message et en code de sortie), puis ouvre le ``with`` sur
+    l'instance déjà acquise.
+    """
+
+    def __init__(self, root: Path, command: str) -> None:
+        self.path = lock_path(root)
+        self.command = command
+        self._fd: int | None = None
+        self._degrade = False
+
+    @property
+    def held(self) -> bool:
+        """Le verrou est-il réellement tenu par ce processus ?"""
+        return self._fd is not None and not self._degrade
+
+    def acquire(self) -> None:
+        """Prend le verrou, ou lève ``RepoLocked`` si un autre le tient.
+
+        Ne bloque jamais : une attente silencieuse ferait passer un conflit
+        pour une lenteur, alors que l'apprenant a justement besoin de savoir
+        quelle commande tourne ailleurs.
+        """
+        if self._fd is not None:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(self.path, os.O_RDWR | os.O_CREAT | os.O_CLOEXEC, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            if exc.errno in (errno.EACCES, errno.EAGAIN):
+                detenteur = _lire_detenteur(fd)
+                os.close(fd)
+                raise RepoLocked(self.path, detenteur) from None
+            if exc.errno in _SANS_VERROU:
+                # Dégradé assumé et tracé : mieux vaut un outil qui travaille
+                # sans filet qu'un outil qui refuse de démarrer.
+                logger.warning(
+                    "verrou indisponible sur %s (%s) : la commande continue "
+                    "sans protection contre une invocation concurrente",
+                    self.path, exc.strerror,
+                )
+                self._fd = fd
+                self._degrade = True
+                return
+            os.close(fd)
+            raise
+        self._fd = fd
+        self._ecrire_detenteur(fd)
+
+    def _ecrire_detenteur(self, fd: int) -> None:
+        """Inscrit qui tient le verrou. Best-effort : un échec ne l'annule pas."""
+        charge = json.dumps({
+            "command": self.command,
+            "pid": os.getpid(),
+            "since": time.time(),
+            "host": socket.gethostname(),
+        })
+        try:
+            os.ftruncate(fd, 0)
+            os.lseek(fd, 0, os.SEEK_SET)
+            os.write(fd, charge.encode("utf-8"))
+        except OSError:
+            logger.warning("verrou pris, mais son détenteur n'a pas pu être inscrit")
+
+    def release(self) -> None:
+        """Relâche le verrou et efface la trace du détenteur.
+
+        La troncature vient **avant** la fermeture : le fichier survit, et un
+        contenu périmé ferait accuser une commande terminée depuis longtemps.
+        """
+        fd = self._fd
+        if fd is None:
+            return
+        self._fd = None
+        if not self._degrade:
+            try:
+                os.ftruncate(fd, 0)
+            except OSError:
+                logger.debug("troncature du verrou impossible", exc_info=True)
+        self._degrade = False
+        os.close(fd)
+
+    def __enter__(self) -> Self:
+        self.acquire()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        del exc_type, exc, tb
+        self.release()

--- a/src/dsoxlab/runtimes/base.py
+++ b/src/dsoxlab/runtimes/base.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from ..interrupt import Interrupted, Stage
 from ..models.lab import LabDefinition
 
 EventCallback = Callable[[dict[str, Any]], None]
@@ -118,8 +119,17 @@ class BaseRuntime(ABC):
             return
         if spec.cwd is not None:
             spec.cwd.mkdir(parents=True, exist_ok=True)
-        subprocess.call(
-            spec.command,
-            cwd=spec.cwd,
-            env={**os.environ, **spec.env} if spec.env else None,
-        )
+        # Un shell interactif prend le terminal au premier plan (job control) et
+        # un `ssh` transmet le Ctrl-C au distant : dans les deux cas, le signal
+        # ne remonte pas jusqu'ici. Il remonte en revanche dans l'intervalle où
+        # le fils n'a pas encore pris la main, et `subprocess.call` tue alors la
+        # session avant de propager. Le dire vaut mieux que la sortie muette
+        # d'avant, qui rendait l'invite sans expliquer ce qui venait de fermer.
+        try:
+            subprocess.call(
+                spec.command,
+                cwd=spec.cwd,
+                env={**os.environ, **spec.env} if spec.env else None,
+            )
+        except KeyboardInterrupt:
+            raise Interrupted(Stage.SESSION) from None

--- a/src/dsoxlab/services/lab_service.py
+++ b/src/dsoxlab/services/lab_service.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -15,6 +16,7 @@ from typing import Any
 from ..discovery.repo import find_meta_yml
 from ..discovery.scanner import discover_labs
 from ..i18n import _
+from ..interrupt import Interrupted, Stage
 from ..models.hint import HintFile
 from ..models.lab import LabDefinition
 from ..runtimes.base import EventCallback, SessionSpec
@@ -406,18 +408,29 @@ def check_lab(
         return CheckResult(ok=False, output=str(exc), passed=0, total=0)
 
     assert proc.stdout is not None
-    for brute in proc.stdout:
-        line = brute.rstrip("\n")
-        output_lines.append(line)
-        m = _PYTEST_VERDICT_RE.match(line)
-        if m:
-            on_event({
-                "type": "verdict",
-                "nodeid": m.group("nodeid"),
-                "verdict": m.group("verdict"),
-            })
-        else:
-            on_event({"type": "log", "line": line})
+    try:
+        for brute in proc.stdout:
+            line = brute.rstrip("\n")
+            output_lines.append(line)
+            m = _PYTEST_VERDICT_RE.match(line)
+            if m:
+                on_event({
+                    "type": "verdict",
+                    "nodeid": m.group("nodeid"),
+                    "verdict": m.group("verdict"),
+                })
+            else:
+                on_event({"type": "log", "line": line})
+    except KeyboardInterrupt:
+        # Sans ce nettoyage, pytest survivait à la commande qui l'avait lancé :
+        # il continue de piloter la VM du lab pendant que l'apprenant croit
+        # avoir tout arrêté, et le processus reste zombie jusqu'à la sortie.
+        proc.kill()
+        with suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=10)
+        # Rien n'est enregistré : une validation interrompue ne vaut pas un
+        # 0/100 dans l'historique de l'apprenant.
+        raise Interrupted(Stage.TESTS) from None
 
     rc = proc.wait(timeout=300)
     output = "\n".join(output_lines)

--- a/src/dsoxlab/utils/fichiers.py
+++ b/src/dsoxlab/utils/fichiers.py
@@ -1,0 +1,59 @@
+"""Écrire un fichier d'état : d'un seul coup, ou pas du tout.
+
+``Path.write_text`` tronque le fichier **avant** d'écrire. Entre les deux, il
+n'existe plus rien de lisible : un Ctrl-C, un ``SIGKILL``, un disque plein ou
+une machine qui s'éteint laissent un fichier vide ou coupé au milieu d'une
+accolade. Sur les fichiers d'état de dsoxlab, ce moment coûte cher et ne se
+signale jamais :
+
+- ``<repo>/.dsoxlab-context.json`` tronqué, et ``read_context`` rend un contexte
+  vide, par sécurité et sans un mot : l'apprenant perd sa section, sa target et
+  son lab actif sans comprendre pourquoi ;
+- un ``ssh_config`` coupé au milieu d'un bloc ``Host``, et ``ssh``, ``scp`` ou
+  le ``conftest.py`` d'un dépôt de labs échouent sur une configuration
+  incohérente au lieu d'une configuration absente ;
+- un ``inventory.json`` tronqué, et c'est le catalogue de machines qui devient
+  illisible.
+
+La parade tient en une ligne de POSIX : écrire à côté, puis ``os.replace``, qui
+est **atomique** sur le même système de fichiers. Le fichier de destination
+n'existe qu'en version complète, ancienne ou nouvelle, jamais entre les deux.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def ecrire_atomiquement(chemin: Path, contenu: str, *, mode: int | None = None) -> None:
+    """Écrit ``contenu`` dans ``chemin`` sans jamais laisser d'état intermédiaire.
+
+    Le fichier temporaire est créé **dans le répertoire de destination** : c'est
+    la condition pour que le ``os.replace`` reste atomique, puisqu'un
+    déplacement entre systèmes de fichiers se dégrade en copie.
+
+    ``mode`` est posé sur le temporaire avant le remplacement, pour qu'un
+    fichier sensible ne soit jamais lisible, même une fraction de seconde.
+    """
+    chemin.parent.mkdir(parents=True, exist_ok=True)
+    fd, brut = tempfile.mkstemp(
+        dir=chemin.parent, prefix=f".{chemin.name}.", suffix=".tmp"
+    )
+    temporaire = Path(brut)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as flux:
+            flux.write(contenu)
+            flux.flush()
+            # Sans ce fsync, le contenu peut n'être encore que dans le cache de
+            # pages : le renommage serait atomique, mais une coupure de courant
+            # laisserait un fichier renommé et vide.
+            os.fsync(flux.fileno())
+        if mode is not None:
+            temporaire.chmod(mode)
+        temporaire.replace(chemin)
+    finally:
+        # Sans effet après un remplacement réussi : le temporaire n'existe plus
+        # sous ce nom. Sur un échec, il ne reste pas derrière.
+        temporaire.unlink(missing_ok=True)

--- a/tests/test_interruption.py
+++ b/tests/test_interruption.py
@@ -1,0 +1,701 @@
+"""La campagne d'interruption : où un Ctrl-C fait mal, et ce qu'il laisse.
+
+Issue #82. L'enjeu n'est pas d'attraper ``KeyboardInterrupt`` quelque part :
+c'est de savoir **où** une interruption fait mal, et de prouver que chacun de
+ces points est traité. Un test qui interrompt toujours au même endroit ne
+prouve presque rien.
+
+L'inventaire des points de rupture, et ce que chacun laissait derrière lui
+=========================================================================
+
+Le point commun : **le silence**. Typer transforme déjà ``KeyboardInterrupt``
+en ``Exit(130)``, donc le code de retour était juste ; l'apprenant retrouvait
+simplement son invite, sans savoir ce qui avait été interrompu, ce qui restait
+debout, ni quoi rejouer. Une seule étape mentait aussi sur le code.
+
+======================  =========================================  ============
+Point                   Avant                                      Ici
+======================  =========================================  ============
+``terraform apply``     Sortie muette. Le fils recevait le Ctrl-C  §1, réel
+                        du terminal en même temps que dsoxlab :
+                        impossible de savoir s'il l'avait eu,
+                        donc impossible de lui en envoyer un.
+                        Et un second Ctrl-C sortait du
+                        ``finally: proc.wait()``, laissant
+                        Terraform continuer, orphelin.
+``terraform destroy``   idem                                       §1, réel
+playbook ansible        La seule étape où le CODE mentait aussi :  §2, réel
+                        ansible-runner posait ses propres
+                        handlers, annulait, et l'appelant rendait
+                        « rc=254, status=canceled » en
+                        « setup.yaml a échoué », code 2. Mesuré.
+                        Et après le playbook, `SIGINT`/`SIGTERM`
+                        restaient détournés : `kill` sans effet.
+services conteneurisés  Sortie muette, conteneur debout mais non   §3, simulé
+                        initialisé.
+attente SSH             Sortie muette, alors que l'infra est en    §3, simulé
+                        place.
+pytest (``check``)      Sortie muette, et pytest survivait à la    §4, réel
+                        commande qui l'avait lancé, en continuant
+                        de piloter la machine du lab.
+session interactive     Sortie muette.                             §3, simulé
+n'importe où ailleurs   Sortie muette.                             §5, réel
+======================  =========================================  ============
+
+Ce qui est réel et ce qui est simulé
+====================================
+
+**Réel** : les signaux (``SIGINT``, ``SIGTERM``, ``SIGKILL``), les processus
+fils et leur mort, ansible-runner et son annulation, pytest et son arrêt.
+
+**Simulé** : Terraform lui-même est remplacé par un fils qui parle son
+protocole ``-json`` et réagit aux signaux comme lui (arrêt gracieux sur
+``SIGINT``). Ce qu'on mesure est le comportement **de dsoxlab** face à un fils
+qui s'arrête, pas celui de Terraform, et c'est bien le sujet : un vrai
+``terraform apply`` mettrait des minutes et exigerait un hyperviseur.
+L'instant de l'interruption, lui, est injecté par le callback d'affichage,
+qui lève ``KeyboardInterrupt`` au n-ième événement : c'est ce qui rend la
+campagne **reproductible** et permet d'en balayer les positions.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import dsoxlab.cli as cli_mod
+from dsoxlab.i18n.strings.en import STRINGS as EN
+from dsoxlab.i18n.strings.fr import STRINGS as FR
+from dsoxlab.infra import ansible as ansible_infra
+from dsoxlab.infra.terraform import _stream_terraform
+from dsoxlab.interrupt import (
+    EVENT_INTERRUPT,
+    EXIT_INTERRUPTED,
+    Interrupted,
+    SignalRelay,
+    Stage,
+    interruptible,
+)
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _lisible(sortie: str) -> str:
+    """La sortie en une seule ligne, sans style.
+
+    Rich replie à la largeur du terminal : « partially configured » s'écrit sur
+    deux lignes et un `in` naïf ne le trouve plus. Chercher dans le texte replié
+    ferait dépendre le test d'une largeur de terminal, ce qui n'a rien à voir
+    avec ce qu'on veut prouver.
+    """
+    return " ".join(_ANSI.sub("", sortie).split())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §0. Le vocabulaire : une étape sans message serait une interruption muette
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_chaque_etape_a_son_message_dans_les_deux_langues() -> None:
+    """Une étape ajoutée sans sa clé afficherait la clé elle-même à l'écran."""
+    manquantes = [
+        (stage.value, langue)
+        for stage in Stage
+        for langue, table in (("en", EN), ("fr", FR))
+        if f"interrupted_{stage.value}" not in table
+    ]
+    assert not manquantes, f"clés absentes : {manquantes}"
+
+
+def test_le_code_de_sortie_dit_la_verite() -> None:
+    """130 = 128 + SIGINT, ce que le shell rend lui-même. Jamais 1."""
+    assert 128 + int(signal.SIGINT) == EXIT_INTERRUPTED
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §1. terraform apply / destroy : un vrai fils, une vraie escalade
+# ─────────────────────────────────────────────────────────────────────────────
+
+#: Un faux Terraform : il parle le protocole ``-json``, et il réagit aux
+#: signaux comme le vrai. Sur ``SIGINT`` il ne meurt pas : il termine ce qu'il
+#: a commencé, continue d'écrire quelques lignes, puis sort en 0 après avoir
+#: « enregistré son state ». Sur ``SIGTERM`` il meurt sans rien enregistrer.
+_FAUX_TERRAFORM = """\
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+temoin = Path(sys.argv[1])
+total = int(sys.argv[2])
+Path(sys.argv[3]).write_text(str(os.getpgrp()), encoding="utf-8")
+arret = {"demande": False, "restant": 6}
+
+
+def _sur_sigint(signum, frame):
+    arret["demande"] = True
+    temoin.write_text("sigint-recu", encoding="utf-8")
+
+
+def _sur_sigterm(signum, frame):
+    temoin.write_text("sigterm-tue", encoding="utf-8")
+    sys.exit(1)
+
+
+signal.signal(signal.SIGINT, _sur_sigint)
+signal.signal(signal.SIGTERM, _sur_sigterm)
+temoin.write_text("vivant", encoding="utf-8")
+
+# `total < 0` : mode campagne. Le fils n'a AUCUNE raison de s'arrêter de
+# lui-même, ce qui retire du test la seule course qu'il pouvait porter : celle
+# où le fils finit avant que le parent ait lu l'événement où il devait
+# interrompre. Le plafond de 2000 est un garde-fou de harnais : un test qui
+# oublierait d'interrompre doit échouer, pas pendre.
+i = 0
+while True:
+    print(json.dumps({
+        "type": "apply_complete",
+        "hook": {"resource": {"addr": f"module.lab.machine[{i}]"},
+                 "elapsed_seconds": 1},
+    }), flush=True)
+    i += 1
+    if arret["demande"]:
+        arret["restant"] -= 1
+        if arret["restant"] <= 0:
+            temoin.write_text("sigint-state-ecrit", encoding="utf-8")
+            sys.exit(0)
+    elif i >= total >= 0 or i >= 2000:
+        temoin.write_text("fini-sans-interruption", encoding="utf-8")
+        sys.exit(0)
+    time.sleep(0.005)
+"""
+
+
+def _faux_terraform(tmp_path: Path, total: int = -1) -> tuple[list[str], Path]:
+    """La commande du faux Terraform, et le témoin qu'il tient à jour."""
+    script = tmp_path / "faux_terraform.py"
+    script.write_text(_FAUX_TERRAFORM, encoding="utf-8")
+    temoin = tmp_path / "temoin.txt"
+    groupe = tmp_path / "groupe.txt"
+    return (
+        [sys.executable, str(script), str(temoin), str(total), str(groupe)],
+        temoin,
+    )
+
+
+def _attendre(temoin: Path, valeur: str, delai: float = 30.0) -> str:
+    """Attend que le témoin porte la valeur voulue, et rend ce qu'il porte."""
+    limite = time.monotonic() + delai
+    while time.monotonic() < limite:
+        contenu = temoin.read_text(encoding="utf-8") if temoin.is_file() else ""
+        if contenu == valeur:
+            return contenu
+        time.sleep(0.02)
+    return temoin.read_text(encoding="utf-8") if temoin.is_file() else ""
+
+
+@pytest.mark.parametrize("rang", [0, 1, 6, 25, 60])
+def test_un_ctrl_c_laisse_terraform_finir_et_ecrire_son_state(
+    tmp_path: Path, rang: int
+) -> None:
+    """La campagne : le même Ctrl-C, joué à quatre instants du flux.
+
+    ``rang`` est le numéro de l'événement pendant lequel l'utilisateur appuie :
+    sur la toute première ressource, juste après, puis de plus en plus loin
+    dans le flux. Le verdict doit être le même partout, et c'est précisément ce
+    qu'un test qui n'interromprait qu'à un seul endroit ne dirait pas.
+    """
+    cmd, temoin = _faux_terraform(tmp_path)
+    vus: list[dict[str, Any]] = []
+    interruptions: list[int] = []
+
+    def _on_event(event: dict[str, Any]) -> None:
+        if event.get("type") == EVENT_INTERRUPT:
+            interruptions.append(int(event["count"]))
+            return
+        vus.append(event)
+        if len(vus) - 1 == rang and not interruptions:
+            raise KeyboardInterrupt  # ← le Ctrl-C de l'apprenant
+
+    with pytest.raises(Interrupted) as capture:
+        _stream_terraform(
+            cmd, env=dict(os.environ), on_event=_on_event,
+            stage=Stage.TERRAFORM_APPLY,
+        )
+
+    assert capture.value.stage is Stage.TERRAFORM_APPLY
+    assert capture.value.hard is False, "un seul Ctrl-C n'est pas un arrêt brutal"
+    assert interruptions == [1], "l'utilisateur doit être prévenu, une fois"
+    assert _attendre(temoin, "sigint-state-ecrit") == "sigint-state-ecrit", (
+        "Terraform doit avoir reçu SIGINT et fini d'écrire son état : c'est ce "
+        "qui rend « rejouer la commande » suffisant"
+    )
+
+
+def test_un_second_ctrl_c_termine_le_fils_sans_attendre(tmp_path: Path) -> None:
+    """L'outil ne doit jamais laisser croire qu'il est bloqué.
+
+    Avant, un second Ctrl-C sortait du ``proc.wait()`` du ``finally`` : dsoxlab
+    rendait la main pendant que Terraform continuait, orphelin, à créer des
+    machines que plus personne ne suivait.
+    """
+    cmd, temoin = _faux_terraform(tmp_path)
+    interruptions: list[int] = []
+
+    def _on_event(event: dict[str, Any]) -> None:
+        if event.get("type") == EVENT_INTERRUPT:
+            interruptions.append(int(event["count"]))
+            return
+        raise KeyboardInterrupt  # l'utilisateur insiste à chaque ligne
+
+    with pytest.raises(Interrupted) as capture:
+        _stream_terraform(
+            cmd, env=dict(os.environ), on_event=_on_event,
+            stage=Stage.TERRAFORM_DESTROY,
+        )
+
+    assert capture.value.hard is True, "l'arrêt dur doit se dire"
+    assert interruptions == [1, 2]
+    assert _attendre(temoin, "sigterm-tue") == "sigterm-tue", (
+        "le fils doit avoir été terminé, pas abandonné derrière soi"
+    )
+
+
+def test_sans_interruption_rien_ne_change(tmp_path: Path) -> None:
+    """Le garde-fou du garde-fou : le chemin nominal reste intact."""
+    cmd, temoin = _faux_terraform(tmp_path, total=3)
+    vus: list[dict[str, Any]] = []
+
+    _stream_terraform(
+        cmd, env=dict(os.environ), on_event=vus.append,
+        stage=Stage.TERRAFORM_APPLY,
+    )
+
+    assert len(vus) == 3
+    assert temoin.read_text(encoding="utf-8") == "fini-sans-interruption"
+
+
+def test_terraform_tourne_dans_sa_propre_session(tmp_path: Path) -> None:
+    """La condition de toute la politique d'arrêt, et elle se vérifie.
+
+    Dans le même groupe de processus, le Ctrl-C du terminal frappe le fils en
+    même temps que dsoxlab : on ne peut plus lui envoyer de signal sans risquer
+    de compter pour le second, celui qui fait sortir Terraform sans finir la
+    ressource en cours. Isolé, il ne reçoit que ce que dsoxlab lui envoie.
+    """
+    cmd, _temoin = _faux_terraform(tmp_path, total=2)
+    groupe = tmp_path / "groupe.txt"
+
+    _stream_terraform(
+        cmd, env=dict(os.environ), on_event=lambda _e: None,
+        stage=Stage.TERRAFORM_APPLY,
+    )
+
+    assert groupe.read_text(encoding="utf-8") != str(os.getpgrp()), (
+        "le fils partage le groupe de processus de dsoxlab : le Ctrl-C du "
+        "terminal l'atteindrait directement, et l'arrêt gracieux deviendrait "
+        "indéterministe"
+    )
+
+
+def test_un_echec_reste_un_echec(tmp_path: Path) -> None:
+    """Interrompre et échouer ne doivent pas se confondre : deux exceptions."""
+    script = tmp_path / "terraform_qui_echoue.py"
+    script.write_text(
+        "import json, sys\n"
+        "print(json.dumps({'@level': 'error', 'type': 'diagnostic',\n"
+        "                  'diagnostic': {'summary': 'network is already in use',\n"
+        "                                 'detail': ''}}))\n"
+        "sys.exit(1)\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError) as capture:
+        _stream_terraform(
+            [sys.executable, str(script)], env=dict(os.environ),
+            on_event=lambda _e: None, stage=Stage.TERRAFORM_APPLY,
+        )
+
+    assert not isinstance(capture.value, Interrupted)
+    assert "network is already in use" in str(capture.value)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §2. ansible-runner : le relais de signal, et l'annulation qui n'est pas un échec
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_le_relais_compte_les_signaux_et_finit_par_rendre_la_main() -> None:
+    """Vrais signaux, envoyés à ce processus. Rien n'est simulé ici."""
+    vus: list[int] = []
+    with SignalRelay(on_notice=vus.append) as relais:
+        assert not relais.is_requested()
+        os.kill(os.getpid(), signal.SIGINT)
+        assert relais.is_requested(), "le premier signal arme l'annulation"
+        assert vus == [1]
+
+        # Le second ne se contente plus d'armer : il relance l'interruption
+        # par le chemin normal de Python, pour que les `finally` jouent.
+        with pytest.raises(KeyboardInterrupt):
+            os.kill(os.getpid(), signal.SIGINT)
+        assert vus == [1, 2]
+
+
+def test_le_relais_rend_les_handlers_quil_a_trouves() -> None:
+    """Le défaut latent d'ansible-runner : détourner SIGTERM et ne jamais le rendre.
+
+    Un ``kill`` sur dsoxlab restait alors sans effet pour le reste du processus.
+    """
+    avant_int = signal.getsignal(signal.SIGINT)
+    avant_term = signal.getsignal(signal.SIGTERM)
+
+    with SignalRelay():
+        assert signal.getsignal(signal.SIGINT) is not avant_int
+
+    assert signal.getsignal(signal.SIGINT) is avant_int
+    assert signal.getsignal(signal.SIGTERM) is avant_term
+
+
+_PLAYBOOK_LENT = """\
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: attendre assez longtemps pour etre interrompu
+      ansible.builtin.wait_for:
+        timeout: 30
+"""
+
+_PLAYBOOK_COURT = """\
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: ne rien faire
+      ansible.builtin.debug:
+        msg: ok
+"""
+
+_INVENTAIRE = {
+    "all": {"hosts": {"localhost": {"ansible_connection": "local"}}}
+}
+
+_sans_ansible = pytest.mark.skipif(
+    not ansible_infra.is_available(),
+    reason="ansible-runner ou ansible-playbook absent de cet environnement",
+)
+
+
+@_sans_ansible
+def test_un_playbook_normal_rend_les_handlers(tmp_path: Path) -> None:
+    """Vrai ansible-runner, vrai playbook : après lui, les signaux nous reviennent."""
+    playbook = tmp_path / "court.yaml"
+    playbook.write_text(_PLAYBOOK_COURT, encoding="utf-8")
+    avant = signal.getsignal(signal.SIGINT)
+
+    resultat = ansible_infra.run_playbook(playbook, _INVENTAIRE)
+
+    assert resultat.ok, resultat.stdout
+    assert signal.getsignal(signal.SIGINT) is avant, (
+        "ansible-runner posait ses handlers et ne les rendait jamais : "
+        "tout Ctrl-C ultérieur devenait muet"
+    )
+
+
+@_sans_ansible
+def test_un_playbook_interrompu_nest_pas_un_playbook_en_echec(tmp_path: Path) -> None:
+    """Vrai ansible-runner, vrai SIGINT, vraie annulation.
+
+    Le signal part **quand la tâche démarre**, pas après un délai choisi au
+    doigt mouillé : l'instant de l'interruption est ainsi le même à chaque
+    exécution, sur une machine chargée comme sur un runner de CI. C'est le
+    ``os.kill`` sur soi-même, exactement ce que fait le terminal au Ctrl-C.
+
+    Avant, l'appelant recevait un ``PlaybookResult(rc=254, status='canceled')``
+    qu'il rendait à l'apprenant en « setup.yaml a échoué », avec le code de
+    sortie d'un échec.
+    """
+    playbook = tmp_path / "lent.yaml"
+    playbook.write_text(_PLAYBOOK_LENT, encoding="utf-8")
+    envoye: list[str] = []
+
+    def _au_demarrage_de_la_tache(event: dict[str, Any]) -> None:
+        # Appelé depuis le fil d'events d'ansible-runner : le signal se délivre
+        # au processus, et Python exécute toujours le handler dans le fil
+        # principal, celui qui attend le playbook.
+        if event.get("event") == "playbook_on_task_start" and not envoye:
+            envoye.append("sigint")
+            os.kill(os.getpid(), signal.SIGINT)
+
+    try:
+        with pytest.raises(Interrupted) as capture:
+            ansible_infra.run_playbook(
+                playbook, _INVENTAIRE, on_event=_au_demarrage_de_la_tache
+            )
+    except KeyboardInterrupt:  # pragma: no cover : le relais n'a pas pris
+        pytest.fail("le SIGINT n'a pas été capté par le relais de dsoxlab")
+
+    assert envoye == ["sigint"], "le signal n'est jamais parti, le test ne mesure rien"
+    assert capture.value.stage is Stage.ANSIBLE
+    assert capture.value.hard is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §3. Les attentes sans processus fils à nous : services, SSH, session
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "stage", [Stage.SERVICES, Stage.HOSTS_WAIT, Stage.SESSION, Stage.TESTS]
+)
+def test_une_attente_interrompue_devient_une_interruption_nommee(stage: Stage) -> None:
+    """``interruptible`` ne fait qu'une chose, mais elle doit être vraie.
+
+    Simulé : le ``KeyboardInterrupt`` est levé directement plutôt que par une
+    sonde Docker ou une boucle SSH réelles. Ce qui est prouvé est la conversion,
+    seule chose que dsoxlab décide à ces endroits-là.
+    """
+    with pytest.raises(Interrupted) as capture, interruptible(stage):
+        raise KeyboardInterrupt
+
+    assert capture.value.stage is stage
+    assert capture.value.hard is False
+
+
+def test_une_attente_qui_reussit_ne_change_rien() -> None:
+    with interruptible(Stage.SERVICES):
+        resultat = 1 + 1
+    assert resultat == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §4. pytest : un `check` interrompu ne doit pas survivre à sa commande
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _lab_de_test(tmp_path: Path, marqueur: Path) -> Any:
+    """Un lab réel, avec deux tests dont le second laisse une trace en finissant."""
+    from dsoxlab.models.lab import LabDefinition, ValidationConfig
+    from dsoxlab.models.runtime import RuntimeConfig, RuntimeType
+
+    (tmp_path / "meta.yml").write_text(
+        "repo:\n  id: interruption-demo\n  category: demo\n", encoding="utf-8"
+    )
+    lab_dir = tmp_path / "labs" / "demo"
+    tests = lab_dir / "challenge" / "tests"
+    tests.mkdir(parents=True)
+    (tests / "test_functional.py").write_text(
+        "import time\n"
+        "from pathlib import Path\n"
+        "\n"
+        "\n"
+        "def test_premier():\n"
+        "    assert True\n"
+        "\n"
+        "\n"
+        "def test_second():\n"
+        "    time.sleep(0.6)\n"
+        f"    Path({str(marqueur)!r}).write_text('pytest a survecu')\n"
+        "    assert True\n",
+        encoding="utf-8",
+    )
+    return LabDefinition(
+        id="demo",
+        title="Demo",
+        level="l1",
+        skills=["s"],
+        runtime=RuntimeConfig(type=RuntimeType.SHELL, workdir="challenge/work"),
+        distros=["alma10"],
+        doc_url="https://example.test/doc",
+        validation=ValidationConfig(),
+        path=lab_dir,
+    )
+
+
+def test_un_check_interrompu_tue_pytest_et_nenregistre_rien(tmp_path: Path) -> None:
+    """Vrai pytest, vraiment arrêté.
+
+    Le marqueur est écrit par le second test **après** l'instant de
+    l'interruption : s'il apparaît, c'est que pytest a continué de tourner sans
+    personne pour l'attendre, en continuant, dans un vrai lab, de piloter la
+    machine que l'apprenant croyait avoir laissée tranquille.
+    """
+    from dsoxlab.services.lab_service import check_lab
+
+    marqueur = tmp_path / "survivant.txt"
+    lab = _lab_de_test(tmp_path, marqueur)
+
+    def _on_event(event: dict[str, Any]) -> None:
+        if event.get("type") == "verdict":
+            raise KeyboardInterrupt  # ← Ctrl-C au premier verdict
+
+    with pytest.raises(Interrupted) as capture:
+        check_lab(lab, on_event=_on_event)
+
+    assert capture.value.stage is Stage.TESTS
+    time.sleep(1.5)
+    assert not marqueur.exists(), "pytest a survécu à la commande qui l'a lancé"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §5. La CLI : ce que l'apprenant lit, et le code que le shell reçoit
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _depot(racine: Path) -> Path:
+    racine.mkdir(parents=True, exist_ok=True)
+    (racine / "meta.yml").write_text(
+        "repo:\n  id: interruption-cli\n  category: demo\n", encoding="utf-8"
+    )
+    lab = racine / "labs" / "demo" / "premier"
+    (lab / "challenge" / "tests").mkdir(parents=True)
+    (lab / "lab.yaml").write_text(
+        "id: premier\n"
+        "title: Premier\n"
+        "level: l1\n"
+        "skills: [rien]\n"
+        "distros: [alma10]\n"
+        "doc_url: https://example.test/doc\n"
+        "runtime:\n"
+        "  type: shell\n"
+        "  workdir: challenge/work\n",
+        encoding="utf-8",
+    )
+    return racine
+
+
+@pytest.fixture(autouse=True)
+def _etat_isole(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.delenv("LAB_HOME", raising=False)
+
+
+def _sortie(argv: list[str], monkeypatch: pytest.MonkeyPatch) -> int:
+    """Joue la CLI par son VRAI point d'entrée et rend le code de sortie.
+
+    Passer par ``main()`` et non par ``CliRunner`` n'est pas un détail : c'est
+    ``main()`` qui porte le filet de dernier recours, et le code de sortie est
+    ici le livrable.
+    """
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit) as capture:
+        cli_mod.main()
+    code = capture.value.code
+    return int(code) if code is not None else 0
+
+
+def test_run_interrompu_sort_en_130_et_dit_comment_reprendre(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    racine = _depot(tmp_path / "depot")
+
+    def _setup_interrompu(*args: Any, **kwargs: Any) -> None:
+        raise Interrupted(Stage.ANSIBLE)
+
+    monkeypatch.setattr(cli_mod, "run_lab", _setup_interrompu)
+    monkeypatch.setenv("DSOXLAB_LANG", "en")
+
+    code = _sortie(
+        ["dsoxlab", "run", "premier", "--lab-home", str(racine)], monkeypatch
+    )
+
+    assert code == EXIT_INTERRUPTED
+    lu = capsys.readouterr()
+    ecran = _lisible(lu.out + lu.err)
+    assert "partially configured" in ecran, "il faut dire ce qui reste en place"
+    assert "dsoxlab run premier" in ecran, "et la commande qui reprend"
+
+
+def test_un_ctrl_c_sans_proprietaire_se_dit_quand_meme(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Le filet : ailleurs, l'interruption sortait en 130 mais sans un mot.
+
+    Le code de retour n'est donc pas ce que ce test garde (typer le rendait
+    déjà) : c'est la PHRASE. Sans le filet posé sur le groupe Click,
+    l'apprenant récupère son invite sans savoir ce qui vient d'être interrompu.
+    """
+    racine = _depot(tmp_path / "depot")
+
+    def _liste_interrompue(*args: Any, **kwargs: Any) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli_mod, "get_best_scores", _liste_interrompue)
+    monkeypatch.setenv("DSOXLAB_LANG", "en")
+
+    code = _sortie(
+        ["dsoxlab", "list-labs", "--lab-home", str(racine)], monkeypatch
+    )
+
+    assert code == EXIT_INTERRUPTED
+    lu = capsys.readouterr()
+    ecran = _lisible(lu.out + lu.err)
+    assert "Interrupted by Ctrl-C" in ecran, (
+        "sans un mot, l'apprenant ne peut pas distinguer une interruption "
+        "d'une commande qui n'a rien trouvé à faire"
+    )
+
+
+def test_un_echec_ordinaire_garde_son_propre_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Le pendant du test précédent : 130 ne doit pas manger les autres codes."""
+    racine = _depot(tmp_path / "depot")
+
+    code = _sortie(
+        ["dsoxlab", "show", "inexistant", "--lab-home", str(racine)], monkeypatch
+    )
+
+    assert code == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §6. L'état à moitié écrit : le fichier n'existe qu'entier, ou pas du tout
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_un_fichier_detat_ne_perd_jamais_sa_version_precedente(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`write_text` tronque AVANT d'écrire : entre les deux, il n'y a plus rien.
+
+    Le contexte de session était réécrit ainsi. Une coupure au mauvais instant
+    le laissait vide, `read_context` rendait alors un contexte neuf sans un mot,
+    et l'apprenant perdait sa section, sa target et son lab actif.
+
+    La panne est simulée (un `fsync` qui lève), parce qu'un vrai arrêt machine
+    au bon microseconde ne se scripte pas. Ce qui est prouvé est ce que dsoxlab
+    garantit : la destination n'est remplacée qu'une fois le contenu complet
+    écrit, et rien ne traîne derrière.
+    """
+    from dsoxlab.config import read_context, set_active_lab, write_context
+    from dsoxlab.utils import fichiers
+
+    write_context(tmp_path, "demo", "l1")
+    set_active_lab(tmp_path, "avant-la-panne")
+
+    def _fsync_en_panne(fd: int) -> None:
+        del fd
+        raise OSError("disque plein")
+
+    monkeypatch.setattr(fichiers.os, "fsync", _fsync_en_panne)
+    with pytest.raises(OSError, match="disque plein"):
+        set_active_lab(tmp_path, "pendant-la-panne")
+
+    monkeypatch.undo()
+    survivant = read_context(tmp_path)
+    assert survivant.active_lab == "avant-la-panne", (
+        "la version précédente doit survivre entière à une écriture en échec"
+    )
+    assert survivant.section == "demo"
+    restes = list(tmp_path.glob(".dsoxlab-context.json.*"))
+    assert not restes, f"un temporaire est resté derrière : {restes}"

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -81,7 +81,7 @@ def test_accents_are_not_escaped(capsys) -> None:
     assert "Préparer les nœuds gérés" in sortie
 
 
-def test_a_failing_check_still_prints_only_json(monkeypatch, capsys) -> None:
+def test_a_failing_check_still_prints_only_json(monkeypatch, capsys, tmp_path) -> None:
     """Un lab en échec ne doit pas préfixer le JSON de sa sortie pytest.
 
     C'est le cas le plus fréquent en usage réel, et le plus facile à manquer :
@@ -90,6 +90,12 @@ def test_a_failing_check_still_prints_only_json(monkeypatch, capsys) -> None:
     """
     from dsoxlab import cli
     from dsoxlab.services.lab_service import CheckResult
+
+    # `_run_check` prend le verrou d'écriture du dépôt, dont le fichier vit
+    # sous XDG_STATE_HOME. Sans cette redirection, ce test déposerait un
+    # répertoire dans le `~/.local/state` de qui lance la suite, pour une
+    # racine (`/repo`) qui n'existe même pas.
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
 
     echec = CheckResult(ok=False, output="=== test session starts ===\nFAILED", passed=1, total=3)
     monkeypatch.setattr(cli, "_run_check_with_progress", lambda *a, **k: echec)

--- a/tests/test_verrou_depot.py
+++ b/tests/test_verrou_depot.py
@@ -1,0 +1,380 @@
+"""Le verrou d'écriture par dépôt : ce qu'il refuse, et ce qu'il ne bloque pas.
+
+Le défaut d'origine (issue #81) n'était pas une course rare : deux terminaux
+ouverts sur le même dépôt, c'est le cas normal chez un apprenant. Les deux
+invocations écrivaient sur le même `.dsoxlab-context.json`, le même state
+Terraform, les mêmes conteneurs, et la dernière écriture gagnait sans que la
+première le sache.
+
+Ce module prouve quatre choses, et la troisième est celle qui coûte cher à
+rater : un verrou qui ne se rend jamais est pire que pas de verrou du tout.
+
+1. Une seconde invocation qui écrit est **refusée**, en nommant la commande
+   détentrice et son PID, avec un code de sortie qui lui est propre.
+2. Les commandes de **lecture** ne sont pas bloquées.
+3. Un verrou laissé par un processus **mort** (tué au ``SIGKILL``, ou perdu
+   dans un redémarrage) est repris sans qu'aucun fichier soit à supprimer.
+4. ``run`` **rend** le verrou avant d'ouvrir la session interactive, sinon le
+   ``dsoxlab check`` que l'apprenant y tape se heurterait à sa propre session.
+
+Tout est réel : de vrais ``flock``, un vrai processus fils tué au ``SIGKILL``,
+la vraie CLI. Rien n'est simulé ici.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dsoxlab.cli import app
+from dsoxlab.locking import EXIT_LOCKED, RepoLock, RepoLocked, lock_identity, lock_path
+
+runner = CliRunner()
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(sortie: str) -> str:
+    """La sortie telle qu'elle est lue à l'écran, sans les codes de style."""
+    return _ANSI.sub("", sortie)
+
+
+@pytest.fixture(autouse=True)
+def _etat_isole(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Aucun test ne touche au ``~/.local/state`` de la machine."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.delenv("LAB_HOME", raising=False)
+
+
+def _depot(racine: Path, repo_id: str = "verrou-demo") -> Path:
+    """Un dépôt de labs minimal mais réel : un meta.yml et un lab shell."""
+    racine.mkdir(parents=True, exist_ok=True)
+    (racine / "meta.yml").write_text(
+        f"repo:\n  id: {repo_id}\n  category: demo\n", encoding="utf-8"
+    )
+    lab = racine / "labs" / "demo" / "premier"
+    lab.mkdir(parents=True)
+    (lab / "lab.yaml").write_text(
+        "id: premier\n"
+        "title: Premier\n"
+        "level: l1\n"
+        "skills: [rien]\n"
+        "distros: [alma10]\n"
+        "doc_url: https://example.test/doc\n"
+        "runtime:\n"
+        "  type: shell\n"
+        "  workdir: challenge/work\n",
+        encoding="utf-8",
+    )
+    return racine
+
+
+# ── Où le verrou se pose ──────────────────────────────────────────────────────
+
+
+def test_le_verrou_vit_dans_letat_du_depot(tmp_path: Path) -> None:
+    """Sous ``<XDG_STATE_HOME>/dsoxlab/<repo.id>/``, là où vit le state Terraform."""
+    racine = _depot(tmp_path / "depot")
+
+    chemin = lock_path(racine)
+
+    assert lock_identity(racine) == "verrou-demo"
+    assert chemin == tmp_path / "state" / "dsoxlab" / "verrou-demo" / "dsoxlab.lock"
+
+
+def test_deux_clones_du_meme_catalogue_partagent_le_verrou(tmp_path: Path) -> None:
+    """Même ``repo.id``, donc même work-dir Terraform, donc même verrou.
+
+    Les sérialiser inutilement ne coûte rien ; les laisser écrire ensemble sur
+    le même state coûte un state corrompu.
+    """
+    un = _depot(tmp_path / "clone-a", repo_id="meme-catalogue")
+    deux = _depot(tmp_path / "clone-b", repo_id="meme-catalogue")
+
+    assert lock_path(un) == lock_path(deux)
+
+
+def test_sans_meta_yml_lidentite_derive_du_chemin(tmp_path: Path) -> None:
+    """Un répertoire sans contrat reste verrouillable, et distinctement."""
+    (tmp_path / "sans-contrat-a").mkdir()
+    (tmp_path / "sans-contrat-b").mkdir()
+
+    a = lock_identity(tmp_path / "sans-contrat-a")
+    b = lock_identity(tmp_path / "sans-contrat-b")
+
+    assert a.startswith("sans-contrat-a-")
+    assert a != b
+    assert a == lock_identity(tmp_path / "sans-contrat-a"), "l'identité est stable"
+
+
+# ── Ce que le verrou refuse ───────────────────────────────────────────────────
+
+
+def test_une_seconde_prise_est_refusee_et_nomme_le_detenteur(tmp_path: Path) -> None:
+    racine = _depot(tmp_path / "depot")
+    premier = RepoLock(racine, "provision")
+    premier.acquire()
+
+    try:
+        with pytest.raises(RepoLocked) as capture:
+            RepoLock(racine, "destroy").acquire()
+    finally:
+        premier.release()
+
+    detenteur = capture.value.holder
+    assert detenteur is not None, "le refus doit dire QUI tient le verrou"
+    assert detenteur.command == "provision"
+    assert detenteur.pid == os.getpid()
+    assert detenteur.age_seconds >= 0
+
+
+def test_apres_relachement_le_verrou_se_reprend(tmp_path: Path) -> None:
+    racine = _depot(tmp_path / "depot")
+    premier = RepoLock(racine, "provision")
+    premier.acquire()
+    premier.release()
+
+    second = RepoLock(racine, "destroy")
+    second.acquire()
+    try:
+        assert second.held
+    finally:
+        second.release()
+
+
+def test_relacher_efface_la_trace_du_detenteur(tmp_path: Path) -> None:
+    """Le fichier survit, son contenu non : sinon il accuserait un mort."""
+    racine = _depot(tmp_path / "depot")
+    verrou = RepoLock(racine, "provision")
+    verrou.acquire()
+    assert lock_path(racine).read_text(encoding="utf-8").strip()
+
+    verrou.release()
+
+    assert lock_path(racine).is_file(), "le fichier ne se supprime jamais"
+    assert lock_path(racine).read_text(encoding="utf-8") == ""
+
+
+# ── Le verrou périmé, la question qui décide de tout ─────────────────────────
+
+
+_ENFANT = """\
+import os
+import sys
+import time
+from pathlib import Path
+
+os.environ["XDG_STATE_HOME"] = sys.argv[1]
+
+from dsoxlab.locking import RepoLock
+
+verrou = RepoLock(Path(sys.argv[2]), "provision")
+verrou.acquire()
+Path(sys.argv[3]).write_text(str(os.getpid()), encoding="utf-8")
+time.sleep(300)
+"""
+
+
+def test_un_verrou_tenu_par_un_processus_tue_est_repris(tmp_path: Path) -> None:
+    """SIGKILL sur le détenteur : le noyau rend le verrou, personne n'efface rien.
+
+    C'est le cas qui rend un verrou par fichier-sentinelle dangereux, et celui
+    que ``flock`` règle sans code : le verrou est attaché au descripteur, que
+    le noyau referme quoi qu'il arrive au processus.
+    """
+    racine = _depot(tmp_path / "depot")
+    script = tmp_path / "detenteur.py"
+    script.write_text(_ENFANT, encoding="utf-8")
+    temoin = tmp_path / "pid.txt"
+
+    enfant = subprocess.Popen(
+        [sys.executable, str(script), str(tmp_path / "state"), str(racine), str(temoin)],
+    )
+    try:
+        limite = time.monotonic() + 30
+        while not temoin.is_file() and time.monotonic() < limite:
+            time.sleep(0.05)
+        assert temoin.is_file(), "l'enfant n'a jamais pris le verrou"
+
+        # Tant qu'il vit, il tient : c'est ce qui prouve que le test qui suit
+        # mesure bien la mort de l'enfant, et pas un verrou qui n'a jamais pris.
+        with pytest.raises(RepoLocked):
+            RepoLock(racine, "run").acquire()
+
+        enfant.send_signal(signal.SIGKILL)
+        enfant.wait(timeout=30)
+    finally:
+        if enfant.poll() is None:  # pragma: no cover : filet du harnais
+            enfant.kill()
+            enfant.wait(timeout=10)
+
+    repris = RepoLock(racine, "run")
+    repris.acquire()  # ne doit pas lever
+    try:
+        assert repris.held
+    finally:
+        repris.release()
+
+
+def test_un_verrou_survivant_a_un_redemarrage_ne_bloque_rien(tmp_path: Path) -> None:
+    """Le fichier survit au redémarrage, le ``flock`` non.
+
+    On rejoue exactement ce que la machine laisse au réveil : le fichier est là,
+    il nomme un PID d'un autre temps, et rien ne le tient. Le verrou doit se
+    prendre sans un mot, et surtout sans demander de supprimer un fichier.
+    """
+    racine = _depot(tmp_path / "depot")
+    chemin = lock_path(racine)
+    chemin.parent.mkdir(parents=True, exist_ok=True)
+    chemin.write_text(
+        '{"command": "provision", "pid": 424242, '
+        '"since": 1000000000.0, "host": "avant-le-reboot"}',
+        encoding="utf-8",
+    )
+
+    verrou = RepoLock(racine, "run")
+    verrou.acquire()
+    try:
+        assert verrou.held
+        # Le détenteur périmé a été remplacé, pas conservé.
+        assert '"command": "run"' in chemin.read_text(encoding="utf-8")
+    finally:
+        verrou.release()
+
+
+def test_un_systeme_de_fichiers_sans_verrou_ne_bloque_pas_loutil(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dégradé assumé : sur un FS sans ``flock``, on travaille sans filet.
+
+    Simulé (``fcntl.flock`` remplacé) : provoquer un vrai ``ENOLCK`` demanderait
+    un montage NFS sans lockd, hors de portée d'une suite unitaire. Ce qui est
+    prouvé ici est le comportement de dsoxlab face à cet errno, pas l'errno.
+    """
+    import errno
+    import fcntl
+
+    def _refus(fd: int, operation: int) -> None:
+        del fd, operation
+        raise OSError(errno.ENOLCK, "no locks available")
+
+    monkeypatch.setattr(fcntl, "flock", _refus)
+    racine = _depot(tmp_path / "depot")
+
+    verrou = RepoLock(racine, "provision")
+    verrou.acquire()  # ne doit pas lever
+    try:
+        assert not verrou.held, "l'outil ne doit pas prétendre tenir un verrou"
+    finally:
+        verrou.release()
+
+
+# ── La CLI : ce qui est refusé, ce qui passe ─────────────────────────────────
+
+
+def test_la_cli_refuse_une_seconde_ecriture_et_dit_laquelle(tmp_path: Path) -> None:
+    racine = _depot(tmp_path / "depot")
+    tenu = RepoLock(racine, "provision")
+    tenu.acquire()
+
+    try:
+        resultat = runner.invoke(
+            app, ["use", "--lang", "fr", "--lab-home", str(racine)]
+        )
+    finally:
+        tenu.release()
+
+    assert resultat.exit_code == EXIT_LOCKED, "un conflit a son propre code"
+    lisible = _plain(resultat.output)
+    assert "provision" in lisible, "la commande détentrice doit être nommée"
+    assert str(os.getpid()) in lisible, "son PID aussi"
+
+
+@pytest.mark.parametrize(
+    "commande",
+    [
+        ["list-labs"],
+        ["show", "premier"],
+        ["scores"],
+        ["progress"],
+        ["validate-structure"],
+    ],
+)
+def test_les_commandes_de_lecture_ne_prennent_pas_le_verrou(
+    tmp_path: Path, commande: list[str]
+) -> None:
+    """Consulter son catalogue pendant un provision n'est pas un conflit."""
+    racine = _depot(tmp_path / "depot")
+    tenu = RepoLock(racine, "provision")
+    tenu.acquire()
+
+    try:
+        resultat = runner.invoke(app, [*commande, "--lab-home", str(racine)])
+    finally:
+        tenu.release()
+
+    assert resultat.exit_code != EXIT_LOCKED, _plain(resultat.output)
+
+
+def test_le_verrou_est_rendu_meme_quand_la_commande_sort_en_erreur(
+    tmp_path: Path,
+) -> None:
+    """Une commande qui échoue ne doit pas condamner le dépôt."""
+    racine = _depot(tmp_path / "depot")
+    (racine / "meta.yml").write_text(
+        "repo:\n  id: verrou-demo\n  category: demo\n"
+        "sections:\n  - id: demo\n    labs:\n      - demo/premier\n",
+        encoding="utf-8",
+    )
+
+    echec = runner.invoke(app, ["use", "inconnue", "--lab-home", str(racine)])
+    assert echec.exit_code == 1, _plain(echec.output)
+
+    apres = RepoLock(racine, "provision")
+    apres.acquire()  # ne doit pas lever
+    try:
+        assert apres.held
+    finally:
+        apres.release()
+
+
+def test_run_rend_le_verrou_avant_douvrir_la_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sinon le ``dsoxlab check`` tapé dans le sous-shell serait refusé.
+
+    C'est le piège de tout verrou pris « pour toute la commande » : ``run``
+    ouvre une session interactive qui dure des minutes, et c'est DEPUIS cette
+    session que l'apprenant relance dsoxlab.
+    """
+    racine = _depot(tmp_path / "depot")
+    observe: dict[str, bool] = {}
+
+    def _session(lab: object) -> None:
+        del lab
+        sonde = RepoLock(racine, "check")
+        try:
+            sonde.acquire()
+        except RepoLocked:
+            observe["libre"] = False
+            return
+        observe["libre"] = True
+        sonde.release()
+
+    monkeypatch.setattr("dsoxlab.cli.open_lab_session", _session)
+
+    resultat = runner.invoke(app, ["run", "premier", "--lab-home", str(racine)])
+
+    assert resultat.exit_code == 0, _plain(resultat.output)
+    assert observe.get("libre") is True, (
+        "le verrou est encore tenu pendant la session : « dsoxlab check » y "
+        "serait refusé par sa propre session"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.53"
+version = "0.1.55"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
# Summary

The two ways dsoxlab's state could corrupt itself: a second invocation writing
over the first, and a Ctrl-C landing in the wrong place.

## The framing changed once it was measured

The first draft of this work claimed Click printed "Aborted!" and exited **1**.
Measured, that is false: `typer/core.py:203` already turns `KeyboardInterrupt`
into `Exit(130)`. The exit code was almost always right.

**The real defect was the silence** — and, in two places, something worse. The
CHANGELOG, the docstrings and the tests were rewritten around the measurement
rather than the assumption.

## The interruption campaign

| Rupture point | Before (measured) | After |
|---|---|---|
| `terraform apply` / `destroy` | Silent, exit 130. The child got the terminal's Ctrl-C **at the same moment** as dsoxlab, so there was no way to know whether it had received it — and a second Ctrl-C escaped `finally: proc.wait()` and left Terraform **orphaned, still creating machines**. | Child in its own session (`start_new_session`). First Ctrl-C: message, `SIGINT` forwarded, **draining continued** to EOF so the child finishes and writes its state. Second: `SIGTERM` then `SIGKILL`, and the message says the state may be partial. Exit 130 with a resume instruction. |
| ansible playbook | **The only step where the code also lied.** Measured: `rc=254, status=canceled`, reported as "setup.yaml failed", exit **2**. Worse, ansible-runner never restored its handlers: after *any* playbook, `SIGINT` **and** `SIGTERM` stayed hijacked, so a `kill` on dsoxlab did nothing. | `SignalRelay` supplies the `cancel_callback` (ansible-runner then installs nothing) and restores the handlers it found. Cancellation is reported as such, exit 130, "the machine may be partially configured, playbooks are idempotent". |
| pytest (`check`/`submit`) | Silent, **and pytest survived** — still driving the lab machine, a zombie until exit | Child killed and reaped; nothing recorded, since an interrupted validation costs no points |
| containerised services | Silent during probes, container up but uninitialised | Named, exit 130; replaying suffices (`post_start` is replayed on a reused container) |
| SSH wait after provision | Silent although the infrastructure is up | "the infrastructure is in place", resume with `dsoxlab provision`, idempotent |
| anywhere else | Silent | Net on `_I18nGroup.invoke`, the only point upstream of typer's `_main()` |

**What makes the campaign reproducible**: the moment of interruption is injected
by the display callback, which raises `KeyboardInterrupt` at the n-th event. The
sweep plays ranks **0, 1, 6, 25 and 60** of the Terraform stream, and the verdict
must be identical at every one.

## The lock, and the stale-lock question

`flock(LOCK_EX|LOCK_NB)` on a file under
`~/.local/state/dsoxlab/<identity>/dsoxlab.lock` — at the root of the state
directory, next to the Terraform state it protects.

**There is no stale lock to recover**: the kernel releases it when the descriptor
closes. Proven rather than asserted, and verified independently before opening
this PR:

```
seconde invocation : code = 7
  ℹ Attends qu'elle se termine, ou arrête-la. Un verrou laissé par un processus
    mort se relâche tout seul : il n'y a aucun fichier à supprimer à la main.
lecture concurrente (list-labs) : code = 0
après SIGKILL du détenteur      : code = 0
```

- **Dead process**: a child takes the lock, is confirmed to block the second
  caller, is `SIGKILL`ed — and the lock is retaken with no gesture.
- **Reboot**: the file survives with a PID from another era and no `flock`; that
  exact state is written in a test, and the lock is taken, replacing the stale
  holder.
- The file is **truncated** on release (never accusing a finished command) and
  **never deleted** — deleting is the race where one process pulls the inode from
  under another.
- **Not inherited** by subprocesses (PEP 446 + exec), and `run` releases it
  **before** the session: otherwise the `dsoxlab check` typed inside the sub-shell
  would be refused by its own session. Tested.
- A filesystem without `flock` (`ENOLCK`) degrades with a warning rather than
  refusing to start.

## Type of change

- [x] Bug fix
- [x] New feature

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — Success, 60 source files
- [x] `uv run pytest` — **482 passed** (440 before, +42); `tests_e2e` — **16 passed**
- [x] The engine stays domain-agnostic
- [x] No hardcoded personal path; `pathlib.Path` throughout
- [x] Manually tested against the **three** lab repositories, read-only:
      `validate-structure` rc=0 on all three, and their `.dsoxlab.db` /
      `.dsoxlab-context.json` are **md5-identical** before and after

### When behavior changes

- [x] Both CHANGELOG files updated; version **0.1.55**; `uv.lock` aligned

### When a command or option is added, removed or changed

- [x] i18n keys in **both** tables; verified under `DSOXLAB_LANG=fr` and `=en`

### When `.github/workflows/` is touched — N/A

### When the declarative contract changes — N/A

## Real vs simulated

**Real**: every signal (`SIGINT`, `SIGTERM`, `SIGKILL`), the `flock` calls, child
processes and their death, ansible-runner and its cancellation, pytest and its
teardown, the installed CLI driven through its own binary. A genuine `SIGINT` on
a genuine `dsoxlab check` (with `set -m` — otherwise bash sets SIGINT to SIG_IGN
for a background job and the signal reaches nobody) gives exit **130**, the
message in FR and EN, no surviving pytest, and the lock returned.

**Simulated**: Terraform (a child speaking its `-json` protocol and reacting to
signals as it does), the Docker probes and the SSH loop (only the conversion is
proven), and `ENOLCK`.

**Not done**: no real `provision`/`destroy` against libvirt. Only `virsh list`
(read-only) was run.

## Mutations played — sixteen, all detected

Lock: flock removed · descriptor left open on release · file deleted instead of
truncated · lock taken by a read-only command · lock held during the session ·
holder not recorded · identity by path despite a readable `meta.yml`.

Interruption: back to `finally: proc.wait()` (**the test never returns**, which is
the defect itself) · `SIGTERM` first · child left in dsoxlab's process group ·
ansible cancellation not distinguished from failure · pytest not killed · exit 1
· Click net removed · first Ctrl-C not announced · non-atomic context write.

**Two mutations survived at first and exposed real defects in the tests
themselves**: the Click net was guarded only by the exit code — which typer
already returned — and not by the message; and two `-k` expressions of two words
were split by `split()`, so "no tests ran" passed for a red. Both fixed.

## Decisions worth reviewing

1. **`check` and `submit` take the lock**, though #81 did not list them: the
   tests drive the lab machine, and two concurrent validations tread on each
   other. Scope deliberately widened (services + pytest).
2. **`status` does not take it**, though #81 cites it as a writer (inventory,
   cached `ssh_config`). It was made harmless through an **atomic write**
   (`utils/fichiers.py`, applied to the session context too) rather than by
   blocking a diagnostic. That is an addition beyond the literal scope.
3. **The lock lives under XDG, not in the lab repository**: all three provider
   repos ignore `.dsoxlab.db` and `.dsoxlab-context.json` **by name**, so a third
   file would have shown up untracked in every one of them.
4. **Identity is `repo.id` first, path as fallback**: two clones of the same
   catalogue share the Terraform work directory, so they must share the lock.
   Over-restrictive, never under-restrictive.
5. **One commit rather than one per issue**: `cli.py` and the i18n tables carry
   both changes, and splitting would have produced a broken intermediate commit.
6. **`tests/test_json_output.py` fixed**: it called `_run_check(Path("/repo"), …)`
   and would therefore have dropped a directory into the `~/.local/state` of
   whoever ran the suite. It now isolates `XDG_STATE_HOME`.
7. The project `CLAUDE.md` (unversioned) does not yet mention the new state
   location or exit codes 7 and 130.

## Related issues

Closes #81
Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)
