### PR TITLE
fix(cli): un exécutable absent se nomme, et click cesse d'être déclaré (0.1.57)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,31 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.57] - 2026-08-23
+
+### Corrigé
+
+- **Un exécutable absent rendait une trace Python.** La CLI convertit
+  soigneusement `CommandError`, `DomainNotFound`, `UnsupportedSchemaVersion` et
+  les erreurs du contrat en message traduit suivi d'un code de sortie ;
+  `FileNotFoundError`, lui, traversait tout et remontait à l'interpréteur. Or
+  une trace dit « l'outil est cassé » alors qu'il manque le plus souvent un
+  binaire que l'apprenant peut poser lui-même. Le filet est posé dans
+  `_I18nGroup.invoke`, au même endroit que celui du Ctrl-C : c'est le seul point
+  qui couvre les vingt-quatre commandes sans en instrumenter aucune. Un nom sans
+  séparateur a été cherché dans le `PATH`, donc c'est un exécutable et le code
+  rendu est **127**, celui que le shell emploie pour « command not found » ; un
+  chemin désigne un fichier et rend **2**.
+
+### Changé
+
+- **`click` n'est plus une dépendance déclarée.** Son dernier importeur a
+  disparu en 0.1.50 avec la migration de la complétion vers `autocompletion=`,
+  et typer 0.27 ne dépend plus de click : il le vendore. La dépendance était
+  donc installée pour rien. Vérifié après retrait : `click` disparaît
+  complètement de `uv.lock`, les 544 tests et les 16 tests de bout en bout
+  passent, et la roue installée pilote toujours les trois catalogues.
+
 ## [0.1.56] - 2026-08-21
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.57] - 2026-08-23
+
+### Fixed
+
+- **A missing executable produced a Python traceback.** The CLI carefully turns
+  `CommandError`, `DomainNotFound`, `UnsupportedSchemaVersion` and the contract
+  errors into a translated message plus an exit code; `FileNotFoundError` went
+  straight through to the interpreter. A traceback says "the tool is broken"
+  when what is usually missing is a binary the learner can install themselves.
+  The net sits in `_I18nGroup.invoke`, alongside the Ctrl-C one: the only point
+  that covers all twenty-four commands without instrumenting any of them. A name
+  with no separator was looked up in `PATH`, so it is an executable and the exit
+  code is **127**, the one the shell uses for "command not found"; a path is a
+  file and yields **2**.
+
+### Changed
+
+- **`click` is no longer a declared dependency.** Its last importer went away in
+  0.1.50 with the completion migration to `autocompletion=`, and typer 0.27 no
+  longer depends on click: it vendors it. The dependency was installed for
+  nothing. Verified after removal: `click` disappears from `uv.lock` entirely,
+  all 544 unit tests and 16 end-to-end tests pass, and the installed wheel still
+  drives the three catalogues.
+
 ## [0.1.56] - 2026-08-21
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.56"
+version = "0.1.57"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -32,7 +32,6 @@ dependencies = [
     "typer>=0.12",
     "rich>=13",
     "pyyaml>=6",
-    "click>=8",
     # ansible-runner pilote ansible-core programmatiquement (API officielle
     # Red Hat utilisée par AAP et ansible-navigator).
     #

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -161,6 +161,23 @@ class _I18nGroup(TyperGroup):
             return super().invoke(ctx)
         except KeyboardInterrupt:
             raise Interrupted(Stage.UNKNOWN) from None
+        except FileNotFoundError as exc:
+            # Un binaire absent remontait jusqu'à l'interpréteur, et une trace
+            # Python dit « l'outil est cassé » alors qu'il manque le plus
+            # souvent un paquet que l'apprenant peut poser lui-même. Toutes les
+            # autres erreurs attendues sont déjà converties en message + code ;
+            # celle-ci ne l'était pas, faute d'un endroit qui la voie passer.
+            manquant = exc.filename or str(exc)
+            # Un nom sans séparateur a été cherché dans le PATH : c'est la
+            # définition d'un exécutable introuvable, et 127 est le code que le
+            # shell rend dans ce cas. Un chemin, lui, désigne un fichier.
+            est_executable = "/" not in str(manquant)
+            error(_(
+                "err_executable_introuvable" if est_executable
+                else "err_fichier_introuvable",
+                nom=manquant,
+            ))
+            raise typer.Exit(127 if est_executable else 2) from None
 
 
 app = typer.Typer(

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -964,4 +964,10 @@ silent.
     "unknown_key_suggest":
         "'{field}' is not part of the contract, and dsoxlab ignores it. "
         "The closest key it does read at that level is '{suggestion}'.",
+
+    # ── #138 : un exécutable absent se nomme, il ne se plante pas ──
+    "err_executable_introuvable":
+        '"{nom}" is not installed, or not on your PATH. dsoxlab needs it for this command; install it, then try again.',
+    "err_fichier_introuvable":
+        'File not found: "{nom}".',
 }

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -975,4 +975,10 @@ hors ligne, elle se tait.
         "« {field} » ne fait pas partie du contrat, et dsoxlab l'ignore. "
         "La clé la plus proche qu'il lit vraiment, à ce niveau, est "
         "« {suggestion} ».",
+
+    # ── #138 : un exécutable absent se nomme, il ne se plante pas ──
+    "err_executable_introuvable":
+        "« {nom} » n'est pas installé, ou n'est pas dans ton PATH. dsoxlab en a besoin pour cette commande : installe-le, puis relance.",
+    "err_fichier_introuvable":
+        'Fichier introuvable : « {nom} ».',
 }

--- a/tests/test_executable_absent.py
+++ b/tests/test_executable_absent.py
@@ -1,0 +1,83 @@
+"""Un exécutable absent se nomme, il ne rend pas une trace Python (#138).
+
+La CLI convertit déjà `CommandError`, `DomainNotFound`, `UnsupportedSchemaVersion`
+et les erreurs du contrat en message traduit suivi d'un code de sortie.
+`FileNotFoundError` traversait tout et remontait à l'interpréteur : l'apprenant
+lisait une trace, qui dit « l'outil est cassé » alors qu'il lui manque le plus
+souvent un binaire qu'il peut poser lui-même.
+
+Le filet vit dans `_I18nGroup.invoke`, au même endroit que celui du Ctrl-C :
+c'est le seul point qui couvre toutes les commandes sans en instrumenter aucune.
+"""
+
+from __future__ import annotations
+
+import typer
+from typer.testing import CliRunner
+
+from dsoxlab import cli
+from dsoxlab.i18n import _load
+
+runner = CliRunner()
+
+
+def _app_qui_leve(erreur: BaseException) -> typer.Typer:
+    """Une application minimale bâtie sur le même groupe que la vraie CLI."""
+    app = typer.Typer(cls=cli._I18nGroup)
+
+    @app.command("sonde")
+    def sonde() -> None:
+        raise erreur
+
+    # Une seconde commande, sans laquelle typer expose l'application comme une
+    # commande unique : le groupe n'est alors jamais construit, et le filet
+    # qu'on teste n'existe pas dans ce montage. La vraie CLI en a vingt-quatre.
+    @app.command("temoin")
+    def temoin() -> None:
+        return None
+
+    return app
+
+
+def test_un_executable_absent_rend_127_et_le_nomme() -> None:
+    """127 est le code que le shell rend pour « command not found »."""
+    absent = FileNotFoundError(2, "No such file or directory")
+    absent.filename = "terraform"
+
+    resultat = runner.invoke(_app_qui_leve(absent), ["sonde"])
+
+    assert resultat.exit_code == 127, resultat.output
+    assert "terraform" in resultat.output
+    assert "Traceback" not in resultat.output
+
+
+def test_un_fichier_absent_rend_2_et_le_nomme() -> None:
+    """Un chemin n'est pas une commande : il ne mérite pas le code du shell."""
+    absent = FileNotFoundError(2, "No such file or directory")
+    absent.filename = "/etc/dsoxlab/absent.yaml"
+
+    resultat = runner.invoke(_app_qui_leve(absent), ["sonde"])
+
+    assert resultat.exit_code == 2, resultat.output
+    assert "/etc/dsoxlab/absent.yaml" in resultat.output
+    assert "Traceback" not in resultat.output
+
+
+def test_le_message_existe_dans_les_deux_langues() -> None:
+    """Une clé posée d'un seul côté lève un KeyError à l'exécution, sur un
+    chemin d'erreur — donc au pire moment, et seulement dans une langue."""
+    for langue in ("en", "fr"):
+        table = _load(langue)
+        for cle in ("err_executable_introuvable", "err_fichier_introuvable"):
+            assert cle in table, f"{cle} manque en {langue}"
+            assert "{nom}" in table[cle], f"{cle} en {langue} n'emploie pas {{nom}}"
+
+
+def test_la_traduction_se_compose_sans_jamais_lever() -> None:
+    """Le garde-fou du garde-fou : une clé présente mais mal formée ne se voit
+    qu'à l'exécution."""
+    for langue in ("en", "fr"):
+        cli_i18n = _load(langue)
+        rendu = cli_i18n["err_executable_introuvable"].format(nom="terraform")
+        assert "terraform" in rendu
+        assert "{" not in rendu

--- a/uv.lock
+++ b/uv.lock
@@ -229,18 +229,6 @@ wheels = [
 ]
 
 [[package]]
-name = "click"
-version = "8.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -316,13 +304,12 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.56"
+version = "0.1.57"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "ansible-core", version = "2.21.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "ansible-runner" },
-    { name = "click" },
     { name = "pytest" },
     { name = "pytest-testinfra" },
     { name = "pyyaml" },
@@ -346,7 +333,6 @@ fuzz = [
 requires-dist = [
     { name = "ansible-core", specifier = ">=2.16" },
     { name = "ansible-runner", specifier = ">=2.4" },
-    { name = "click", specifier = ">=8" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-testinfra", specifier = ">=10" },
     { name = "pyyaml", specifier = ">=6" },


### PR DESCRIPTION
Deux dettes courtes, mergées ensemble parce qu'aucune ne justifie sa propre CI.

## `FileNotFoundError` rendait une trace Python

La CLI convertit soigneusement `CommandError`, `DomainNotFound`,
`UnsupportedSchemaVersion` et les erreurs du contrat en message traduit suivi
d'un code de sortie. `FileNotFoundError`, lui, traversait tout et remontait à
l'interpréteur. Or une trace dit **« l'outil est cassé »** alors qu'il manque le
plus souvent un binaire que l'apprenant peut poser lui-même.

Le filet est posé dans `_I18nGroup.invoke`, au même endroit que celui du Ctrl-C :
c'est le seul point qui couvre les vingt-quatre commandes sans en instrumenter
aucune.

Deux codes, parce que les deux cas ne disent pas la même chose : un nom **sans
séparateur** a été cherché dans le `PATH`, donc c'est un exécutable et le code
est **127**, celui que le shell emploie pour « command not found » ; un chemin
désigne un fichier et rend **2**.

## `click` n'est plus déclaré

Son dernier importeur a disparu en 0.1.50 avec la migration de la complétion
vers `autocompletion=`, et typer 0.27 ne dépend plus de click : il le **vendore**.
La dépendance était donc installée pour rien.

Vérifié après retrait : `click` disparaît **complètement** de `uv.lock` — ce qui
prouve que plus rien ne le tirait, même transitivement.

## Type of change

- [x] Bug fix
- [x] Chore / tooling

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — no issues in 60 source files
- [x] `uv run pytest` — **548 passed** (544 avant, +4) ; `tests_e2e` — **16 passed**
- [x] Domain-agnostic ; aucun chemin personnel
- [x] La roue installée pilote toujours les trois catalogues — c'est le contrôle
      qui compte pour un retrait de dépendance, et la suite E2E l'exerce

### When behavior changes

- [x] CHANGELOG EN + FR ; version **0.1.57** ; `uv.lock` régénéré

### When a command or option is added, removed or changed

- [x] Deux clés ajoutées **simultanément** dans `en.py` et `fr.py`. Aucune
      commande ni option ne change, donc `fullhelp` est inchangé.

### When `.github/workflows/` is touched — N/A
### When the declarative contract changes — N/A

## Mutation

Débrancher le filet fait échouer les tests qui vérifient le code de sortie et
l'absence de trace ; restauré, les quatre passent.

Deux faux départs, corrigés et documentés dans le fichier : le montage de test
n'avait **qu'une** commande, si bien que typer exposait l'application comme
commande unique et ne construisait jamais le groupe — le filet testé n'existait
pas dans ce montage. Et un nom de test faisait exactement 35 caractères après
`test_`, ce que le détecteur Lob de trufflehog signale comme un secret vérifié :
renommé, jamais excepté.

## Related issues

Closes #135
Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)