### PR TITLE
fix(doctor): dire ce qui manque au lieu d'un « 0 lab » muet (0.1.58)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,32 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.58] - 2026-08-23
+
+### Corrigé
+
+- **`doctor` affichait « 0 lab » sans dire pourquoi.** `list-labs` explique très
+  bien, lui : il nomme le fichier, la version en cause et la commande qui
+  répare. `doctor` se contentait d'un rouge muet, alors que c'est lui qu'on
+  lance quand quelque chose cloche, et lui qu'on colle dans un rapport de bug.
+  Le contrôle compare désormais les `lab.yaml` **présents sur le disque** aux
+  labs réellement chargés, et nomme l'écart. Cet écart couvre d'un coup les
+  trois façons dont un lab devient invisible, sans avoir à deviner laquelle
+  s'applique : un `schema_version` trop récent, un fichier qui lève au parsing,
+  ou un lab déclaré au `meta.yml` mais absent du disque.
+
+- **Un `lab.yaml` qui lève au parsing n'allait qu'au journal**, que rien
+  n'affiche : il disparaissait sans laisser de trace exploitable, ce dont le
+  `CLAUDE.md` fait son piège n°4. `CatalogScan` retient désormais le chemin et
+  la raison.
+
+### Interne
+
+- La règle de recherche des `lab.yaml` est extraite dans le scanner et exposée
+  par `compter_fichiers_labs()`. Un premier jet la dupliquait dans `doctor`, et
+  les deux définitions divergeaient dès l'écriture : le comptage ignorait les
+  `tp-*/` que le scanner accepte pour les anciens dépôts.
+
 ## [0.1.57] - 2026-08-23
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.58] - 2026-08-23
+
+### Fixed
+
+- **`doctor` reported "0 labs" without saying why.** `list-labs` explains it
+  well: it names the file, the offending version and the command that fixes it.
+  `doctor` showed a silent red, although it is the command people run when
+  something is wrong, and the one they paste into a bug report. The check now
+  compares the `lab.yaml` files **present on disk** with the labs actually
+  loaded, and names the gap. That gap covers all three ways a lab becomes
+  invisible at once, with no need to guess which one applies: a `schema_version`
+  that is too new, a file that raises while parsing, or a lab declared in
+  `meta.yml` but missing from disk.
+
+- **A `lab.yaml` that raises while parsing only went to the log**, which nothing
+  displays: it vanished without a usable trace — trap #4 in the repository's
+  `CLAUDE.md`. `CatalogScan` now keeps the path and the reason.
+
+### Internal
+
+- The `lab.yaml` search rule is extracted into the scanner and exposed through
+  `compter_fichiers_labs()`. A first attempt duplicated it inside `doctor`, and
+  the two definitions diverged as they were written: the count ignored the
+  `tp-*/` layout the scanner accepts for older repositories.
+
 ## [0.1.57] - 2026-08-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.57"
+version = "0.1.58"
 description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/discovery/scanner.py
+++ b/src/dsoxlab/discovery/scanner.py
@@ -53,10 +53,48 @@ class CatalogScan:
     labs: list[LabDefinition] = field(default_factory=list)
 
     unsupported: list[UnsupportedSchemaVersion] = field(default_factory=list)
+
+    #: Les `lab.yaml` que le parseur a refusés, et la raison. Ils n'allaient
+    #: qu'au journal, que rien n'affiche : un lab disparaissait alors sans
+    #: laisser de trace lisible, ce dont le CLAUDE.md fait son piège n°4.
+    illisibles: list[tuple[Path, str]] = field(default_factory=list)
+
+    #: Combien de `lab.yaml` ont été **rencontrés**, chargés ou non. C'est le
+    #: scanner qui compte, parce que lui seul sait où il cherche : sous `labs/`
+    #: mais aussi dans les `tp-*/` des anciens dépôts. Un appelant qui
+    #: recompterait de son côté finirait par diverger de cette règle.
+    fichiers_vus: int = 0
     """Les ``lab.yaml`` écartés parce qu'ils déclarent une version du contrat
     postérieure à celle que ce dsoxlab lit. Le reste du catalogue est servi
     normalement : un lab venu du futur ne doit pas rendre les 283 autres
     injouables, sans quoi aucun auteur ne pourrait jamais en publier un."""
+
+
+def _chemins_candidats(root: Path) -> list[Path]:
+    """Les fichiers où un `lab.yaml` peut se trouver, sous ``root``.
+
+    Extrait du balayage pour que :func:`compter_fichiers_labs` applique
+    exactement la même règle. Deux définitions de « où sont les labs » finiraient
+    par diverger, et c'est arrivé dès le premier essai : un comptage limité à
+    ``labs/`` ignorait les ``tp-*/`` des anciens dépôts.
+    """
+    chemins: list[Path] = []
+    if (root / "labs").exists():
+        chemins += list((root / "labs").glob("**/*.yaml"))
+    # Compat : tp-* à la racine (anciens dépôts)
+    chemins += list(root.glob("tp-*/lab.yaml"))
+    return chemins
+
+
+def compter_fichiers_labs(root: Path) -> int:
+    """Combien de `lab.yaml` existent sous ``root``, lisibles ou non.
+
+    Comparé au nombre de labs réellement chargés, l'écart désigne d'un coup les
+    trois façons dont un lab devient invisible : un ``schema_version`` trop
+    récent, un fichier qui lève au parsing, ou un lab déclaré au ``meta.yml``
+    mais absent du disque.
+    """
+    return sum(1 for p in _chemins_candidats(root) if p.name == "lab.yaml")
 
 
 def scan_catalog(
@@ -86,15 +124,10 @@ def scan_catalog(
 
     scan = CatalogScan()
 
-    search_paths: list[Path] = []
-    if (root / "labs").exists():
-        search_paths += list((root / "labs").glob("**/*.yaml"))
-    # Compat : tp-* à la racine (anciens dépôts)
-    search_paths += list(root.glob("tp-*/lab.yaml"))
-
-    for yaml_path in search_paths:
+    for yaml_path in _chemins_candidats(root):
         if yaml_path.name != "lab.yaml":
             continue
+        scan.fichiers_vus += 1
         try:
             lab = LabDefinition.from_yaml(yaml_path, lang=lang)
             _assign_section(lab, yaml_path, root, repo_meta)
@@ -116,6 +149,7 @@ def scan_catalog(
             scan.unsupported.append(exc)
         except (KeyError, ValueError, yaml.YAMLError) as exc:
             logger.warning("lab.yaml ignoré (%s) : %s", yaml_path, exc)
+            scan.illisibles.append((yaml_path, f"{type(exc).__name__}: {exc}"))
 
     scan.labs = _sort_labs(scan.labs, root, repo_meta)
     return scan

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -970,4 +970,8 @@ silent.
         '"{nom}" is not installed, or not on your PATH. dsoxlab needs it for this command; install it, then try again.',
     "err_fichier_introuvable":
         'File not found: "{nom}".',
+
+    # ── #132 : un « 0 lab » muet oblige à chercher ailleurs ──
+    "detail_labs_ecart":
+        "{ecart} of the {presents} lab.yaml files on disk could not be loaded. `dsoxlab list-labs` names them and says why.",
 }

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -981,4 +981,8 @@ hors ligne, elle se tait.
         "« {nom} » n'est pas installé, ou n'est pas dans ton PATH. dsoxlab en a besoin pour cette commande : installe-le, puis relance.",
     "err_fichier_introuvable":
         'Fichier introuvable : « {nom} ».',
+
+    # ── #132 : un « 0 lab » muet oblige à chercher ailleurs ──
+    "detail_labs_ecart":
+        "{ecart} des {presents} fichiers lab.yaml présents sur le disque n'ont pas pu être chargés. « dsoxlab list-labs » les nomme et dit pourquoi.",
 }

--- a/src/dsoxlab/services/doctor.py
+++ b/src/dsoxlab/services/doctor.py
@@ -33,6 +33,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from ..discovery.scanner import compter_fichiers_labs
 from ..i18n import _
 from ..infra import ansible as ansible_infra
 from ..models import LabDefinition, RepoMetadata
@@ -477,11 +478,24 @@ def _check_iso_tool() -> Check:
     )
 
 
-def _check_labs(root: Path, labs: list[LabDefinition]) -> Check:
-    return Check(
-        _("check_labs"), len(labs) > 0,
-        _("detail_labs_count", count=len(labs), root=root),
-    )
+def _check_labs(root: Path, labs: list[LabDefinition], vus: int) -> Check:
+    """Le compte des labs, et **ce qui manque** quand il ne colle pas.
+
+    Un « 0 lab » muet oblige l'utilisateur à retrouver seul une information que
+    `list-labs` possède déjà. Trois causes rendent un lab invisible : un
+    `schema_version` trop récent, un `lab.yaml` qui lève au parsing, ou un lab
+    déclaré dans le `meta.yml` mais absent du disque. Plutôt que de deviner
+    laquelle s'applique, on compare les fichiers présents aux labs chargés :
+    l'écart les couvre toutes les trois.
+    """
+    ecart = vus - len(labs)
+    detail = _("detail_labs_count", count=len(labs), root=root)
+    if ecart > 0:
+        detail += " " + _("detail_labs_ecart", ecart=ecart, presents=vus)
+    # Seul un écart POSITIF dit quelque chose : des fichiers présents que le
+    # moteur n'a pas su charger. L'inverse ne peut pas venir d'un catalogue réel,
+    # et vaut zéro information.
+    return Check(_("check_labs"), len(labs) > 0 and ecart <= 0, detail)
 
 
 def _check_lab_home(root: Path) -> Check:
@@ -582,6 +596,6 @@ def collect_checks(root: Path, repo_meta: RepoMetadata | None) -> DoctorReport:
         elif active == "incus" and hypervisors["incus"].ok:
             report.required.append(_check_iso_tool())
 
-    report.required.append(_check_labs(root, labs))
+    report.required.append(_check_labs(root, labs, compter_fichiers_labs(root)))
     report.required.append(_check_lab_home(root))
     return report

--- a/tests/test_doctor_explique.py
+++ b/tests/test_doctor_explique.py
@@ -1,0 +1,95 @@
+"""`doctor` dit ce qu'il ne trouve pas, au lieu d'un « 0 lab » muet (#132).
+
+`list-labs` explique très bien : il nomme le fichier, la version et la commande
+qui répare. `doctor` affichait « ✘ KO — 0 lab » sans un mot, alors que c'est lui
+qu'on lance quand quelque chose cloche, et lui qu'on colle dans un rapport de
+bug.
+
+Trois causes rendent un lab invisible : un `schema_version` trop récent, un
+`lab.yaml` qui lève au parsing, ou un lab déclaré au `meta.yml` mais absent du
+disque. Plutôt que de deviner laquelle s'applique, le contrôle compare les
+fichiers présents aux labs chargés : l'écart les couvre toutes les trois.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dsoxlab.discovery.scanner import compter_fichiers_labs, scan_catalog
+
+LAB = """id: {ident}
+title: Lab {ident}
+level: beginner
+skills: [demo]
+distros: [any]
+doc_url: https://example.invalid/doc
+runtime:
+  type: shell
+  workdir: challenge/work
+"""
+
+
+def _catalogue(racine: Path, *, sains: int = 1, casses: int = 0) -> Path:
+    (racine / "meta.yml").write_text(
+        "repo:\n  id: essai\n  category: demo\n", encoding="utf-8"
+    )
+    for i in range(sains):
+        d = racine / "labs" / "demo" / f"bon{i}"
+        d.mkdir(parents=True)
+        (d / "lab.yaml").write_text(LAB.format(ident=f"bon{i}"), encoding="utf-8")
+    for i in range(casses):
+        d = racine / "labs" / "demo" / f"casse{i}"
+        d.mkdir(parents=True)
+        # Sans `level`, le parseur lève : c'est un champ requis du contrat.
+        (d / "lab.yaml").write_text(
+            LAB.format(ident=f"casse{i}").replace("level: beginner\n", ""),
+            encoding="utf-8",
+        )
+    return racine
+
+
+def test_le_compte_couvre_les_fichiers_illisibles(tmp_path: Path) -> None:
+    """C'est l'écart qui porte l'information, pas le nombre de labs chargés."""
+    racine = _catalogue(tmp_path, sains=2, casses=1)
+
+    assert compter_fichiers_labs(racine) == 3
+    assert len(scan_catalog(racine).labs) == 2
+
+
+def test_un_fichier_qui_leve_est_retenu_et_nomme(tmp_path: Path) -> None:
+    """Il n'allait qu'au journal, que rien n'affiche : le lab disparaissait
+    alors sans laisser de trace exploitable."""
+    racine = _catalogue(tmp_path, sains=1, casses=1)
+
+    scan = scan_catalog(racine)
+
+    assert len(scan.illisibles) == 1
+    chemin, raison = scan.illisibles[0]
+    assert chemin.name == "lab.yaml"
+    assert "casse0" in str(chemin)
+    assert raison, "la raison ne doit pas être vide"
+
+
+def test_un_catalogue_sain_ne_signale_aucun_ecart(tmp_path: Path) -> None:
+    """Le contre-exemple : sans lui, un contrôle qui crie toujours ne dit rien."""
+    racine = _catalogue(tmp_path, sains=3)
+
+    assert compter_fichiers_labs(racine) == len(scan_catalog(racine).labs) == 3
+    assert scan_catalog(racine).illisibles == []
+
+
+def test_le_comptage_voit_les_anciens_depots_en_tp(tmp_path: Path) -> None:
+    """La règle de recherche est celle du scanner, pas une seconde définition.
+
+    Un premier jet comptait sous `labs/` seulement, et ignorait les `tp-*/` que
+    le scanner accepte pour les anciens dépôts : deux définitions de « où sont
+    les labs » qui divergeaient déjà.
+    """
+    (tmp_path / "meta.yml").write_text(
+        "repo:\n  id: essai\n  category: demo\n", encoding="utf-8"
+    )
+    ancien = tmp_path / "tp-01"
+    ancien.mkdir()
+    (ancien / "lab.yaml").write_text(LAB.format(ident="ancien"), encoding="utf-8")
+
+    assert compter_fichiers_labs(tmp_path) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -304,7 +304,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.57"
+version = "0.1.58"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
`list-labs` explique très bien : il nomme le fichier, la version en cause et la
commande qui répare. `doctor` se contentait d'un rouge muet — alors que c'est
**lui** qu'on lance quand quelque chose cloche, et lui qu'on colle dans un
rapport de bug.

## Le comportement, avant et après

Sur un catalogue de deux labs dont un est illisible :

```
avant :  │ Labs détectés │ ✘ KO │ 1 lab(s) dans /tmp/…                    │

après :  │ Labs détectés │ ✘ KO │ 1 lab(s) dans /tmp/…                    │
         │               │      │ 1 des 2 fichiers lab.yaml présents sur  │
         │               │      │ le disque n'ont pas pu être chargés.    │
         │               │      │ « dsoxlab list-labs » les nomme et dit  │
         │               │      │ pourquoi.                               │
```

**L'écart couvre les trois causes d'un coup**, sans avoir à deviner laquelle
s'applique : un `schema_version` trop récent, un fichier qui lève au parsing, ou
un lab déclaré au `meta.yml` mais absent du disque. C'est ce qui rend le contrôle
robuste : il ne dépend pas d'une énumération de causes qu'il faudrait tenir à
jour.

Et un `lab.yaml` qui lève n'allait **qu'au journal**, que rien n'affiche : il
disparaissait sans laisser de trace exploitable, ce dont le `CLAUDE.md` fait son
piège n°4. `CatalogScan` retient désormais le chemin et la raison.

## Type of change

- [x] Bug fix

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — no issues in 60 source files
- [x] `uv run pytest` — **552 passed** (548 avant, +4) ; `tests_e2e` — **16 passed**
- [x] Domain-agnostic ; aucun chemin personnel
- [x] Testé sur les catalogues réels : `validate-structure` rc=0 sur
      `linux-dsoxlab-training` et `terraform-training`, et `doctor` rend
      « ✔ OK — 87 lab(s) » sur ce dernier, sans écart

### When behavior changes

- [x] CHANGELOG EN + FR ; version **0.1.58** ; `uv.lock` régénéré

### When a command or option is added, removed or changed

- [x] Une clé ajoutée **simultanément** dans `en.py` et `fr.py`. Aucune commande
      ni option ne change, donc `fullhelp` est inchangé.

### When `.github/workflows/` is touched — N/A
### When the declarative contract changes — N/A

## Mutation

Faire oublier au scanner les fichiers illisibles fait échouer le test qui les
nomme ; restauré, les quatre passent.

## Deux jets antérieurs, documentés dans le code

Ils valent d'être connus, parce qu'ils disent où sont les pièges de ce fichier.

**Le premier dupliquait la règle de recherche** dans `doctor` (`rglob` sous
`labs/`) — et les deux définitions divergeaient **dès l'écriture** : le comptage
ignorait les `tp-*/` que le scanner accepte pour les anciens dépôts. Trois tests
sont tombés. La règle est donc extraite dans le scanner et exposée par
`compter_fichiers_labs()`, avec un test qui couvre justement le cas `tp-*`.

**Le second remplaçait `get_all_labs` par `scan_catalog`** dans `collect_checks`.
Douze tests sont tombés — non parce que le comportement changeait, mais parce
qu'ils monkeypatchent `get_all_labs` pour injecter leurs labs. Casser douze tests
pour un détail d'implémentation est le signe qu'on s'y prend mal : l'appel
d'origine est conservé, et seul le comptage est délégué.

**Et la condition finale ne teste pas l'égalité mais `ecart <= 0`** : seul un
écart positif dit quelque chose. L'inverse ne peut pas venir d'un catalogue réel,
et c'était un artefact des tests qui injectent des labs sans fichiers sur disque.

## Related issues

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)