### PR TITLE
docs(brand): dire ce que l'outil est devenu, aux quatre endroits (0.1.59)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,29 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.59] - 2026-08-23
+
+### Modifié
+
+- **La description du projet disait ce que l'outil fait pour son auteur.**
+  « Un framework CLI neutre vis-à-vis du domaine qui pilote des labs répartis
+  dans plusieurs dépôts » était juste quand elle a été écrite. Ce qui a changé
+  depuis n'est pas une fonctionnalité, c'est la nature de l'outil : le contrat
+  déclaratif, les runtimes interchangeables, la validation et les diagnostics en
+  font un moteur que quelqu'un d'autre peut employer pour ses propres exercices.
+  Les quatre emplacements (`pyproject.toml`, la description GitHub, les deux
+  README et `fullhelp`) portent désormais la même phrase : dsoxlab transforme des
+  exercices déclaratifs en environnements **reproductibles, exécutables et
+  vérifiables**.
+
+- **`fullhelp` annonçait des runtimes qui n'existent plus.** Il promettait un
+  « conteneur incus ou VM KVM » là où le contrat n'expose que deux types,
+  `shell` et `vm` : Incus est un backend de `vm`, choisi par le `meta.yml` du
+  catalogue, pas un runtime que l'apprenant déclare. Il liait aussi chaque lab à
+  un guide d'un site précis, et énumérait des niveaux (`l1`, `lfcs`, `rhcsa`)
+  qui appartiennent à un catalogue particulier, alors que c'est le catalogue qui
+  nomme ses sections et ses niveaux.
+
 ## [0.1.58] - 2026-08-23
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.59] - 2026-08-23
+
+### Changed
+
+- **The project description said what the tool does for its author.** "A
+  domain-agnostic CLI framework driving labs spread across multiple
+  repositories" was accurate when it was written. What changed since is not a
+  feature but the nature of the tool: the declarative contract, interchangeable
+  runtimes, validation and diagnostics make it an engine someone else can use
+  for their own exercises. All four places (`pyproject.toml`, the GitHub
+  description, both READMEs and `fullhelp`) now carry the same sentence: dsoxlab
+  turns declarative exercises into **reproducible, runnable and verifiable**
+  environments.
+
+- **`fullhelp` advertised runtimes that no longer exist.** It promised an "incus
+  container or KVM VM" where the contract only exposes two types, `shell` and
+  `vm`: Incus is a backend of `vm`, picked by the catalog's `meta.yml`, not a
+  runtime a learner declares. It also tied every lab to a guide on one specific
+  site, and listed levels (`l1`, `lfcs`, `rhcsa`) that belong to one particular
+  catalog, when it is the catalog that names its own sections and levels.
+
 ## [0.1.58] - 2026-08-23
 
 ### Fixed

--- a/README.fr.md
+++ b/README.fr.md
@@ -14,18 +14,20 @@
 
 **Autre langue :** [English](./README.md)
 
-`dsoxlab` est un **framework CLI neutre vis-à-vis du domaine** qui pilote des
-labs pédagogiques répartis dans **plusieurs dépôts**. Chaque dépôt déclare son
-catalogue via un fichier `meta.yml` à la racine et un `lab.yaml` par lab.
+`dsoxlab` transforme des **exercices déclaratifs en environnements
+reproductibles, exécutables et vérifiables**. Un catalogue déclare ce qu'il
+propose via un `meta.yml` à la racine et un `lab.yaml` par lab ; le moteur
+provisionne ce que le lab demande, l'ouvre, et prouve le résultat par des tests
+qui lisent l'**état du système** plutôt que les commandes tapées.
 
-Le framework sert aussi bien des labs Linux, Ansible, Kubernetes que Terraform,
-tout ce qui respecte le contrat déclaratif. Il provisionne l'environnement,
-exécute une validation au niveau du système (`pytest` + `pytest-testinfra`),
-score la progression et conserve l'historique en local. Rien de spécifique à un
-domaine ne vit dans le moteur.
+Rien de spécifique à un domaine ne vit dans le moteur : il sert aussi bien des
+labs Linux, Ansible, Kubernetes que Terraform, et tout autre catalogue qui
+respecte le contrat déclaratif. Il score aussi la progression et conserve
+l'historique en local, par catalogue.
 
-> Compagnon des tutoriels de
-> [blog.stephane-robert.info](https://blog.stephane-robert.info).
+> Né pour accompagner les tutoriels de
+> [blog.stephane-robert.info](https://blog.stephane-robert.info), et utilisable
+> sans eux.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/stephrobert/dsoxlab/main/docs/demo.gif" alt="dsoxlab en action : list-labs et show" width="820">

--- a/README.md
+++ b/README.md
@@ -14,19 +14,20 @@
 
 **Read this in another language:** [Français](./README.fr.md)
 
-`dsoxlab` is a **domain-agnostic CLI framework** that drives hands-on
-learning labs spread across **multiple repositories**. Each repository
-declares its own catalog through a root `meta.yml` file and one `lab.yaml`
-per lab.
+`dsoxlab` turns **declarative exercises into reproducible, runnable and
+verifiable environments**. A catalog states what it offers through a root
+`meta.yml` and one `lab.yaml` per lab; the engine provisions what each lab
+asks for, opens it, and proves the result with tests that read the **state of
+the system** rather than the commands typed into it.
 
-The framework serves Linux, Ansible, Kubernetes or Terraform labs equally
-well — anything that honors the declarative contract. It provisions the
-environment, runs infrastructure-level validation (`pytest` +
-`pytest-testinfra`), scores progress, and stores history locally. Nothing
-about a specific domain lives in the engine.
+Nothing about a specific domain lives in the engine: it serves Linux, Ansible,
+Kubernetes or Terraform labs equally well, and any other catalog that honors
+the declarative contract. It also scores progress and keeps the history
+locally, per catalog.
 
-> Companion to the tutorials on
-> [blog.stephane-robert.info](https://blog.stephane-robert.info).
+> Originally built for the tutorials on
+> [blog.stephane-robert.info](https://blog.stephane-robert.info), and usable
+> without them.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/stephrobert/dsoxlab/main/docs/demo.gif" alt="dsoxlab in action: list-labs and show" width="820">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.58"
-description = "DevSecOps XL Labs — a domain-agnostic CLI framework to drive hands-on learning labs across multiple repositories"
+version = "0.1.59"
+description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -275,22 +275,22 @@ STRINGS: dict[str, str] = {
     "fullhelp_concept": """\
 [bold]What is dsoxlab?[/bold]
 
-dsoxlab is the CLI of the [bold cyan]DevSecOps XL Labs[/bold cyan] platform: a self-contained
-practice platform built to complement the training content at
-[bold]https://blog.stephane-robert.info/docs/[/bold]
+dsoxlab turns [bold]declarative exercises[/bold] into reproducible, runnable and
+verifiable environments.
 
-Each [cyan]lab[/cyan] is a standalone exercise linked to a site guide, covering a
-specific skill: Linux, containers, Kubernetes, IaC, security, CI/CD…
+A [bold]catalog[/bold] is a repository that states what it offers: a root [cyan]meta.yml[/cyan]
+for the topology, one [cyan]lab.yaml[/cyan] per lab for what that lab needs. Nothing
+about a domain lives in the tool, so the same engine serves Linux, Ansible,
+Terraform or Kubernetes labs, and any other catalog that honors the contract.
 
-Labs are organised by [bold]section[/bold] (linux, ansible, terraform, kubernetes…)
-and [bold]level[/bold] (l1 → beginner, l2 → intermediate, lfcs, rhcsa).
+Labs are organised by [bold]section[/bold] and [bold]level[/bold], both named by the catalog itself.
 
-Each lab exposes:
+Each lab declares:
   • an observable [bold]skill[/bold] to acquire,
-  • a [bold]runtime[/bold] (shell, incus container or KVM VM),
-  • [bold]automated tests[/bold] to validate your solution,
+  • a [bold]runtime[/bold] ([bold]shell[/bold] on your machine, or a [bold]vm[/bold] provisioned for you),
+  • [bold]automated tests[/bold] that read the state of the system, not the commands typed,
   • [bold]hints[/bold] if you are stuck (with a score penalty),
-  • a [bold]direct link[/bold] to the corresponding site guide.""",
+  • a [bold]link[/bold] to the guide that goes with it.""",
 
     "fullhelp_workflow": """\
 [bold]Typical workflow[/bold]

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -279,22 +279,23 @@ STRINGS: dict[str, str] = {
     "fullhelp_concept": """\
 [bold]Qu'est-ce que dsoxlab ?[/bold]
 
-dsoxlab est la CLI de la plateforme [bold cyan]DevSecOps XL Labs[/bold cyan] : une plateforme de
-formation pratique auto-portée, conçue pour accompagner les formations du site
-[bold]https://blog.stephane-robert.info/docs/[/bold]
+dsoxlab transforme des [bold]exercices déclaratifs[/bold] en environnements
+reproductibles, exécutables et vérifiables.
 
-Chaque [cyan]lab[/cyan] est un exercice autonome lié à un guide du site, portant sur une
-compétence précise : Linux, conteneurs, Kubernetes, IaC, sécurité, CI/CD…
+Un [bold]catalogue[/bold] est un dépôt qui déclare ce qu'il propose : un [cyan]meta.yml[/cyan] à la
+racine pour la topologie, un [cyan]lab.yaml[/cyan] par lab pour ce dont ce lab a besoin.
+Rien de spécifique à un domaine ne vit dans l'outil : le même moteur sert des
+labs Linux, Ansible, Terraform ou Kubernetes, et tout autre catalogue qui
+respecte le contrat.
 
-Les labs sont organisés par [bold]section[/bold] (linux, ansible, terraform, kubernetes…)
-et par [bold]niveau[/bold] (l1 → débutant, l2 → intermédiaire, lfcs, rhcsa).
+Les labs sont organisés par [bold]section[/bold] et par [bold]niveau[/bold], que le catalogue nomme lui-même.
 
-Chaque lab expose :
+Chaque lab déclare :
   • une [bold]compétence observable[/bold] à acquérir,
-  • un [bold]runtime[/bold] (shell, conteneur incus ou VM KVM),
-  • des [bold]tests automatiques[/bold] pour valider votre réponse,
+  • un [bold]runtime[/bold] ([bold]shell[/bold] sur votre poste, ou une [bold]vm[/bold] provisionnée pour vous),
+  • des [bold]tests automatiques[/bold] qui lisent l'état du système, pas les commandes tapées,
   • des [bold]indices[/bold] en cas de blocage (avec pénalité sur le score),
-  • un [bold]lien direct[/bold] vers le guide du site correspondant.""",
+  • un [bold]lien[/bold] vers le guide qui l'accompagne.""",
 
     "fullhelp_workflow": """\
 [bold]Workflow typique[/bold]

--- a/tests/test_description_alignee.py
+++ b/tests/test_description_alignee.py
@@ -1,0 +1,64 @@
+"""La description du produit dit la même chose aux quatre endroits (#120).
+
+Elle vit dans `pyproject.toml`, sur la page GitHub, en tête des deux README et
+dans `fullhelp`. Rien ne les tenait ensemble, et elles avaient divergé : le
+`fullhelp` promettait encore un « conteneur incus ou VM KVM » que le contrat
+n'expose plus depuis longtemps.
+
+Ce test ne juge pas la formulation, qui appartient à l'auteur. Il vérifie que
+les trois qualités que le produit revendique restent nommées partout : un
+environnement **reproductible** (le contrat, pas un script), **exécutable**
+(plusieurs runtimes) et **vérifiable** (des tests qui prouvent l'état).
+
+La description GitHub n'est pas dans le dépôt, donc hors de portée d'un test.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from dsoxlab.i18n.strings.en import STRINGS as EN
+from dsoxlab.i18n.strings.fr import STRINGS as FR
+
+RACINE = Path(__file__).resolve().parent.parent
+
+TRIPTYQUE_EN = ("reproducible", "runnable", "verifiable")
+TRIPTYQUE_FR = ("reproductibles", "exécutables", "vérifiables")
+
+
+def test_le_pyproject_annonce_les_trois_qualites() -> None:
+    """C'est la phrase que lit PyPI, et souvent la seule qu'on lise."""
+    with (RACINE / "pyproject.toml").open("rb") as f:
+        description = tomllib.load(f)["project"]["description"]
+
+    for mot in TRIPTYQUE_EN:
+        assert mot in description.lower(), f"« {mot} » a disparu de la description"
+
+
+def test_les_deux_readme_ouvrent_sur_la_meme_idee() -> None:
+    for nom, mots in (("README.md", TRIPTYQUE_EN), ("README.fr.md", TRIPTYQUE_FR)):
+        # Le premier paragraphe seulement : plus bas, tout est déjà dit autrement.
+        tete = (RACINE / nom).read_text(encoding="utf-8")[:2500].lower()
+        for mot in mots:
+            assert mot in tete, f"{nom} : « {mot} » manque en tête"
+
+
+def test_le_fullhelp_dit_la_meme_chose_dans_les_deux_langues() -> None:
+    """C'est la version que lit un utilisateur qui n'ouvrira jamais le README."""
+    for strings, mots in ((EN, TRIPTYQUE_EN), (FR, TRIPTYQUE_FR)):
+        concept = strings["fullhelp_concept"].lower()
+        for mot in mots:
+            assert mot in concept, f"fullhelp_concept : « {mot} » manque"
+
+
+def test_le_fullhelp_ne_promet_pas_de_runtime_qui_nexiste_pas() -> None:
+    """Le contrat n'expose que `shell` et `vm`.
+
+    Incus est un backend de `vm`, choisi par le `meta.yml` du catalogue : le
+    présenter comme un runtime à part apprenait une chose fausse du contrat.
+    """
+    for strings in (EN, FR):
+        concept = strings["fullhelp_concept"].lower()
+        assert "incus" not in concept
+        assert "kvm" not in concept

--- a/uv.lock
+++ b/uv.lock
@@ -304,7 +304,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.58"
+version = "0.1.59"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
La description décrivait ce que le projet fait **pour son auteur** : piloter ses
labs, répartis dans plusieurs dépôts. Ce qui a changé depuis n'est pas une
fonctionnalité, c'est la nature de l'outil. Le contrat déclaratif, les runtimes
interchangeables, la validation et les diagnostics en font un moteur que
**quelqu'un d'autre** peut employer pour ses propres exercices.

## La phrase, et pourquoi ces trois mots

> dsoxlab transforme des exercices déclaratifs en environnements
> **reproductibles**, **exécutables** et **vérifiables**.

Chacun porte un fait, pas un adjectif de brochure : reproductibles (le contrat,
pas un script), exécutables (plusieurs runtimes), vérifiables (des tests qui
prouvent l'**état du système**, pas la commande tapée). C'est ce que fait
réellement le produit, et ce qu'un lecteur de PyPI ne devinait pas.

**La formulation reste la tienne** : l'issue proposait, elle ne tranchait pas.
Elle se change en un point, dans `pyproject.toml`, et le test la suit.

## Ce que le `fullhelp` racontait encore

Deux dérives, invisibles parce que rien ne les tenait :

- il promettait un « conteneur incus ou VM KVM », **un runtime qui n'existe
  pas** : le contrat n'expose que `shell` et `vm`, et Incus est un *backend* de
  `vm` choisi par le `meta.yml` du catalogue. Un lecteur en tirait une idée
  fausse du contrat qu'il allait écrire ;
- il liait chaque lab au guide d'**un site précis** et énumérait des niveaux
  (`l1`, `lfcs`, `rhcsa`) qui appartiennent à **un seul catalogue**, alors que
  c'est le catalogue qui nomme ses sections et ses niveaux.

## Le rendu réel, dans les deux langues

```console
$ DSOXLAB_LANG=en dsoxlab fullhelp        $ DSOXLAB_LANG=fr dsoxlab fullhelp
What is dsoxlab?                          Qu'est-ce que dsoxlab ?

dsoxlab turns declarative exercises       dsoxlab transforme des exercices
into reproducible, runnable and           déclaratifs en environnements
verifiable environments.                  reproductibles, exécutables et
                                          vérifiables.
```

## Type of change

- [x] Documentation

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — no issues in 60 source files
- [x] `uv run pytest` — **556 passed** (552 avant, +4)
- [x] Domain-agnostic : le texte cite Linux/Ansible/Terraform **en exemple**,
      et dit explicitement que le catalogue nomme ses propres sections
- [x] Rendu vérifié à l'écran dans les deux langues (ci-dessus)

### When behavior changes

- [x] CHANGELOG EN + FR ; version **0.1.59** ; `uv.lock` régénéré

### When a command or option is added, removed or changed

- [x] Aucune commande ne change. Le **contenu** de `fullhelp` est corrigé
      simultanément en EN et FR.

### When `.github/workflows/` is touched — N/A
### When the declarative contract changes — N/A

## Le test, et sa mutation

`tests/test_description_alignee.py` tient les emplacements ensemble : c'est de
les avoir laissés libres qui les avait fait diverger. Il ne juge pas la
formulation, il vérifie que les trois qualités restent nommées partout, et que
le `fullhelp` ne réinvente pas un runtime.

Mutation : remettre « shell, incus container or KVM VM » dans `en.py` fait
rougir `test_le_fullhelp_ne_promet_pas_de_runtime_qui_nexiste_pas`. Restauré,
les quatre passent.

## Reste à faire hors dépôt

La **description GitHub** du dépôt ne vit pas dans le code : je l'aligne après
le merge, aucun test ne peut la couvrir.

## Related issues

Closes #120
Voisine de #86, dont elle partage l'emplacement et le public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)