### PR TITLE
ci(distributions): éprouver cinq systèmes plutôt que quatre Python sur un seul

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        # 3.14 n'est pas une anticipation : Fedora et Ubuntu 26.04 le
+        # packagent déjà, et l'environnement de développement de ce dépôt
+        # tourne dessus. La matrice mesurait donc trois versions dont
+        # aucune n'était celle qui sert tous les jours.
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     env:
       # Passed through the environment (not template-expanded into run blocks)
       # so no context value is ever interpolated into shell code.
@@ -237,6 +241,124 @@ jobs:
       # up by accident and the contribution gate keeps its measured duration.
       - name: End-to-end suite (build the wheel, install it, drive the binary)
         run: uv run pytest tests_e2e
+
+  # The wheel every distribution job installs — built ONCE, on purpose.
+  #
+  # Letting each distribution build its own would make five artifacts and prove
+  # nothing about the one PyPI serves. It would also hide a packaging bug behind
+  # a build that happens to work on that particular system. One artifact, five
+  # systems: any difference in the outcome then belongs to the system.
+  roue:
+    name: Build the wheel (once, for every distribution)
+    needs: [zizmor, actionlint, poutine]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          version: "0.11.26"
+          enable-cache: true
+
+      - name: Build the wheel
+        run: uv build --wheel --out-dir dist
+
+      - name: Publish it for the distribution jobs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: roue-parcours
+          path: dist/*.whl
+          retention-days: 1
+          if-no-files-found: error
+
+  # Distribution gate — the users of dsoxlab do not have different Python
+  # versions, they have different DISTRIBUTIONS.
+  #
+  # That is where the product breaks, because what it drives (ssh, terraform,
+  # libvirt, docker, sudo) is packaged differently there, in different versions,
+  # under different paths. A matrix that only varies Python on a single Ubuntu
+  # measures none of it.
+  #
+  # `UV_PYTHON_DOWNLOADS=never` (set by the script) is what gives this job its
+  # meaning: uv installs its own standalone CPython by default, identical
+  # everywhere, and the matrix would then measure GitHub's network rather than
+  # the systems. Pinned off, the wheel installs on the Python the distribution
+  # ships — the only way to learn that one of them ships a Python too old.
+  #
+  # The scenario is the E2E suite itself, not a copy of it: one scenario, five
+  # systems. `fail-fast: false` because "Fedora is red" and "Arch is red" are
+  # two different pieces of news, and stopping at the first hides the second.
+  distributions:
+    name: Parcours on ${{ matrix.nom }}
+    needs: [roue]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - nom: Debian 13
+            image: debian:13
+            amorcage: apt-get update -qq && apt-get install -y -qq python3 python3-venv python3-pip >/dev/null
+          - nom: Ubuntu 24.04 LTS
+            image: ubuntu:24.04
+            amorcage: apt-get update -qq && apt-get install -y -qq python3 python3-venv python3-pip >/dev/null
+          - nom: Ubuntu 26.04 LTS
+            image: ubuntu:26.04
+            amorcage: apt-get update -qq && apt-get install -y -qq python3 python3-venv python3-pip >/dev/null
+          - nom: Fedora
+            image: fedora:latest
+            amorcage: dnf install -y -q python3 python3-pip >/dev/null
+          # `-Syu`, never `-Sy`: a partial upgrade pulls a python built against
+          # a newer glibc than the image ships, and every import of a C module
+          # then fails on `GLIBC_2.44 not found`. Seen while writing this job.
+          - nom: Arch Linux
+            image: archlinux:latest
+            amorcage: pacman -Syu --noconfirm --quiet python python-pip >/dev/null
+    env:
+      # Passed through the environment (not template-expanded into run blocks)
+      # so no context value is ever interpolated into shell code.
+      IMAGE: ${{ matrix.image }}
+      AMORCAGE: ${{ matrix.amorcage }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Fetch the wheel built once
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: roue-parcours
+          path: dist
+
+      # The repository is mounted READ-ONLY inside the container: a newcomer's
+      # parcours never writes into the tool's own sources, and if it ever needs
+      # to, that is a defect this mount makes visible.
+      - name: Parcours end to end
+        run: |
+          roue=$(find dist -name '*.whl' | head -1)
+          python3 scripts/parcours-distribution.py \
+            --image "$IMAGE" --bootstrap "$AMORCAGE" --wheel "$roue"
 
   # Parity gate — run EVERY pre-commit hook (commit AND push stages) exactly as
   # a contributor's local pre-commit would, from this project's locked env. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Education",
     "Topic :: System :: Systems Administration",
     "Typing :: Typed",

--- a/scripts/parcours-distribution.py
+++ b/scripts/parcours-distribution.py
@@ -1,0 +1,138 @@
+"""Joue la suite E2E dans une distribution, sur le Python que cette distribution package.
+
+Les utilisateurs de dsoxlab n'ont pas des versions de Python différentes : ils
+ont des **distributions** différentes. C'est là que le produit casse, parce que
+ce qu'il pilote (ssh, terraform, libvirt, docker, sudo) y est packagé
+autrement, dans d'autres versions, avec d'autres chemins. Une matrice qui ne
+fait varier que Python sur un seul Ubuntu ne mesure rien de tout cela.
+
+Ce script est le même pour toutes les distributions : ce qui change tient dans
+la commande d'amorçage, passée en argument. Un script par distribution ferait
+converger cinq scénarios différents vers cinq verts qui ne disent rien.
+
+Il tourne en CI (un job par distribution, cf. `.github/workflows/ci.yml`) et
+**à la main**, ce qui est le point : la matrice se rejoue sur un poste avant
+d'être poussée.
+
+    uv build --wheel --out-dir dist
+    python3 scripts/parcours-distribution.py \
+        --image debian:13 \
+        --bootstrap 'apt-get update -qq && apt-get install -y -qq python3 python3-venv python3-pip' \
+        --wheel dist/dsoxlab-*.whl
+
+Deux garde-fous portent tout le sens de l'exercice.
+
+``UV_PYTHON_DOWNLOADS=never`` interdit à uv de télécharger son propre CPython.
+uv en installe un « standalone » par défaut, identique partout : la matrice ne
+mesurerait plus alors que le réseau de GitHub. Avec ce garde-fou, la roue
+s'installe sur le Python de la distribution, et c'est le seul moyen d'apprendre
+qu'elle en package un trop vieux.
+
+``DSOXLAB_E2E_WHEEL`` fournit la roue **déjà construite** : la suite sait la
+lire, donc aucune distribution ne reconstruit, et toutes éprouvent l'artefact
+que PyPI servirait plutôt que cinq artefacts différents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+#: Le dépôt, monté **en lecture seule** dans le conteneur. Le parcours d'un
+#: utilisateur n'écrit jamais dans les sources de l'outil : si un jour il en a
+#: besoin, c'est un défaut, et le montage le fait apparaître ici.
+POINT_TRAVAIL = "/travail"
+
+#: L'environnement du harnais (uv + pytest), séparé de celui où la roue sera
+#: installée. Sans cette séparation, la suite testerait sa propre installation
+#: plutôt que l'empaquetage.
+HARNAIS = "/opt/harnais"
+
+
+def _commande_conteneur(amorcage: str, roue_dans_conteneur: str) -> str:
+    """Les étapes jouées **dans** la distribution, dans l'ordre.
+
+    Composées ici plutôt que dans un fichier shell : le dépôt n'en contient
+    aucun, et l'orchestration reste en Python comme le reste de l'outillage.
+    """
+    etapes = [
+        # `set -e` : une étape ratée arrête tout. Sans lui, un amorçage en échec
+        # laisserait la suite tourner sur un Python absent, et le message
+        # d'erreur ne parlerait plus de la distribution.
+        "set -e",
+        "echo '── amorçage de la distribution ──'",
+        amorcage,
+        "echo '── le Python de cette distribution ──'",
+        "python3 --version",
+        f"python3 -m venv {HARNAIS}",
+        f"{HARNAIS}/bin/pip install --quiet --disable-pip-version-check uv pytest",
+        f"export PATH={HARNAIS}/bin:$PATH",
+        f"cd {POINT_TRAVAIL}",
+        "echo '── parcours de bout en bout ──'",
+        # `-p no:cacheprovider` : le dépôt est monté en lecture seule, et pytest
+        # tenterait sinon d'y écrire son cache. Un avertissement, pas un échec,
+        # mais un avertissement qu'on lira un jour comme un vrai problème.
+        f"exec {HARNAIS}/bin/python -m pytest tests_e2e -q -p no:cacheprovider",
+    ]
+    return "\n".join(etapes)
+
+
+def _argv_docker(image: str, depot: Path, roue: Path, amorcage: str) -> list[str]:
+    # La roue est prise **dans** le dépôt monté : un seul montage, donc un seul
+    # chemin à raisonner, et rien à recopier avant de lancer le conteneur.
+    relative = roue.resolve().relative_to(depot.resolve())
+    dans_conteneur = f"{POINT_TRAVAIL}/{relative}"
+
+    return [
+        "docker", "run", "--rm",
+        # Les distributions Debian posent des questions à l'installation si on
+        # ne les en dispense pas, et le conteneur n'a pas de terminal.
+        "-e", "DEBIAN_FRONTEND=noninteractive",
+        "-e", "UV_PYTHON_DOWNLOADS=never",
+        "-e", f"DSOXLAB_E2E_WHEEL={dans_conteneur}",
+        "-v", f"{depot.resolve()}:{POINT_TRAVAIL}:ro",
+        "-w", POINT_TRAVAIL,
+        image,
+        "sh", "-c", _commande_conteneur(amorcage, dans_conteneur),
+    ]
+
+
+def main() -> int:
+    analyseur = argparse.ArgumentParser(description=__doc__ or "")
+    analyseur.add_argument("--image", required=True, help="image de la distribution")
+    analyseur.add_argument(
+        "--bootstrap",
+        required=True,
+        help="commande qui installe python3, venv et pip dans cette distribution",
+    )
+    analyseur.add_argument(
+        "--wheel", required=True, type=Path, help="la roue à éprouver, dans le dépôt"
+    )
+    analyseur.add_argument(
+        "--repo",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="racine du dépôt (défaut : celle de ce script)",
+    )
+    arguments = analyseur.parse_args()
+
+    if shutil.which("docker") is None:
+        # On n'ignore pas en silence : une matrice de distributions désactivée
+        # est une matrice qui n'existe pas.
+        print("docker est introuvable, et ce contrôle ne sait pas s'en passer.", file=sys.stderr)
+        return 127
+
+    if not arguments.wheel.is_file():
+        print(f"roue introuvable : {arguments.wheel}", file=sys.stderr)
+        return 2
+
+    argv = _argv_docker(arguments.image, arguments.repo, arguments.wheel, arguments.bootstrap)
+    print(f"── {arguments.image} ──", flush=True)
+    return subprocess.run(argv, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_parcours_distribution.py
+++ b/tests/test_parcours_distribution.py
@@ -1,0 +1,82 @@
+"""Les deux garde-fous de la matrice de distributions (#84).
+
+Le job qui joue le parcours sur cinq systèmes ne vaut que par deux réglages, et
+tous deux sont silencieux quand ils sautent : la CI resterait verte, plus rien
+ne serait mesuré, et personne ne le verrait avant le rapport de bug.
+
+* Sans ``UV_PYTHON_DOWNLOADS=never``, uv installe son propre CPython
+  « standalone », le même partout. Les cinq jobs mesureraient alors le réseau
+  de GitHub, pas les cinq distributions.
+* Sans ``DSOXLAB_E2E_WHEEL``, chaque distribution reconstruirait sa roue. On
+  éprouverait cinq artefacts au lieu de celui que PyPI sert, et un défaut
+  d'empaquetage pourrait se cacher derrière une construction qui, là, marche.
+
+D'où ces tests sur la composition de la commande : ils coûtent une milliseconde
+et attrapent la seule régression que la CI ne peut pas voir elle-même.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+RACINE = Path(__file__).resolve().parent.parent
+
+
+def _script() -> ModuleType:
+    """Le script chargé par son chemin : `scripts/` n'est pas un paquet.
+
+    C'est volontaire (rien n'y est importable par le produit), donc le test
+    passe par importlib plutôt que de transformer l'outillage en dépendance.
+    """
+    chemin = RACINE / "scripts" / "parcours-distribution.py"
+    spec = importlib.util.spec_from_file_location("parcours_distribution", chemin)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_uv_ne_telecharge_jamais_son_propre_python() -> None:
+    """Sinon la matrice mesure le réseau de GitHub, pas cinq distributions."""
+    argv = _script()._argv_docker(
+        "debian:13", RACINE, RACINE / "dist" / "dsoxlab-0.0.0-py3-none-any.whl", "true"
+    )
+
+    assert "UV_PYTHON_DOWNLOADS=never" in argv
+
+
+def test_la_roue_est_fournie_et_jamais_reconstruite() -> None:
+    """Une seule roue pour cinq systèmes : c'est ce qui rend l'écart lisible."""
+    argv = _script()._argv_docker(
+        "fedora:latest", RACINE, RACINE / "dist" / "dsoxlab-0.0.0-py3-none-any.whl", "true"
+    )
+
+    fourniture = [a for a in argv if a.startswith("DSOXLAB_E2E_WHEEL=")]
+    assert fourniture == ["DSOXLAB_E2E_WHEEL=/travail/dist/dsoxlab-0.0.0-py3-none-any.whl"]
+
+
+def test_le_depot_n_est_monte_qu_en_lecture() -> None:
+    """Le parcours d'un utilisateur n'écrit pas dans les sources de l'outil.
+
+    Le montage en lecture seule est ce qui le prouve : le jour où la suite en a
+    besoin, elle échoue ici plutôt que de laisser passer un défaut réel.
+    """
+    argv = _script()._argv_docker(
+        "archlinux:latest", RACINE, RACINE / "dist" / "roue.whl", "true"
+    )
+
+    montages = [argv[i + 1] for i, a in enumerate(argv) if a == "-v"]
+    assert montages == [f"{RACINE}:/travail:ro"]
+
+
+def test_un_amorcage_en_echec_arrete_tout() -> None:
+    """`set -e` en tête : sans lui, la suite tournerait sur un Python absent,
+    et le message d'erreur ne parlerait plus de la distribution."""
+    commande = _script()._commande_conteneur("apt-get install python3", "/travail/x.whl")
+
+    assert commande.splitlines()[0] == "set -e"
+    assert "apt-get install python3" in commande


### PR DESCRIPTION
Les utilisateurs de dsoxlab n'ont pas des **versions de Python** différentes :
ils ont des **distributions** différentes. C'est là que le produit casse, parce
que ce qu'il pilote y est packagé autrement, dans d'autres versions, sous
d'autres chemins. La matrice ne mesurait rien de cela : les huit jobs étaient
figés sur `ubuntu-24.04`, et seule la version de Python variait.

## Ce que la CI mesure maintenant

| Job | Système | Python de la distribution |
|---|---|---|
| `Parcours on Debian 13` | `debian:13` | 3.13.5 |
| `Parcours on Ubuntu 24.04 LTS` | `ubuntu:24.04` | 3.12.3 |
| `Parcours on Ubuntu 26.04 LTS` | `ubuntu:26.04` | 3.14.4 |
| `Parcours on Fedora` | `fedora:latest` | 3.14.7 |
| `Parcours on Arch Linux` | `archlinux:latest` | 3.14.7 |

Les cinq sont **joués localement avant d'être poussés**, et rendent 16/16.

## Le scénario n'est pas réécrit

C'est la suite E2E elle-même. Le harnais prévoyait déjà le cas :

> `DSOXLAB_E2E_WHEEL` permet de fournir une roue déjà construite : c'est ce dont
> une matrice de distributions a besoin pour jouer le même scénario sur
> plusieurs systèmes sans reconstruire à chaque fois.

La roue est donc construite **une fois**, dans un job dédié, et les cinq
systèmes éprouvent **l'artefact que PyPI sert**. Cinq constructions auraient
donné cinq artefacts, et auraient pu cacher un défaut d'empaquetage derrière une
construction qui, là, marche.

## Le réglage qui porte tout le sens du job

`UV_PYTHON_DOWNLOADS=never`. uv installe sinon son propre CPython
« standalone », **identique partout** : les cinq jobs mesureraient alors le
réseau de GitHub, pas cinq distributions. Coupé, la roue s'installe sur le
Python que la distribution package, et c'est la seule façon d'apprendre qu'elle
en package un trop vieux.

C'est aussi ce qu'aucun test d'intégration ne peut voir de lui-même : le job
resterait **vert** en ne mesurant plus rien. D'où
`tests/test_parcours_distribution.py`, qui tient les deux garde-fous.

## Python 3.14

Ajouté à la matrice de versions **et** aux classifiers. Ce n'était pas une
anticipation : Fedora et Ubuntu 26.04 le packagent déjà, l'environnement de
développement de ce dépôt tourne dessus, et les trois versions testées ne
comprenaient donc pas celle qui sert tous les jours. Suite complète, `mypy` et
`ruff` vérifiés dessus avant de l'inscrire.

## Ce que j'ai appris en l'écrivant, et qui est dans le code

- **Arch : `-Syu`, jamais `-Sy`.** La mise à jour partielle installe un python
  compilé contre une glibc plus récente que celle de l'image, et tout import de
  module C meurt sur `GLIBC_2.44 not found`. Le premier jet est tombé dessus.
- **Le dépôt est monté en lecture seule** dans le conteneur : le parcours d'un
  utilisateur n'écrit pas dans les sources de l'outil, et le jour où il en a
  besoin, ce montage le fera apparaître.
- **L'orchestration est en Python.** Le dépôt ne contient aucun script shell, et
  `scripts/parcours-distribution.py` se rejoue à la main :
  ```console
  $ uv build --wheel --out-dir dist
  $ python3 scripts/parcours-distribution.py --image fedora:latest \
      --bootstrap 'dnf install -y -q python3 python3-pip' --wheel dist/*.whl
  ```

## Type of change

- [x] CI / build

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — no issues in 60 source files
- [x] `uv run pytest` — **560 passed** (556 avant, +4) ; suite jouée aussi sous **Python 3.14**
- [x] Domain-agnostic ; aucun chemin personnel (le script prend sa racine de son propre emplacement)

### When behavior changes

- [ ] **Pas de bump ni de CHANGELOG, et c'est délibéré** : rien ne change pour
      un utilisateur de la CLI. Le seul élément qui atteindra PyPI est le
      classifier `Python :: 3.14`, qui partira avec la prochaine version.

### When a command or option is added, removed or changed — N/A
### When the declarative contract changes — N/A

### When `.github/workflows/` is touched

- [x] `actionlint` : 0 problème
- [x] `zizmor --persona=regular` : *No findings to report. Good job!*
- [x] Actions épinglées par SHA (les mêmes que celles déjà en place),
      `permissions: contents: read`, `persist-credentials: false`,
      `timeout-minutes` sur les deux jobs
- [x] Aucune valeur de contexte interpolée dans du shell : `matrix.image` et
      `matrix.amorcage` passent par `env:`

## Durée

Les cinq jobs sont parallèles et indépendants, chacun borné à 20 minutes, et
chacun tient sous 4 minutes en pratique (tirage de l'image compris). Le job
`roue` qui les précède prend moins d'une minute. `fail-fast: false` parce que
« Fedora est rouge » et « Arch est rouge » sont deux nouvelles différentes, et
s'arrêter à la première cache la seconde. Aucune réduction de matrice n'est
donc nécessaire sur les branches de travail.

## Mutation

Les quatre tests sont prouvés : retirer `UV_PYTHON_DOWNLOADS=never`, retirer la
fourniture de la roue, monter le dépôt en écriture, ou ôter le `set -e` fait
rougir le test correspondant. Restauré, les quatre passent.

## Ce que ces jobs ne couvrent toujours pas

Les labs `vm` : ni hyperviseur ni privilèges sur un runner. Le catalogue de
démonstration est un lab `shell`, donc le parcours joué est complet **pour ce
qu'il couvre**, et rien de ce qui touche libvirt, Terraform ou Incus n'est
mesuré ici. C'était déjà le cas avant cette PR, et ça reste à traiter ailleurs.

## Related issues

Closes #84
Complète #85 (la suite E2E boîte noire), qui fournit le scénario que ces jobs
exécutent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)