### PR TITLE
fix(i18n): un catalogue mal formé se dit dans la langue de qui le lit (0.1.60)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,53 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.60] - 2026-08-24
+
+### Corrigé
+
+- **Un catalogue mal formé parlait français sous `DSOXLAB_LANG=en`.** Chaque
+  message affiché par `validate-structure` venait d'un champ `message` écrit à
+  la main dans une dataclass de validator, qu'aucun garde-fou ne pouvait voir :
+  les quatre puits que surveille le garde-fou i18n (`help=`, les helpers
+  d'affichage, `raise`, les verbes de sortie de Rich) ne couvrent pas une valeur
+  rangée dans une dataclass. `ContentIssue`, `MetadataIssue` et `StructureIssue`
+  portent désormais une **clé** et ses paramètres, exactement comme
+  `ContractIssue` le faisait déjà, et c'est la CLI qui compose la phrase. 39
+  clés ajoutées en anglais et en français. `check_doc_url()` suit la même
+  règle : il rend une `ContentIssue` au lieu d'un motif qu'il rédigeait.
+
+- **Les erreurs de contrat du `meta.yml` étaient françaises elles aussi**, et
+  celles-là atteignent l'écran : `discovery/repo.py` les laisse remonter et
+  `cli.py` les affiche. Elles sont levées en `ContractError`, qui porte
+  `source`, `field`, une clé i18n et ses paramètres, le patron que
+  `UnsupportedSchemaVersion` et `ProviderUnresolved` suivaient déjà. Le modèle
+  reste agnostique de la langue ; la CLI dit la phrase et l'encadre du chemin
+  du fichier.
+
+- **Un champ mal typé du `meta.yml` rendait un traceback brut sur
+  `list-labs`**, parce que le scanner relit ce fichier pour l'ordre des
+  sections et que rien n'attrapait l'erreur sur ce chemin, là où les autres
+  commandes passaient par `_read_repo` et obtenaient une phrase. Les deux
+  chemins passent désormais par le même helper.
+
+### Changé
+
+- Les 24 `ValueError` de `models/` ont été triées sur une seule question : ce
+  message atteint-il un humain qui lit l'interface ? 17 oui, par le `meta.yml`,
+  et suivent le patron. 7 non : elles viennent d'un `lab.yaml`, dont le seul
+  lecteur est `discovery/scanner.py`, qui écarte le lab et journalise la
+  raison. Celles-là lèvent une `LabYamlError` dont le texte reste technique,
+  parce que traduire ce qui ne s'affiche jamais est du travail perdu et du
+  bruit dans les tables de traduction.
+
+- Le garde-fou i18n couvre désormais `models/`, dont l'exclusion en bloc
+  disparaît, et gagne un cinquième puits pour les anomalies que
+  `validate-structure` affiche. Il connaît `LabYamlError` par son nom, ce qui
+  rend le tri **vérifiable** : le jour où l'un de ces messages doit s'afficher,
+  il change de classe et le garde-fou réclame sa clé.
+
+Closes #139.
+
 ## [0.1.59] - 2026-08-23
 
 ### Modifié

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.60] - 2026-08-24
+
+### Fixed
+
+- **A malformed catalogue spoke French under `DSOXLAB_LANG=en`.** Every message
+  `validate-structure` prints came from a `message` field written by hand in a
+  validator dataclass, and no guard could see it: the four sinks the i18n guard
+  watches (`help=`, the display helpers, `raise`, the Rich output verbs) do not
+  cover a value stored in a dataclass. `ContentIssue`, `MetadataIssue` and
+  `StructureIssue` now carry a **key** and its parameters, exactly like
+  `ContractIssue` already did, and the CLI composes the sentence. 39 keys added
+  in English and French. `check_doc_url()` follows the same rule: it returns a
+  `ContentIssue` instead of a reason it wrote itself.
+
+- **The contract errors of `meta.yml` were French too**, and they reach the
+  screen: `discovery/repo.py` lets them through and `cli.py` renders them. They
+  are raised as `ContractError`, which carries `source`, `field`, an i18n key
+  and its parameters, the pattern `UnsupportedSchemaVersion` and
+  `ProviderUnresolved` already followed. The model stays language-agnostic; the
+  CLI says the sentence and frames it with the file path.
+
+- **A mistyped field in `meta.yml` produced a raw traceback on `list-labs`**,
+  because the scanner reads that file for the section order and nothing caught
+  the error on that path, while the other commands went through `_read_repo`
+  and got a sentence. Both paths now go through the same helper.
+
+### Changed
+
+- The 24 `ValueError` of `models/` were sorted on one question: does this
+  message reach a human reading the interface? 17 do, through `meta.yml`, and
+  follow the pattern. 7 do not: they come from a `lab.yaml`, whose only reader
+  is `discovery/scanner.py`, which drops the lab and logs the reason. Those
+  raise a `LabYamlError` whose text stays technical, because translating what
+  is never displayed is wasted work and noise in the translation tables.
+
+- The i18n guard now covers `models/`, whose blanket exclusion is gone, and
+  gains a fifth sink for the anomalies `validate-structure` displays. It knows
+  `LabYamlError` by name, which is what makes the sort **checkable**: the day
+  one of those messages has to be displayed, it changes class and the guard
+  asks for its key.
+
+Closes #139.
+
 ## [0.1.59] - 2026-08-23
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.59"
+version = "0.1.60"
 description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -59,6 +59,7 @@ from .interrupt import (
 from .locking import EXIT_LOCKED, RepoLock, RepoLocked
 from .logging_setup import configurer as configurer_journal
 from .models import (
+    ContractError,
     CourseManifest,
     LabDefinition,
     ProviderUnresolved,
@@ -241,6 +242,27 @@ def _contrat_trop_recent(exc: UnsupportedSchemaVersion) -> NoReturn:
     raise typer.Exit(1)
 
 
+def _phrase_contrat(exc: ContractError) -> str:
+    """La phrase d'un champ du contrat que le moteur ne sait pas lire.
+
+    Le modèle porte les faits (``source``, ``field``) et la **clé** ; la phrase
+    se compose ici, dans la langue de l'apprenant. Le chemin du fichier encadre
+    le message plutôt que d'entrer dans chaque traduction : il est le même pour
+    toutes, et le répéter dans les tables les ferait diverger.
+
+    Un seul endroit la compose, parce que deux appelants la disent :
+    :func:`_contrat_illisible`, qui sort en ``typer.Exit``, et le filet de
+    :func:`main`, qui sort en ``SystemExit``.
+    """
+    return f"{exc.source}: {_(exc.key, **exc.params)}"
+
+
+def _contrat_illisible(exc: ContractError) -> NoReturn:
+    """Rend l'erreur de contrat et sort, pour les commandes qui lisent le catalogue."""
+    error(_phrase_contrat(exc))
+    raise typer.Exit(1)
+
+
 def _read_repo(root: Path) -> RepoMetadata | None:
     """Wrapper de ``read_repo_metadata`` qui formate proprement les
     erreurs de résolution de provider (ValueError) en message CLI +
@@ -250,10 +272,15 @@ def _read_repo(root: Path) -> RepoMetadata | None:
 
     try:
         return read_repo_metadata(root)
-    # AVANT ValueError, dont elle hérite : `str(exc)` rendrait un message
-    # technique et non traduit là où la cause mérite une phrase.
+    # AVANT ValueError, dont elles héritent toutes deux : `str(exc)` rendrait
+    # un message technique et non traduit là où la cause mérite une phrase.
     except UnsupportedSchemaVersion as exc:
         _contrat_trop_recent(exc)
+    # Le meta.yml est le seul fichier du contrat dont les erreurs de lecture
+    # s'affichent : le modèle porte la clé et les faits, la phrase se compose
+    # dans `_contrat_illisible`.
+    except ContractError as exc:
+        _contrat_illisible(exc)
     except ValueError as exc:
         error(str(exc))
         raise typer.Exit(1) from None
@@ -276,6 +303,11 @@ def _catalogue(root: Path, lang: str, *, quiet: bool = False) -> list[LabDefinit
         scan = scan_catalog(root, lang=lang)
     except UnsupportedSchemaVersion as exc:
         _contrat_trop_recent(exc)
+    # Le scanner relit le meta.yml pour l'ordre des sections : un champ mal
+    # typé y remontait donc en traceback, sur `list-labs` comme sur `progress`,
+    # alors que `_read_repo` disait déjà la phrase sur les autres commandes.
+    except ContractError as exc:
+        _contrat_illisible(exc)
     if not quiet:
         for ecarte in scan.unsupported:
             warn(_(
@@ -1539,6 +1571,7 @@ def validate_structure_cmd(
     from .discovery.repo import read_repo_metadata
     from .discovery.scanner import discover_labs
     from .validators.content import (
+        ContentIssue,
         check_doc_url,
         validate_internal_links,
         validate_language_parity,
@@ -1605,7 +1638,7 @@ def validate_structure_cmd(
     except Exception:  # noqa: BLE001 - meta.yml illisible : les autres contrôles restent utiles
         host_names = set()
 
-    content_issues: list[tuple[str, Path, str]] = []
+    content_issues: list[tuple[str, Path, ContentIssue]] = []
     for lab in labs:
         rapports = [
             validate_internal_links(lab),
@@ -1626,35 +1659,40 @@ def validate_structure_cmd(
             )
         for rapport in rapports:
             for souci in rapport.issues:
-                content_issues.append((lab.id, souci.path, souci.message))
+                content_issues.append((lab.id, souci.path, souci))
 
     if content_issues:
         console.print(_("content_issues_header"))
-        for lab_id, chemin, message in content_issues:
-            try:
-                affiche = chemin.relative_to(root)
-            except ValueError:
-                affiche = chemin
-            console.print(f"  [red]✘[/red] {lab_id} — {affiche}: {message}")
+        for lab_id, chemin, souci in content_issues:
+            console.print(
+                f"  [red]✘[/red] {lab_id} — {_rendu(chemin)}: "
+                f"{_(souci.key, **souci.params)}"
+            )
 
-    url_issues: list[tuple[str, str]] = []
+    url_issues: list[tuple[str, str, ContentIssue]] = []
     if check_urls:
         info(_("checking_doc_urls", count=len(labs)))
         for lab in labs:
-            motif = check_doc_url(lab)
-            if motif is not None:
-                url_issues.append((lab.id, f"{lab.doc_url} — {motif}"))
+            injoignable = check_doc_url(lab)
+            if injoignable is not None:
+                url_issues.append((lab.id, lab.doc_url, injoignable))
         if url_issues:
             console.print(_("doc_url_issues_header"))
-            for lab_id, detail in url_issues:
-                console.print(f"  [red]✘[/red] {lab_id} — {detail}")
+            for lab_id, url, raison in url_issues:
+                console.print(
+                    f"  [red]✘[/red] {lab_id} — {url} — "
+                    f"{_(raison.key, **raison.params)}"
+                )
 
     issues = [r for r in metadata_reports if not r.ok]
     if issues:
         console.print(_("metadata_issues_header"))
         for report in issues:
             for issue in report.issues:
-                console.print(f"  [red]✘[/red] {report.lab_id} — {issue.field}: {issue.message}")
+                console.print(
+                    f"  [red]✘[/red] {report.lab_id} — {issue.field}: "
+                    f"{_(issue.key, **issue.params)}"
+                )
 
     all_ok = (
         contract.ok
@@ -2877,4 +2915,9 @@ def main() -> None:
             "schema_version_meta_too_new",
             path=exc.source, found=exc.found, supported=exc.supported,
         ))
+        raise SystemExit(1) from None
+    # Filet de dernier recours, comme au-dessus : une commande qui lirait un
+    # meta.yml par un autre chemin doit rendre la phrase, pas un traceback.
+    except ContractError as exc:
+        error(_phrase_contrat(exc))
         raise SystemExit(1) from None

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -558,6 +558,93 @@ silent.
         "Checking doc_url for {count} lab(s)…",
     "metadata_issues_header": "\n[bold red]Metadata issues:[/bold red]",
 
+    # ── validate-structure: what each validator found ────────────────────────
+    # Les validators ne composent aucune phrase : ils portent une clé et ses
+    # paramètres, et le texte se dit ici, dans la langue de l'auteur.
+    "struct_missing_file": "Missing file: {name}",
+    "struct_missing_dir":  "Missing directory: {name}/",
+    "struct_vm_targets_empty":
+        "runtime.type is 'vm' but runtime.targets[] is empty. Declare at least "
+        "one target, with its name and its host.",
+    "struct_default_unknown":
+        "runtime.default='{default}' matches no runtime.targets[].name. "
+        "Available: {available}",
+    "struct_session_unknown":
+        "runtime.session='{session}' is unknown. Accepted values: 'target' (SSH "
+        "session on targets[].host, the default) or 'local' (sub-shell on the "
+        "learner's machine, for a lab driven from the repository).",
+    "struct_shell_workdir_empty":
+        "runtime.type is 'shell' but runtime.workdir is empty. Declare the work "
+        "directory (e.g. workdir: challenge/work).",
+    "struct_forbidden_cleanup_sh_vm":
+        "cleanup.sh is not allowed for runtime: vm. Use cleanup.yaml.",
+    "struct_forbidden_cleanup_sh_shell":
+        "cleanup.sh is not allowed for runtime: shell. Declare fixtures in lab.yaml.",
+    "struct_forbidden_kvm_sh":
+        "runtime/kvm.sh is not allowed. Use setup.yaml.",
+    "struct_forbidden_incus_sh":
+        "runtime/incus.sh is not allowed. Use setup.yaml.",
+    "struct_forbidden_shell_sh":
+        "runtime/shell.sh is not allowed. Preparation is declared through "
+        "runtime.workdir and runtime.fixtures.",
+    "struct_forbidden_makefile":
+        "A Makefile is not allowed in a lab: dsoxlab drives everything.",
+
+    "metadata_field_empty": "the '{field}' field is empty",
+    "metadata_list_empty":  "the '{field}' list is empty",
+    "metadata_doc_url_scheme": "invalid URL (http/https scheme expected): {url}",
+    "metadata_lab_type_invalid":
+        "Invalid value '{value}'. Expected one of: {expected}",
+    "metadata_exam_score_invalid":
+        "Invalid value '{value}'. Expected a percentage of the lab scale, "
+        "between 1 and 100 (omit the field for a lab that is not an exam).",
+
+    "content_broken_links": "{count} dead relative link(s): {links}",
+    "content_solution_unreadable": "unreadable: {error}",
+    "content_solution_plaintext":
+        "solution in plain text: encrypt it with 'ansible-vault encrypt', "
+        "otherwise git keeps it forever and the lab is spoiled",
+    "content_scoring_tasks_vs_tests":
+        "{tasks} scored task(s) for {tests} test(s): the score is computed per "
+        "test, so the scale on display is not the mark that comes out",
+    "content_scoring_points_mismatch":
+        "the tasks add up to {total} points, the header announces {announced}",
+    "content_scoring_count_mismatch":
+        "{count} scored task(s), the header announces {announced}",
+    "content_missing_english": "no English counterpart ({name})",
+    "content_target_host_unknown":
+        "target '{target}' aims at host '{host}', missing from infra.hosts in meta.yml",
+    "content_role_host_unknown":
+        "role '{role}' aims at '{host}', missing from infra.hosts in meta.yml",
+    "content_doc_url_no_scheme": "no URL scheme",
+    "content_doc_url_scheme": "unexpected scheme: {scheme}",
+    "content_doc_url_unreachable": "unreachable: {error}",
+    "content_doc_url_status": "HTTP {code}",
+
+    # ── contract fields the engine cannot read (models/) ─────────────────────
+    # Levées par la lecture d'un meta.yml, qui s'affiche. La CLI encadre ces
+    # phrases du chemin du fichier ; elles n'ont donc pas à le porter.
+    "contract_field_not_int":
+        "'{field}' must be an integer (got: {got}).",
+    "contract_field_not_list":
+        "'{field}' must be a list (got: {got}).",
+    "contract_field_not_mapping":
+        "'{field}' must be a mapping (got: {got}).",
+    "contract_field_not_mapping_list":
+        "'{field}' must be a list of mappings (got: {got}).",
+    "contract_root_not_mapping":
+        "the document must be a YAML mapping (got: {got}).",
+    "contract_repo_required":
+        "'repo.id' and 'repo.category' are required (dsoxlab contract).",
+    "contract_provider_empty_list":
+        "'infra.provider' is an empty list. Declare at least one provider "
+        "(e.g. 'kvm').",
+    "contract_provider_bad_type":
+        "'infra.provider' must be a string or a list of strings, not {got}.",
+    "contract_provider_not_declared":
+        "DSOXLAB_PROVIDER='{provider}' is not among the providers this meta.yml "
+        "declares: {candidates}",
+
     # ── contract version (schema_version) ─────────────────────────────────────
     "contract_issues_header": "\n[bold red]Contract version:[/bold red]",
     "schema_version_invalid":

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -561,6 +561,96 @@ hors ligne, elle se tait.
         "Vérification des doc_url de {count} lab(s)…",
     "metadata_issues_header": "\n[bold red]Problèmes de métadonnées :[/bold red]",
 
+    # ── validate-structure : ce que chaque validator a trouvé ────────────────
+    # Les validators ne composent aucune phrase : ils portent une clé et ses
+    # paramètres, et le texte se dit ici, dans la langue de l'auteur.
+    "struct_missing_file": "Fichier manquant : {name}",
+    "struct_missing_dir":  "Répertoire manquant : {name}/",
+    "struct_vm_targets_empty":
+        "runtime.type est 'vm' mais runtime.targets[] est vide. Déclare au "
+        "moins une target, avec son name et son host.",
+    "struct_default_unknown":
+        "runtime.default='{default}' ne matche aucun runtime.targets[].name. "
+        "Disponibles : {available}",
+    "struct_session_unknown":
+        "runtime.session='{session}' inconnu. Valeurs acceptées : 'target' "
+        "(session SSH sur targets[].host, défaut) ou 'local' (sous-shell sur "
+        "le poste, pour un lab piloté depuis le dépôt).",
+    "struct_shell_workdir_empty":
+        "runtime.type est 'shell' mais runtime.workdir est vide. Déclare le "
+        "répertoire de travail (ex. workdir: challenge/work).",
+    "struct_forbidden_cleanup_sh_vm":
+        "cleanup.sh interdit pour runtime: vm. Utilise cleanup.yaml.",
+    "struct_forbidden_cleanup_sh_shell":
+        "cleanup.sh interdit pour runtime: shell. Déclare les fixtures dans "
+        "lab.yaml.",
+    "struct_forbidden_kvm_sh":
+        "runtime/kvm.sh interdit. Utilise setup.yaml.",
+    "struct_forbidden_incus_sh":
+        "runtime/incus.sh interdit. Utilise setup.yaml.",
+    "struct_forbidden_shell_sh":
+        "runtime/shell.sh interdit. La préparation se déclare par "
+        "runtime.workdir et runtime.fixtures.",
+    "struct_forbidden_makefile":
+        "Makefile interdit dans un lab : dsoxlab pilote tout.",
+
+    "metadata_field_empty": "le champ '{field}' est vide",
+    "metadata_list_empty":  "la liste '{field}' est vide",
+    "metadata_doc_url_scheme": "URL invalide (schéma http/https attendu) : {url}",
+    "metadata_lab_type_invalid":
+        "Valeur invalide « {value} ». Attendu, l'une de : {expected}",
+    "metadata_exam_score_invalid":
+        "Valeur invalide « {value} ». Attendu : un pourcentage du barème du "
+        "lab, entre 1 et 100 (omets le champ pour un lab qui n'est pas un examen).",
+
+    "content_broken_links": "{count} lien(s) relatif(s) mort(s) : {links}",
+    "content_solution_unreadable": "illisible : {error}",
+    "content_solution_plaintext":
+        "solution en clair : chiffre-la avec « ansible-vault encrypt », sinon "
+        "git la garde pour toujours et le lab est gâché",
+    "content_scoring_tasks_vs_tests":
+        "{tasks} tâche(s) notée(s) pour {tests} test(s) : le score se calcule "
+        "par test, donc le barème affiché ne correspond pas à la note obtenue",
+    "content_scoring_points_mismatch":
+        "les tâches totalisent {total} points, l'en-tête en annonce {announced}",
+    "content_scoring_count_mismatch":
+        "{count} tâche(s) notée(s), l'en-tête en annonce {announced}",
+    "content_missing_english": "pas d'équivalent anglais ({name})",
+    "content_target_host_unknown":
+        "la target « {target} » vise l'hôte « {host} », absent de infra.hosts "
+        "du meta.yml",
+    "content_role_host_unknown":
+        "le rôle « {role} » vise « {host} », absent de infra.hosts du meta.yml",
+    "content_doc_url_no_scheme": "aucun schéma d'URL",
+    "content_doc_url_scheme": "schéma inattendu : {scheme}",
+    "content_doc_url_unreachable": "injoignable : {error}",
+    "content_doc_url_status": "HTTP {code}",
+
+    # ── champs du contrat que le moteur ne sait pas lire (models/) ───────────
+    # Levées par la lecture d'un meta.yml, qui s'affiche. La CLI encadre ces
+    # phrases du chemin du fichier ; elles n'ont donc pas à le porter.
+    "contract_field_not_int":
+        "'{field}' doit être un entier (reçu : {got}).",
+    "contract_field_not_list":
+        "'{field}' doit être une liste (reçu : {got}).",
+    "contract_field_not_mapping":
+        "'{field}' doit être un mapping (reçu : {got}).",
+    "contract_field_not_mapping_list":
+        "'{field}' doit être une liste de mappings (reçu : {got}).",
+    "contract_root_not_mapping":
+        "le document doit être un mapping YAML (reçu : {got}).",
+    "contract_repo_required":
+        "les champs 'repo.id' et 'repo.category' sont requis (contrat dsoxlab).",
+    "contract_provider_empty_list":
+        "'infra.provider' est une liste vide. Déclare au moins un provider "
+        "(ex. 'kvm').",
+    "contract_provider_bad_type":
+        "'infra.provider' doit être une string ou une liste de strings, "
+        "pas {got}.",
+    "contract_provider_not_declared":
+        "DSOXLAB_PROVIDER='{provider}' n'est pas dans les providers déclarés "
+        "par ce meta.yml : {candidates}",
+
     # ── version du contrat (schema_version) ───────────────────────────────────
     "contract_issues_header": "\n[bold red]Version du contrat :[/bold red]",
     "schema_version_invalid":

--- a/src/dsoxlab/models/__init__.py
+++ b/src/dsoxlab/models/__init__.py
@@ -1,5 +1,6 @@
 """Package models."""
 
+from ._contract import ContractError, LabYamlError
 from .course import CourseManifest, CourseSection
 from .lab import LabDefinition, ValidationConfig
 from .repo import (
@@ -20,11 +21,13 @@ from .schema_version import (
 __all__ = [
     "DEFAULT_SCHEMA_VERSION",
     "SUPPORTED_SCHEMA_VERSION",
+    "ContractError",
     "CourseManifest",
     "CourseSection",
     "HostDefinition",
     "InfraDefinition",
     "LabDefinition",
+    "LabYamlError",
     "ProviderUnresolved",
     "RepoMetadata",
     "RuntimeConfig",

--- a/src/dsoxlab/models/_contract.py
+++ b/src/dsoxlab/models/_contract.py
@@ -13,6 +13,24 @@ Ces helpers ramènent donc chaque champ mal typé dans le contrat. Ils sont
 partagés par ``models/lab.py`` et ``models/repo.py`` : mêmes pièges, mêmes
 garde-fous, une seule implémentation. Les cas couverts ont été trouvés par les
 harnais de ``fuzz/``.
+
+Deux classes d'erreur, et un seul critère pour choisir
+=====================================================
+
+La question n'est pas de quel fichier vient le champ, mais **qui lit le
+message** :
+
+- un champ de ``meta.yml`` remonte jusqu'à ``cli.py``, qui l'affiche. Ces
+  erreurs sont des :class:`ContractError` : elles portent une clé i18n et ses
+  paramètres, et la CLI compose la phrase traduite ;
+- un champ de ``lab.yaml`` est rattrapé par ``discovery/scanner.py``, qui
+  écarte le lab et journalise la raison. Rien ne l'affiche : ce sont des
+  :class:`LabYamlError`, dont le texte reste technique.
+
+Les coercions partagées (:func:`as_int`, :func:`as_str_list`,
+:func:`as_mapping`, :func:`as_mapping_list`) servent les deux fichiers, donc
+elles lèvent la première. :func:`as_argv` et :func:`as_argv_list` ne servent
+qu'à ``runtime.services`` d'un ``lab.yaml``, donc la seconde.
 """
 
 from __future__ import annotations
@@ -20,6 +38,52 @@ from __future__ import annotations
 import shlex
 from pathlib import Path
 from typing import Any
+
+
+class ContractError(ValueError):
+    """Un champ du contrat mal typé, dont le message **atteint l'utilisateur**.
+
+    Même patron que :class:`~dsoxlab.models.schema_version.UnsupportedSchemaVersion`
+    et :class:`~dsoxlab.models.repo.ProviderUnresolved` : l'exception porte des
+    **données** (``source``, ``field``, ``key``, ``params``) et jamais une
+    phrase. La CLI compose le message traduit ; traduire ici mettrait de la
+    langue dans le modèle, c'est-à-dire graver le mauvais patron.
+
+    Le chemin qui l'affiche : ``meta.yml`` → ``discovery/repo.py``, qui laisse
+    remonter → ``cli.py: _read_repo()``, qui rend ``_(exc.key, **exc.params)``.
+
+    Le ``str()``, lui, reste en jetons techniques : c'est ce que voit le
+    journal, et deux rapports de bug doivent rester comparables quelle que soit
+    la locale de qui les produit.
+    """
+
+    def __init__(self, source: Path, field: str, key: str, **params: Any) -> None:
+        self.source = source
+        self.field = field
+        self.key = key
+        #: ``field`` en fait partie : les messages le nomment presque tous, et
+        #: ``str.format`` ignore sans broncher un paramètre qu'un texte n'emploie pas.
+        self.params: dict[str, Any] = {"field": field, **params}
+        detail = " ".join(f"{nom}={valeur!r}" for nom, valeur in params.items())
+        super().__init__(f"{source}: {field}: {key} {detail}".rstrip())
+
+
+class LabYamlError(ValueError):
+    """Un ``lab.yaml`` illisible. Ce message **ne s'affiche jamais**.
+
+    ``discovery/scanner.py`` est le seul appelant de
+    ``LabDefinition.from_yaml`` : il rattrape ``(KeyError, ValueError,
+    yaml.YAMLError)``, écarte le lab, et range la raison au journal et dans
+    ``CatalogScan.illisibles``. Ni l'un ni l'autre n'est de l'interface, d'où
+    un texte technique laissé tel quel : le traduire serait du travail perdu et
+    du bruit dans les fichiers de traduction.
+
+    La classe existe pour que ce fait soit **vérifiable** plutôt que promis. Le
+    garde-fou i18n (``tests/test_i18n_coverage.py``) la connaît par son nom et
+    laisse passer les phrases qu'elle porte. Le jour où l'un de ces messages
+    devra s'afficher, il changera de classe pour :class:`ContractError`, et le
+    garde-fou réclamera sa clé.
+    """
 
 
 def as_int(value: object, default: int, field_name: str, source: Path) -> int:
@@ -35,20 +99,18 @@ def as_int(value: object, default: int, field_name: str, source: Path) -> int:
     if value is None:
         return default
     if isinstance(value, bool):
-        raise ValueError(
-            f"{source}: '{field_name}' doit être un entier (reçu un booléen : {value!r})."
-        )
+        raise ContractError(source, field_name, "contract_field_not_int", got=repr(value))
     if isinstance(value, (int, float)):
         return int(value)
     if isinstance(value, str):
         try:
             return int(value.strip())
         except ValueError:
-            raise ValueError(
-                f"{source}: '{field_name}' doit être un entier (reçu : {value!r})."
+            raise ContractError(
+                source, field_name, "contract_field_not_int", got=repr(value)
             ) from None
-    raise ValueError(
-        f"{source}: '{field_name}' doit être un entier (reçu : {type(value).__name__})."
+    raise ContractError(
+        source, field_name, "contract_field_not_int", got=type(value).__name__
     )
 
 
@@ -61,9 +123,8 @@ def as_str_list(value: object, field_name: str, source: Path) -> list[str]:
     if value is None:
         return []
     if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
-        raise ValueError(
-            f"{source}: '{field_name}' doit être une liste "
-            f"(reçu : {type(value).__name__})."
+        raise ContractError(
+            source, field_name, "contract_field_not_list", got=type(value).__name__
         )
     return [str(item) for item in value]
 
@@ -77,9 +138,8 @@ def as_mapping(value: object, field_name: str, source: Path, *, default_empty: b
     if value is None and default_empty:
         return {}
     if not isinstance(value, dict):
-        raise ValueError(
-            f"{source}: '{field_name}' doit être un mapping "
-            f"(reçu : {type(value).__name__})."
+        raise ContractError(
+            source, field_name, "contract_field_not_mapping", got=type(value).__name__
         )
     return value
 
@@ -110,11 +170,14 @@ def as_argv_list(value: object, field_name: str, source: Path) -> list[list[str]
     redirection, ni expansion. Une chaîne vide (ou qui ne contient que des
     espaces) est refusée plutôt qu'ignorée : ``docker exec`` sans commande
     échouerait plus loin, avec un message qui ne désignerait pas le lab fautif.
+
+    ``runtime.services`` n'existe que dans un ``lab.yaml`` : ces messages ne
+    vont qu'au journal, d'où :class:`LabYamlError` et un texte non traduit.
     """
     if value is None:
         return []
     if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
-        raise ValueError(
+        raise LabYamlError(
             f"{source}: '{field_name}' doit être une liste de commandes "
             f"(reçu : {type(value).__name__})."
         )
@@ -124,19 +187,19 @@ def as_argv_list(value: object, field_name: str, source: Path) -> list[list[str]
             try:
                 argv = shlex.split(item)
             except ValueError as exc:  # guillemet non fermé
-                raise ValueError(
+                raise LabYamlError(
                     f"{source}: '{field_name}[{idx}]' n'est pas une commande "
                     f"analysable ({exc})."
                 ) from None
         elif isinstance(item, (list, tuple)):
             argv = [str(mot) for mot in item]
         else:
-            raise ValueError(
+            raise LabYamlError(
                 f"{source}: '{field_name}[{idx}]' doit être une chaîne ou une "
                 f"liste d'arguments (reçu : {type(item).__name__})."
             )
         if not argv:
-            raise ValueError(
+            raise LabYamlError(
                 f"{source}: '{field_name}[{idx}]' est une commande vide."
             )
         commandes.append(argv)
@@ -152,16 +215,18 @@ def as_mapping_list(value: object, field_name: str, source: Path) -> list[dict[s
     if value is None:
         return []
     if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
-        raise ValueError(
-            f"{source}: '{field_name}' doit être une liste de mappings "
-            f"(reçu : {type(value).__name__})."
+        raise ContractError(
+            source, field_name, "contract_field_not_mapping_list",
+            got=type(value).__name__,
         )
     items: list[dict[str, Any]] = []
     for idx, item in enumerate(value):
         if not isinstance(item, dict):
-            raise ValueError(
-                f"{source}: '{field_name}[{idx}]' doit être un mapping "
-                f"(reçu : {type(item).__name__})."
+            # Le champ nommé porte son index : « infra.hosts[1] » désigne la
+            # ligne fautive, là où « infra.hosts » enverrait relire toute la liste.
+            raise ContractError(
+                source, f"{field_name}[{idx}]", "contract_field_not_mapping",
+                got=type(item).__name__,
             )
         items.append(item)
     return items

--- a/src/dsoxlab/models/lab.py
+++ b/src/dsoxlab/models/lab.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import yaml
 
 from ._contract import (
+    LabYamlError,
     as_argv,
     as_argv_list,
     as_int,
@@ -91,6 +92,13 @@ class LabDefinition:
         If ``lang`` != "en" and a ``lab.<lang>.yaml`` file exists in the same
         directory, translatable fields (title, description) are overridden by
         that file.
+
+        Raises:
+            LabYamlError: le fichier sort du contrat. Le message n'est
+                **jamais affiché** : ``discovery/scanner.py`` est le seul
+                appelant, il écarte le lab et journalise la raison. Il reste
+                donc technique et non traduit, à la différence de ce que lève
+                la lecture d'un ``meta.yml``. Voir :class:`._contract.LabYamlError`.
         """
         with lab_yaml.open(encoding="utf-8") as fh:
             data = yaml.safe_load(fh)
@@ -101,7 +109,7 @@ class LabDefinition:
         # ValueError, YAMLError) que discovery/scanner.py rattrape : le lab
         # ferait planter la CLI au lieu d'être ignoré avec un warning.
         if not isinstance(data, dict):
-            raise ValueError(
+            raise LabYamlError(
                 f"{lab_yaml}: le document doit être un mapping YAML "
                 f"(reçu : {type(data).__name__})."
             )
@@ -135,7 +143,7 @@ class LabDefinition:
         targets: list[Target] = []
         for idx, t in enumerate(targets_raw):
             if "name" not in t or "host" not in t:
-                raise ValueError(
+                raise LabYamlError(
                     f"{lab_yaml}: runtime.targets[{idx}] doit contenir "
                     f"'name' et 'host'."
                 )
@@ -154,7 +162,7 @@ class LabDefinition:
         services: list[Service] = []
         for idx, s in enumerate(services_raw):
             if "name" not in s or "image" not in s:
-                raise ValueError(
+                raise LabYamlError(
                     f"{lab_yaml}: runtime.services[{idx}] doit contenir "
                     f"'name' et 'image'."
                 )

--- a/src/dsoxlab/models/repo.py
+++ b/src/dsoxlab/models/repo.py
@@ -42,7 +42,13 @@ from typing import Any
 
 import yaml
 
-from ._contract import as_int, as_mapping, as_mapping_list, as_str_list
+from ._contract import (
+    ContractError,
+    as_int,
+    as_mapping,
+    as_mapping_list,
+    as_str_list,
+)
 from .schema_version import DEFAULT_SCHEMA_VERSION, read_schema_version
 
 #: Champs qu'un ``meta.<lang>.yml`` peut surcharger, et eux seuls.
@@ -114,9 +120,9 @@ def _provider_overrides(value: object, meta_path: Path) -> dict[str, dict[str, A
     if value is None:
         return {}
     if not isinstance(value, dict):
-        raise ValueError(
-            f"{meta_path}: 'infra.providers' doit être un mapping "
-            f"(reçu : {type(value).__name__})."
+        raise ContractError(
+            meta_path, "infra.providers", "contract_field_not_mapping",
+            got=type(value).__name__,
         )
     overrides: dict[str, dict[str, Any]] = {}
     for name, cfg in value.items():
@@ -125,9 +131,9 @@ def _provider_overrides(value: object, meta_path: Path) -> dict[str, dict[str, A
         elif isinstance(cfg, dict):
             overrides[str(name)] = dict(cfg)
         else:
-            raise ValueError(
-                f"{meta_path}: 'infra.providers.{name}' doit être un mapping "
-                f"(reçu : {type(cfg).__name__})."
+            raise ContractError(
+                meta_path, f"infra.providers.{name}", "contract_field_not_mapping",
+                got=type(cfg).__name__,
             )
     return overrides
 
@@ -192,23 +198,22 @@ def _resolve_provider(
     elif isinstance(raw_provider, list):
         candidates = [str(p).strip() for p in raw_provider if str(p).strip()]
         if not candidates:
-            raise ValueError(
-                f"{meta_path}: infra.provider est une liste vide. "
-                "Déclare au moins un provider (ex. 'kvm')."
+            raise ContractError(
+                meta_path, "infra.provider", "contract_provider_empty_list"
             )
         default_solo = candidates[0] if len(candidates) == 1 else ""
     else:
-        raise ValueError(
-            f"{meta_path}: infra.provider doit être une string ou une "
-            f"liste de strings, pas {type(raw_provider).__name__}."
+        raise ContractError(
+            meta_path, "infra.provider", "contract_provider_bad_type",
+            got=type(raw_provider).__name__,
         )
 
     env = os.environ.get("DSOXLAB_PROVIDER", "").strip()
     if env:
         if candidates and env not in candidates:
-            raise ValueError(
-                f"DSOXLAB_PROVIDER='{env}' n'est pas dans les providers "
-                f"déclarés par {meta_path}: {candidates}"
+            raise ContractError(
+                meta_path, "infra.provider", "contract_provider_not_declared",
+                provider=env, candidates=", ".join(candidates),
             )
         return env, candidates
 
@@ -380,7 +385,11 @@ class RepoMetadata:
                 ``meta.<lang>.yml`` existe à côté, ses titres et
                 descriptions surchargent ceux du ``meta.yml``.
 
-        Lève ``ValueError`` si ``repo.id``/``repo.category`` manquent.
+        Lève :class:`~dsoxlab.models._contract.ContractError` si
+        ``repo.id``/``repo.category`` manquent, ou si un champ du ``meta.yml``
+        n'a pas le type que le contrat attend. C'est un ``ValueError``, et il
+        porte une clé i18n : ce fichier-ci s'affiche, donc la CLI compose la
+        phrase dans la langue de l'apprenant.
 
         Une résolution de provider ambiguë (plusieurs candidats, aucun
         choix actif) **ne lève pas** : ``infra.provider`` reste vide et
@@ -394,9 +403,9 @@ class RepoMetadata:
         # (ni un bloc `repo:` qui ne serait pas un mapping) : l'accès `.get`
         # lèverait alors AttributeError au lieu du ValueError attendu par la CLI.
         if not isinstance(data, dict):
-            raise ValueError(
-                f"{meta_path}: le document doit être un mapping YAML "
-                f"(reçu : {type(data).__name__})."
+            raise ContractError(
+                meta_path, "meta.yml", "contract_root_not_mapping",
+                got=type(data).__name__,
             )
 
         # AVANT `repo.id` : un meta.yml v2 pourrait très bien ne plus déclarer
@@ -411,15 +420,12 @@ class RepoMetadata:
 
         repo = data.get("repo") or {}
         if not isinstance(repo, dict):
-            raise ValueError(
-                f"{meta_path}: le bloc 'repo' doit être un mapping "
-                f"(reçu : {type(repo).__name__})."
+            raise ContractError(
+                meta_path, "repo", "contract_field_not_mapping",
+                got=type(repo).__name__,
             )
         if not repo.get("id") or not repo.get("category"):
-            raise ValueError(
-                f"{meta_path}: les champs 'repo.id' et 'repo.category' "
-                "sont requis (contrat dsoxlab)."
-            )
+            raise ContractError(meta_path, "repo", "contract_repo_required")
 
         infra_data = as_mapping(data.get("infra"), "infra", meta_path)
         hosts_data = as_mapping_list(infra_data.get("hosts"), "infra.hosts", meta_path)

--- a/src/dsoxlab/models/schema_version.py
+++ b/src/dsoxlab/models/schema_version.py
@@ -26,6 +26,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from ._contract import ContractError
+
 #: Version la plus récente du contrat d'entrée que ce dsoxlab sait lire. Un
 #: fichier qui en déclare une plus grande n'est pas lu : le moteur ignore ce
 #: que ses champs signifient, et deviner serait pire que refuser.
@@ -81,7 +83,10 @@ def read_schema_version(data: Mapping[str, Any], source: Path) -> int:
 
     Raises:
         UnsupportedSchemaVersion: la version dépasse celle que ce dsoxlab lit.
-        ValueError: la valeur n'est pas un entier YAML, ou est inférieure à 1.
+        ContractError: la valeur n'est pas un entier YAML, ou est inférieure à
+            1. Elle porte la clé i18n et ses paramètres ; c'est la CLI qui dit
+            la phrase, dans la langue de l'apprenant. Reste un ``ValueError``,
+            donc le filet de ``discovery/scanner.py`` ne change pas.
 
     Le champ absent, ou présent mais vide (``schema_version:`` en blanc), vaut
     la v1 : **aucun catalogue existant ne doit casser**, et aucun n'en déclare
@@ -103,15 +108,19 @@ def read_schema_version(data: Mapping[str, Any], source: Path) -> int:
 
     # `bool` avant `int` : True est un int en Python, donc `schema_version: true`
     # passerait pour la version 1 sans ce garde-fou.
+    #
+    # Les deux refus partagent la clé du validator : c'est le même fait pour
+    # l'auteur (« ce n'est pas un numéro de version »), et deux textes pour un
+    # seul fait finissent par diverger.
     if isinstance(brut, bool) or not isinstance(brut, int):
-        raise ValueError(
-            f"{source}: '{SCHEMA_VERSION_FIELD}' doit être un entier YAML "
-            f"(reçu : {type(brut).__name__} {brut!r})."
+        raise ContractError(
+            source, SCHEMA_VERSION_FIELD, "schema_version_invalid",
+            got=repr(brut), supported=SUPPORTED_SCHEMA_VERSION,
         )
     if brut < 1:
-        raise ValueError(
-            f"{source}: '{SCHEMA_VERSION_FIELD}' doit valoir au moins 1 "
-            f"(reçu : {brut})."
+        raise ContractError(
+            source, SCHEMA_VERSION_FIELD, "schema_version_invalid",
+            got=repr(brut), supported=SUPPORTED_SCHEMA_VERSION,
         )
     if brut > SUPPORTED_SCHEMA_VERSION:
         raise UnsupportedSchemaVersion(source, brut)

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -274,7 +274,7 @@ def print_structure_reports(reports: list[StructureReport]) -> None:
         else:
             branch = tree.add(f"[red]✘[/red] {report.lab_id}")
             for issue in report.issues:
-                branch.add(f"[red]{issue.message}[/red]")
+                branch.add(f"[red]{_(issue.key, **issue.params)}[/red]")
     console.print(tree)
 
 

--- a/src/dsoxlab/validators/content.py
+++ b/src/dsoxlab/validators/content.py
@@ -17,6 +17,9 @@ vivent ici pour que tout dépôt en bénéficie sans les recopier.
 
 Rien ici n'est spécifique à un domaine : on ne lit que le contrat déclaratif et
 l'arborescence.
+
+Et rien n'y compose de phrase : chaque anomalie porte une clé i18n et ses
+paramètres, que ``validate-structure`` rend dans la langue de l'auteur.
 """
 
 from __future__ import annotations
@@ -26,6 +29,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from ..models.lab import LabDefinition
@@ -52,8 +56,19 @@ _ENTETES = {"User-Agent": "dsoxlab-doc-url-check/1.0"}
 
 @dataclass
 class ContentIssue:
+    """Une anomalie de contenu, prête à être traduite.
+
+    Même patron que :class:`~dsoxlab.validators.contract.ContractIssue` : une
+    **clé** et des paramètres, jamais une phrase. La sortie de
+    ``validate-structure`` est de l'interface, donc elle suit ``DSOXLAB_LANG``.
+    """
+
     path: Path
-    message: str
+    key: str
+    """Clé i18n du message, présente dans ``strings/en.py`` ET ``strings/fr.py``."""
+
+    params: dict[str, Any] = field(default_factory=dict)
+    """Paramètres de substitution du message."""
 
 
 @dataclass
@@ -91,10 +106,8 @@ def validate_internal_links(lab: LabDefinition) -> ContentReport:
         if casses:
             report.issues.append(ContentIssue(
                 path=fichier,
-                message=(
-                    f"{len(casses)} lien(s) relatif(s) mort(s) : "
-                    + ", ".join(casses)
-                ),
+                key="content_broken_links",
+                params={"count": len(casses), "links": ", ".join(casses)},
             ))
     return report
 
@@ -118,33 +131,45 @@ def validate_solutions_encrypted(
             with fichier.open("r", encoding="utf-8", errors="ignore") as flux:
                 premiere = flux.readline()
         except OSError as exc:
-            report.issues.append(ContentIssue(fichier, f"illisible : {exc}"))
+            report.issues.append(ContentIssue(
+                path=fichier,
+                key="content_solution_unreadable",
+                params={"error": exc},
+            ))
             continue
         if not premiere.startswith(_ENTETE_VAULT):
             report.issues.append(ContentIssue(
-                path=fichier,
-                message=(
-                    "solution en clair : chiffre-la avec "
-                    "« ansible-vault encrypt », sinon git la garde pour "
-                    "toujours et le lab est gâché"
-                ),
+                path=fichier, key="content_solution_plaintext"
             ))
     return report
 
 
-def check_doc_url(lab: LabDefinition, *, timeout: float = _TIMEOUT_HTTP) -> str | None:
-    """Vérifie que le `doc_url` du lab répond. Rend le motif d'échec, ou None.
+def check_doc_url(
+    lab: LabDefinition, *, timeout: float = _TIMEOUT_HTTP
+) -> ContentIssue | None:
+    """Vérifie que le `doc_url` du lab répond. Rend l'anomalie, ou None.
 
     Séparé des autres contrôles parce qu'il sort sur le réseau : il n'a rien à
     faire dans une validation par défaut, qui doit rester rapide et jouable
     hors ligne.
+
+    Rend une :class:`ContentIssue` plutôt qu'un motif rédigé : le motif était
+    la dernière phrase française que ce module composait lui-même, et elle
+    s'affichait telle quelle sous ``DSOXLAB_LANG=en``.
     """
     url = lab.doc_url
     if not url:
         return None
+    chemin = lab.path / "lab.yaml"
     schema = urlparse(url).scheme
+    if not schema:
+        # Deux clés plutôt qu'un « (aucun) » glissé dans le paramètre : ce
+        # mot-là serait la seule chose non traduite de la phrase.
+        return ContentIssue(path=chemin, key="content_doc_url_no_scheme")
     if schema not in ("http", "https"):
-        return f"schéma inattendu : {schema or '(aucun)'}"
+        return ContentIssue(
+            path=chemin, key="content_doc_url_scheme", params={"scheme": schema}
+        )
     requete = urllib.request.Request(  # noqa: S310 - schéma vérifié
         url, method="HEAD", headers=_ENTETES
     )
@@ -160,12 +185,26 @@ def check_doc_url(lab: LabDefinition, *, timeout: float = _TIMEOUT_HTTP) -> str 
                 with urllib.request.urlopen(repli, timeout=timeout) as reponse:  # noqa: S310
                     code = reponse.status
             except (urllib.error.URLError, OSError) as exc2:
-                return f"injoignable : {exc2}"
+                return ContentIssue(
+                    path=chemin,
+                    key="content_doc_url_unreachable",
+                    params={"error": exc2},
+                )
         else:
-            return f"HTTP {exc.code}"
+            return ContentIssue(
+                path=chemin,
+                key="content_doc_url_status",
+                params={"code": exc.code},
+            )
     except (urllib.error.URLError, OSError) as exc:
-        return f"injoignable : {exc}"
-    return None if 200 <= code < 400 else f"HTTP {code}"
+        return ContentIssue(
+            path=chemin, key="content_doc_url_unreachable", params={"error": exc}
+        )
+    if 200 <= code < 400:
+        return None
+    return ContentIssue(
+        path=chemin, key="content_doc_url_status", params={"code": code}
+    )
 
 
 #: `### Tâche 3 — … (20 pts)` : un titre de tâche qui annonce ses points.
@@ -221,11 +260,8 @@ def validate_scoring(lab: LabDefinition) -> ContentReport:
     if nb_tests and nb_tests != len(points):
         report.issues.append(ContentIssue(
             path=enonce,
-            message=(
-                f"{len(points)} tâche(s) notée(s) pour {nb_tests} test(s) : "
-                "le score se calcule par test, donc le barème affiché ne "
-                "correspond pas à la note obtenue"
-            ),
+            key="content_scoring_tasks_vs_tests",
+            params={"tasks": len(points), "tests": nb_tests},
         ))
 
     annonce = _FORMAT_ANNONCE.search(texte)
@@ -234,18 +270,14 @@ def validate_scoring(lab: LabDefinition) -> ContentReport:
         if sum(points) != total_annonce:
             report.issues.append(ContentIssue(
                 path=enonce,
-                message=(
-                    f"les tâches totalisent {sum(points)} points, "
-                    f"l'en-tête en annonce {total_annonce}"
-                ),
+                key="content_scoring_points_mismatch",
+                params={"total": sum(points), "announced": total_annonce},
             ))
         if len(points) != nb_annonce:
             report.issues.append(ContentIssue(
                 path=enonce,
-                message=(
-                    f"{len(points)} tâche(s) notée(s), "
-                    f"l'en-tête en annonce {nb_annonce}"
-                ),
+                key="content_scoring_count_mismatch",
+                params={"count": len(points), "announced": nb_annonce},
             ))
     return report
 
@@ -264,7 +296,8 @@ def validate_language_parity(lab: LabDefinition) -> ContentReport:
         if not anglais.is_file():
             report.issues.append(ContentIssue(
                 path=francais,
-                message=f"pas d'équivalent anglais ({anglais.name})",
+                key="content_missing_english",
+                params={"name": anglais.name},
             ))
     return report
 
@@ -283,18 +316,14 @@ def validate_targets(lab: LabDefinition, host_names: set[str]) -> ContentReport:
         if cible.host and cible.host not in host_names:
             report.issues.append(ContentIssue(
                 path=lab.path / "lab.yaml",
-                message=(
-                    f"target « {cible.name} » vise l'hôte « {cible.host} », "
-                    "absent de infra.hosts du meta.yml"
-                ),
+                key="content_target_host_unknown",
+                params={"target": cible.name, "host": cible.host},
             ))
         for role, hote in (cible.roles or {}).items():
             if hote not in host_names:
                 report.issues.append(ContentIssue(
                     path=lab.path / "lab.yaml",
-                    message=(
-                        f"le rôle « {role} » vise « {hote} », "
-                        "absent de infra.hosts du meta.yml"
-                    ),
+                    key="content_role_host_unknown",
+                    params={"role": role, "host": hote},
                 ))
     return report

--- a/src/dsoxlab/validators/contract.py
+++ b/src/dsoxlab/validators/contract.py
@@ -36,8 +36,8 @@ from typing import Any
 
 import yaml
 
+from ..models._contract import ContractError
 from ..models.schema_version import (
-    SUPPORTED_SCHEMA_VERSION,
     UnsupportedSchemaVersion,
     read_schema_version,
 )
@@ -120,16 +120,12 @@ def validate_schema_versions(root: Path) -> ContractReport:
                 key="schema_version_too_new",
                 params={"found": exc.found, "supported": exc.supported},
             ))
-        except ValueError:
-            # Le message du modèle est technique et non traduit : on ne le
-            # relaie pas, on nomme la valeur fautive et la CLI dit le reste.
+        except ContractError as exc:
+            # Le modèle porte désormais la clé et les faits : les recopier ici
+            # ferait deux textes pour un seul défaut, qui finiraient par
+            # diverger. Voir `models/_contract.py: ContractError`.
             report.issues.append(ContractIssue(
-                path=chemin,
-                key="schema_version_invalid",
-                params={
-                    "got": repr(data.get("schema_version")),
-                    "supported": SUPPORTED_SCHEMA_VERSION,
-                },
+                path=chemin, key=exc.key, params=exc.params,
             ))
 
     return report

--- a/src/dsoxlab/validators/metadata.py
+++ b/src/dsoxlab/validators/metadata.py
@@ -1,8 +1,16 @@
-"""Lab metadata validation."""
+"""Lab metadata validation.
+
+Comme les autres validators, ce module ne compose **aucune phrase** : chaque
+anomalie porte une clé i18n et ses paramètres, que ``validate-structure`` rend
+dans la langue de l'auteur. Les messages écrits ici en dur sortaient en
+français quel que soit ``DSOXLAB_LANG``.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import dataclasses
+from dataclasses import dataclass
+from typing import Any
 from urllib.parse import urlparse
 
 from ..models.lab import LabDefinition
@@ -13,13 +21,19 @@ _VALID_LAB_TYPES = {"lab", "challenge", "capstone"}
 @dataclass
 class MetadataIssue:
     field: str
-    message: str
+    key: str
+    """Clé i18n du message, présente dans ``strings/en.py`` ET ``strings/fr.py``."""
+
+    # `dataclasses.field`, en toutes lettres : la dataclass porte un attribut
+    # nommé `field`, et le nom court désignerait alors le champ, pas la fonction.
+    params: dict[str, Any] = dataclasses.field(default_factory=dict)
+    """Paramètres de substitution du message."""
 
 
 @dataclass
 class MetadataReport:
     lab_id: str
-    issues: list[MetadataIssue] = field(default_factory=list)
+    issues: list[MetadataIssue] = dataclasses.field(default_factory=list)
 
     @property
     def ok(self) -> bool:
@@ -30,29 +44,39 @@ def validate_metadata(lab: LabDefinition) -> MetadataReport:
     """Check required fields and their consistency."""
     report = MetadataReport(lab_id=lab.id)
 
-    if not lab.id:
-        report.issues.append(MetadataIssue("id", "Le champ 'id' est vide"))
-    if not lab.title:
-        report.issues.append(MetadataIssue("title", "Le champ 'title' est vide"))
-    if not lab.level:
-        report.issues.append(MetadataIssue("level", "Le champ 'level' est vide"))
-    if not lab.skills:
-        report.issues.append(MetadataIssue("skills", "La liste 'skills' est vide"))
-    if not lab.distros:
-        report.issues.append(MetadataIssue("distros", "La liste 'distros' est vide"))
-    if not lab.doc_url:
-        report.issues.append(MetadataIssue("doc_url", "Le champ 'doc_url' est vide"))
-    else:
+    for champ, valeur in (
+        ("id", lab.id),
+        ("title", lab.title),
+        ("level", lab.level),
+        ("doc_url", lab.doc_url),
+    ):
+        if not valeur:
+            report.issues.append(
+                MetadataIssue(champ, "metadata_field_empty", {"field": champ})
+            )
+    for champ, liste in (("skills", lab.skills), ("distros", lab.distros)):
+        if not liste:
+            report.issues.append(
+                MetadataIssue(champ, "metadata_list_empty", {"field": champ})
+            )
+
+    if lab.doc_url:
         parsed = urlparse(lab.doc_url)
         if parsed.scheme not in ("http", "https"):
             report.issues.append(
-                MetadataIssue("doc_url", f"URL invalide (scheme attendu http/https) : {lab.doc_url}")
+                MetadataIssue(
+                    "doc_url", "metadata_doc_url_scheme", {"url": lab.doc_url}
+                )
             )
     if lab.lab_type not in _VALID_LAB_TYPES:
         report.issues.append(
             MetadataIssue(
                 "lab_type",
-                f"Invalid value '{lab.lab_type}'. Expected one of: {', '.join(sorted(_VALID_LAB_TYPES))}",
+                "metadata_lab_type_invalid",
+                {
+                    "value": lab.lab_type,
+                    "expected": ", ".join(sorted(_VALID_LAB_TYPES)),
+                },
             )
         )
     # Le seuil est un POURCENTAGE du barème. Hors de 1..100, il ne veut rien
@@ -63,9 +87,8 @@ def validate_metadata(lab: LabDefinition) -> MetadataReport:
         report.issues.append(
             MetadataIssue(
                 "exam_passing_score",
-                f"Invalid value '{lab.exam_passing_score}'. Expected a percentage "
-                f"of the lab scale, between 1 and 100 (omit the field for a lab "
-                f"that is not an exam).",
+                "metadata_exam_score_invalid",
+                {"value": lab.exam_passing_score},
             )
         )
 

--- a/src/dsoxlab/validators/structure.py
+++ b/src/dsoxlab/validators/structure.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from ..models.lab import LabDefinition
 from ..models.runtime import RuntimeType
@@ -25,8 +26,21 @@ from ..models.runtime import RuntimeType
 
 @dataclass
 class StructureIssue:
+    """Une anomalie de structure, prête à être traduite.
+
+    Porte une **clé** et ses paramètres, jamais une phrase : ce rapport est
+    affiché par ``validate-structure``, donc son texte suit ``DSOXLAB_LANG``.
+    Les messages écrits ici en dur s'affichaient en français sous
+    ``DSOXLAB_LANG=en``, c'est-à-dire au moment précis où un auteur découvre
+    le contrat.
+    """
+
     path: Path
-    message: str
+    key: str
+    """Clé i18n du message, présente dans ``strings/en.py`` ET ``strings/fr.py``."""
+
+    params: dict[str, Any] = field(default_factory=dict)
+    """Paramètres de substitution du message."""
 
 
 @dataclass
@@ -62,14 +76,7 @@ def validate_structure(lab: LabDefinition) -> StructureReport:
         # pouvoir choisir une target)
         if not lab.runtime.targets:
             report.issues.append(
-                StructureIssue(
-                    path=base / "lab.yaml",
-                    message=(
-                        "runtime.type est 'vm' mais runtime.targets[] "
-                        "est vide. Déclare au moins une target avec "
-                        "{name, host}."
-                    ),
-                )
+                StructureIssue(path=base / "lab.yaml", key="struct_vm_targets_empty")
             )
         # Si default défini, doit matcher un name de target
         if lab.runtime.default:
@@ -78,11 +85,11 @@ def validate_structure(lab: LabDefinition) -> StructureReport:
                 report.issues.append(
                     StructureIssue(
                         path=base / "lab.yaml",
-                        message=(
-                            f"runtime.default='{lab.runtime.default}' "
-                            f"ne matche aucun runtime.targets[].name. "
-                            f"Disponibles : {target_names}"
-                        ),
+                        key="struct_default_unknown",
+                        params={
+                            "default": lab.runtime.default,
+                            "available": ", ".join(target_names),
+                        },
                     )
                 )
         # runtime.session : énuméré. Une valeur libre passerait silencieusement
@@ -91,24 +98,16 @@ def validate_structure(lab: LabDefinition) -> StructureReport:
             report.issues.append(
                 StructureIssue(
                     path=base / "lab.yaml",
-                    message=(
-                        f"runtime.session='{lab.runtime.session}' inconnu. "
-                        "Valeurs acceptées : 'target' (session SSH sur "
-                        "targets[].host, défaut) ou 'local' (sous-shell sur le "
-                        "poste, pour un lab piloté depuis le dépôt)."
-                    ),
+                    key="struct_session_unknown",
+                    params={"session": lab.runtime.session},
                 )
             )
         # Présence interdite de scripts bash legacy (signal de migration
         # incomplète vers le tout-déclaratif).
-        _forbid_file(base / "cleanup.sh", report,
-                     "cleanup.sh interdit pour runtime: vm — utilise cleanup.yaml.")
-        _forbid_file(base / "runtime" / "kvm.sh", report,
-                     "runtime/kvm.sh interdit — utilise setup.yaml.")
-        _forbid_file(base / "runtime" / "incus.sh", report,
-                     "runtime/incus.sh interdit — utilise setup.yaml.")
-        _forbid_file(base / "Makefile", report,
-                     "Makefile interdit dans un lab — dsoxlab pilote tout.")
+        _forbid_file(base / "cleanup.sh", report, "struct_forbidden_cleanup_sh_vm")
+        _forbid_file(base / "runtime" / "kvm.sh", report, "struct_forbidden_kvm_sh")
+        _forbid_file(base / "runtime" / "incus.sh", report, "struct_forbidden_incus_sh")
+        _forbid_file(base / "Makefile", report, "struct_forbidden_makefile")
 
     elif rt_type == RuntimeType.SHELL:
         # Runtime shell : tout déclaratif via lab.yaml, aucun script
@@ -116,24 +115,12 @@ def validate_structure(lab: LabDefinition) -> StructureReport:
         # défaut "challenge/work" mais on le valide explicite).
         if not lab.runtime.workdir:
             report.issues.append(
-                StructureIssue(
-                    path=base / "lab.yaml",
-                    message=(
-                        "runtime.type est 'shell' mais runtime.workdir "
-                        "est vide. Déclare le répertoire de travail "
-                        "(ex. workdir: challenge/work)."
-                    ),
-                )
+                StructureIssue(path=base / "lab.yaml", key="struct_shell_workdir_empty")
             )
         # Idem : signaler les scripts bash résiduels.
-        _forbid_file(base / "cleanup.sh", report,
-                     "cleanup.sh interdit pour runtime: shell — déclare "
-                     "fixtures dans lab.yaml.")
-        _forbid_file(base / "runtime" / "shell.sh", report,
-                     "runtime/shell.sh interdit — la préparation est "
-                     "déclarée via runtime.workdir + runtime.fixtures.")
-        _forbid_file(base / "Makefile", report,
-                     "Makefile interdit dans un lab — dsoxlab pilote tout.")
+        _forbid_file(base / "cleanup.sh", report, "struct_forbidden_cleanup_sh_shell")
+        _forbid_file(base / "runtime" / "shell.sh", report, "struct_forbidden_shell_sh")
+        _forbid_file(base / "Makefile", report, "struct_forbidden_makefile")
 
     return report
 
@@ -141,18 +128,26 @@ def validate_structure(lab: LabDefinition) -> StructureReport:
 def _require_file(path: Path, report: StructureReport) -> None:
     if not path.is_file():
         report.issues.append(
-            StructureIssue(path=path, message=f"Fichier manquant : {path.name}")
+            StructureIssue(
+                path=path, key="struct_missing_file", params={"name": path.name}
+            )
         )
 
 
 def _require_dir(path: Path, report: StructureReport) -> None:
     if not path.is_dir():
         report.issues.append(
-            StructureIssue(path=path, message=f"Répertoire manquant : {path.name}/")
+            StructureIssue(
+                path=path, key="struct_missing_dir", params={"name": path.name}
+            )
         )
 
 
-def _forbid_file(path: Path, report: StructureReport, message: str) -> None:
-    """Inverse de _require_file : signale la présence d'un fichier interdit."""
+def _forbid_file(path: Path, report: StructureReport, key: str) -> None:
+    """Inverse de _require_file : signale la présence d'un fichier interdit.
+
+    Prend une **clé**, pas une phrase : chaque fichier interdit a son message,
+    et c'est la couche d'affichage qui le dit dans la langue de l'auteur.
+    """
     if path.exists():
-        report.issues.append(StructureIssue(path=path, message=message))
+        report.issues.append(StructureIssue(path=path, key=key))

--- a/tests/test_i18n_coverage.py
+++ b/tests/test_i18n_coverage.py
@@ -60,19 +60,29 @@ au formatage paresseux (``logger.info("x %s", v)``) que la famille de règles
 doit être *cohérent* — il mélange aujourd'hui le français et l'anglais, ce qui
 est un vrai défaut — mais cohérent n'est pas traduit, et c'est un autre lot.
 
-**``models/`` est hors périmètre, sciemment.** Le bon patron y est déjà écrit :
-``UnsupportedSchemaVersion`` et ``ProviderUnresolved`` portent des **données**
-(``source``, ``found``, ``supported``, ``candidates``) et laissent la CLI
-composer la phrase traduite. Les coercions du contrat (``models/_contract.py``,
-``models/lab.py``, ``models/repo.py``, ``models/schema_version.py``) portent
-encore la dette inverse : 24 ``ValueError`` dont le texte français est rendu tel
-quel par ``error(str(exc))``. Les passer par ``_()`` serait traduire dans le
-modèle, c'est-à-dire graver le mauvais patron ; les convertir en exceptions
-porteuses de données est le bon geste, mais c'est une refonte du contrat, pas un
-correctif d'i18n. La dette est nommée ici plutôt que masquée par un test qui
-l'ignore en silence. Même raison pour ``validators/content.py`` et
-``validators/metadata.py``, dont les messages vivent dans des champs de
-dataclasses qu'aucun puits ci-dessus ne voit.
+**``models/`` est dans le périmètre depuis #139**, et la dette qui l'en tenait
+dehors est soldée. Les 24 ``ValueError`` du contrat ont été triées sur une seule
+question : *ce message atteint-il un humain qui lit l'interface ?*
+
+* **oui pour un ``meta.yml``** : ``discovery/repo.py`` laisse remonter l'erreur
+  et ``cli.py`` l'affiche. Ces raises lèvent une ``ContractError``, qui porte
+  ``source``, ``field``, une **clé i18n** et ses paramètres, comme
+  ``UnsupportedSchemaVersion`` et ``ProviderUnresolved`` le faisaient déjà. La
+  phrase se compose dans la CLI ; le modèle reste agnostique de la langue ;
+* **non pour un ``lab.yaml``** : ``discovery/scanner.py`` est son seul lecteur,
+  il écarte le lab et journalise la raison. Ces raises lèvent une
+  ``LabYamlError``, dont le texte reste technique, car traduire ce qui ne
+  s'affiche jamais serait du travail perdu et du bruit dans les tables. Le
+  garde-fou la connaît par son nom (voir :data:`JOURNAL_SEULEMENT`), et c'est ce
+  qui rend le tri **vérifiable** : le jour où l'un de ces messages doit
+  s'afficher, il change de classe et le garde-fou réclame sa clé.
+
+**Les validators sont surveillés par un cinquième puits.** Leurs messages ne
+passaient par aucun des quatre autres : ils vivaient dans un champ ``message``
+de dataclasse, que ``validate-structure`` affichait tel quel. Ils portent
+désormais une clé, et toute phrase écrite en dur dans la construction d'une
+``ContentIssue`` / ``MetadataIssue`` / ``StructureIssue`` / ``ContractIssue``
+est signalée ici.
 
 **``templates/demo/`` est du contenu pédagogique**, pas le code de l'outil : le
 lab de démonstration packagé s'adresse à l'apprenant dans le fichier même qu'il
@@ -94,7 +104,10 @@ _RACINE = Path(dsoxlab.__file__).parent
 #: Répertoires écartés du garde-fou, avec la raison — voir le docstring.
 #: Toute entrée ajoutée ici doit y être justifiée : c'est une porte qu'on
 #: choisit de ne pas surveiller, pas un détail de configuration.
-_HORS_PERIMETRE = ("models/", "templates/demo/")
+#:
+#: ``models/`` en est sorti en 0.1.59 : ses erreurs d'interface portent
+#: désormais une clé, et celles qui n'en sont pas se nomment.
+_HORS_PERIMETRE = ("templates/demo/",)
 
 
 def _sources() -> list[Path]:
@@ -117,6 +130,18 @@ SORTIE_FUNCS = {"print", "echo", "secho"}
 #: `typer.Exit` et `SystemExit` portent un code de sortie, jamais un message :
 #: les inclure ferait crier le garde-fou sur chaque sortie propre de la CLI.
 CONTROLE_DE_FLUX = {"Exit", "SystemExit"}
+
+#: Les exceptions dont le texte ne va **qu'au journal**. `LabYamlError` est
+#: levée par la lecture d'un `lab.yaml`, dont `discovery/scanner.py` est le seul
+#: appelant : il écarte le lab et journalise la raison, que rien n'affiche.
+#: Cette liste est le pendant vérifiable du tri de #139 : une classe y entre
+#: seulement si aucun chemin de code ne rend son message à l'écran.
+JOURNAL_SEULEMENT = {"LabYamlError"}
+
+#: Les anomalies que `validate-structure` affiche. Elles portent une clé i18n
+#: et des paramètres ; une phrase écrite en dur dans leur construction
+#: s'afficherait dans une seule langue, ce qui est précisément le défaut de #139.
+ISSUE_CLASSES = {"ContentIssue", "MetadataIssue", "StructureIssue", "ContractIssue"}
 
 #: Balises Rich (`[bold]`, `[/green]`…) : de la mise en forme, pas du texte.
 _RICH_TAG = re.compile(r"\[/?[a-z0-9 #]+\]", re.IGNORECASE)
@@ -224,7 +249,7 @@ def _coupables(module: str, tree: ast.Module) -> list[str]:
         # ── Puits 3 : le texte d'une exception, rendu par `error(str(exc))` ───
         if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
             nom = _nom_appele(node.exc.func)
-            if nom not in CONTROLE_DE_FLUX:
+            if nom not in CONTROLE_DE_FLUX and nom not in JOURNAL_SEULEMENT:
                 arguments = list(node.exc.args) + [kw.value for kw in node.exc.keywords]
                 for argument in arguments:
                     if not _is_i18n_call(argument):
@@ -239,6 +264,16 @@ def _coupables(module: str, tree: ast.Module) -> list[str]:
             and not _is_i18n_call(node.args[0])
         ):
             _retenir(node.args[0], f".{node.func.attr}()")
+
+        # ── Puits 5 : les anomalies que `validate-structure` affiche ──────────
+        if isinstance(node, ast.Call) and _nom_appele(node.func) in ISSUE_CLASSES:
+            for argument in list(node.args) + [kw.value for kw in node.keywords]:
+                _retenir(argument, _nom_appele(node.func))
+                # Le message d'un validator vit souvent dans `params={...}` :
+                # une phrase glissée en valeur s'afficherait telle quelle.
+                if isinstance(argument, ast.Dict):
+                    for valeur in argument.values:
+                        _retenir(valeur, _nom_appele(node.func))
 
     return trouves
 
@@ -339,6 +374,35 @@ def test_il_ignore_les_sorties_de_controle_de_flux() -> None:
     """`typer.Exit(1)` n'est pas un message, et n'a pas à être traduit."""
     assert not _analyse('raise typer.Exit(1)')
     assert not _analyse('raise SystemExit(1)')
+
+
+def test_il_mord_sur_une_anomalie_de_validator() -> None:
+    """Le défaut de #139 : une phrase française dans un champ de dataclasse."""
+    assert _analyse('StructureIssue(path=p, message="Fichier manquant : lab.yaml")')
+    assert _analyse('MetadataIssue("doc_url", "URL invalide, schéma attendu")')
+    assert _analyse('ContentIssue(path=f, params={"x": "solution en clair, chiffre-la"})')
+    assert not _analyse('StructureIssue(path=p, key="struct_missing_file")')
+    assert not _analyse(
+        'ContentIssue(path=f, key="content_broken_links", params={"links": cibles})'
+    )
+
+
+def test_une_erreur_de_contrat_affichee_doit_porter_sa_cle() -> None:
+    """`models/` est dans le périmètre : une phrase levée là s'afficherait."""
+    assert _analyse('raise ContractError(source, "infra", "reçu un mapping vide")')
+    assert not _analyse(
+        'raise ContractError(source, "infra.hosts", "contract_field_not_mapping_list")'
+    )
+
+
+def test_une_erreur_qui_ne_va_qu_au_journal_reste_libre() -> None:
+    """Le pendant du tri : ce que personne n'affiche n'a pas à être traduit.
+
+    Le jour où l'un de ces messages doit s'afficher, il change de classe pour
+    `ContractError`, et le test ci-dessus le réclame.
+    """
+    assert not _analyse('raise LabYamlError(f"{p}: runtime.targets[0] doit contenir un name")')
+    assert _analyse('raise ValueError(f"{p}: runtime.targets[0] doit contenir un name")')
 
 
 def test_le_journal_reste_hors_du_perimetre() -> None:

--- a/tests/test_i18n_validators.py
+++ b/tests/test_i18n_validators.py
@@ -1,0 +1,301 @@
+"""Un catalogue mal formé se dit dans la langue de qui le lit (#139).
+
+Les validators et la lecture du contrat étaient la dernière zone à composer ses
+phrases en français, dans des champs de dataclasses et des ``ValueError``.
+Elles sortaient telles quelles sous ``DSOXLAB_LANG=en``, c'est-à-dire au pire
+moment : quand un auteur découvre le contrat et que son catalogue est cassé.
+
+Trois comportements sont tenus ici, un par correction :
+
+1. ``validate-structure`` suit ``DSOXLAB_LANG``, structure, métadonnées et
+   contenu compris ;
+2. une erreur de lecture du ``meta.yml`` aussi, parce que ce fichier-là
+   s'affiche ;
+3. un ``lab.yaml`` illisible, lui, **ne s'affiche pas** : sa raison va au
+   journal, elle reste technique, et la classe qui la porte le dit.
+
+Et un quatrième contrôle, mécanique celui-là : toute clé employée par les
+validators ou par le contrat existe dans **les deux** tables. Une clé écrite
+d'un seul côté rendrait la clé elle-même à l'écran.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import dsoxlab
+from dsoxlab.cli import app
+from dsoxlab.discovery.scanner import scan_catalog
+from dsoxlab.i18n import set_lang
+from dsoxlab.i18n.strings.en import STRINGS as EN
+from dsoxlab.i18n.strings.fr import STRINGS as FR
+from dsoxlab.models._contract import ContractError, LabYamlError
+from dsoxlab.models.lab import LabDefinition
+from dsoxlab.models.repo import RepoMetadata
+
+runner = CliRunner()
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+META = """\
+repo:
+  id: demo-training
+  category: demo
+"""
+
+LAB_CASSE = """\
+id: demo-lab
+title: Demo lab
+level: beginner
+skills: []
+distros: [any]
+doc_url: ftp://example.org/docs/demo/
+lab_type: inconnu
+runtime:
+  type: shell
+  workdir: challenge/work
+"""
+
+
+def _plain(sortie: str) -> str:
+    """Sortie sans couleur ni repli de ligne.
+
+    Rich replie ses lignes à la largeur du terminal, et un message coupé en
+    deux ne se retrouve plus par un simple ``in``. On compare donc des textes
+    dont les blancs sont normalisés, des deux côtés.
+    """
+    return re.sub(r"\s+", " ", _ANSI.sub("", sortie))
+
+
+def _morceaux(texte: str) -> list[str]:
+    """Ce qu'une traduction écrit en toutes lettres, autour de ses paramètres.
+
+    Chercher le **début** du message ne prouverait rien : un message qui ouvre
+    sur son paramètre (``'{field}' must be…``) n'aurait pour début qu'une
+    apostrophe, et le test passerait sur n'importe quelle sortie. On exige donc
+    la présence de **tous** ses fragments fixes, et on vérifie qu'il y a là
+    assez de texte pour que la vérification veuille dire quelque chose.
+    """
+    morceaux = [re.sub(r"\s+", " ", m).strip() for m in re.split(r"\{[^}]*\}", texte)]
+    morceaux = [m for m in morceaux if len(m) >= 4]
+    assert sum(len(m) for m in morceaux) > 10, f"trop peu de texte fixe : {texte!r}"
+    return morceaux
+
+
+def _catalogue_casse(racine: Path) -> Path:
+    """Un dépôt qui rate tout ce que `validate-structure` sait voir.
+
+    `skills` vide et `lab_type` hors énuméré pour les métadonnées, un
+    `scenario.md` absent pour la structure, un lien relatif mort et une
+    traduction orpheline pour le contenu.
+    """
+    (racine / "meta.yml").write_text(META, encoding="utf-8")
+    dossier = racine / "labs" / "demo" / "premiers-pas"
+    tests = dossier / "challenge" / "tests"
+    tests.mkdir(parents=True)
+    (dossier / "lab.yaml").write_text(LAB_CASSE, encoding="utf-8")
+    (dossier / "README.md").write_text(
+        "# Demo\n\nVoir [la suite](./absent.md).\n", encoding="utf-8"
+    )
+    (dossier / "cours.fr.md").write_text("# Cours\n", encoding="utf-8")
+    (tests / "test_functional.py").write_text(
+        "def test_ok():\n    assert True\n", encoding="utf-8"
+    )
+    return dossier
+
+
+def _valide(racine: Path, langue: str, monkeypatch: pytest.MonkeyPatch) -> str:
+    """`dsoxlab validate-structure` joué dans une langue, sortie nettoyée."""
+    monkeypatch.setenv("DSOXLAB_LANG", langue)
+    set_lang(langue)
+    try:
+        resultat = runner.invoke(
+            app, ["validate-structure", "--lab-home", str(racine)]
+        )
+    finally:
+        set_lang("en")
+    return _plain(resultat.output)
+
+
+# ── 1. validate-structure suit la langue ─────────────────────────────────────
+
+def test_les_trois_familles_de_controles_suivent_la_langue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Structure, métadonnées et contenu : chacune avait sa phrase en dur."""
+    _catalogue_casse(tmp_path)
+
+    anglais = _valide(tmp_path, "en", monkeypatch)
+    francais = _valide(tmp_path, "fr", monkeypatch)
+
+    for cle in (
+        "struct_missing_file",          # scenario.md absent
+        "metadata_list_empty",          # skills: []
+        "metadata_lab_type_invalid",    # lab_type: inconnu
+        "content_broken_links",         # ./absent.md
+        "content_missing_english",      # cours.fr.md orphelin
+    ):
+        for morceau in _morceaux(EN[cle]):
+            assert morceau in anglais, f"{cle} absent de la sortie anglaise :\n{anglais}"
+        for morceau in _morceaux(FR[cle]):
+            assert morceau in francais, f"{cle} absent de la sortie française :\n{francais}"
+
+
+def test_aucune_phrase_francaise_ne_traverse_la_sortie_anglaise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Le défaut d'origine, pris par le seul bout qui compte pour l'auteur."""
+    _catalogue_casse(tmp_path)
+
+    anglais = _valide(tmp_path, "en", monkeypatch)
+
+    for temoin in ("Fichier manquant", "est vide", "lien(s) relatif(s)", "Valeur invalide"):
+        assert temoin not in anglais, anglais
+
+
+# ── 2. le meta.yml s'affiche, donc il se traduit ─────────────────────────────
+
+def test_un_champ_mal_type_du_meta_se_dit_dans_la_langue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`infra.hosts` écrit en mapping : la faute la plus naturelle du contrat."""
+    (tmp_path / "meta.yml").write_text(
+        META + "infra:\n  hosts:\n    web1.lab: {}\n", encoding="utf-8"
+    )
+    (tmp_path / "labs").mkdir()
+
+    sorties = {}
+    for langue in ("en", "fr"):
+        monkeypatch.setenv("DSOXLAB_LANG", langue)
+        set_lang(langue)
+        try:
+            resultat = runner.invoke(app, ["list-labs", "--lab-home", str(tmp_path)])
+        finally:
+            set_lang("en")
+        assert resultat.exit_code == 1
+        sorties[langue] = _plain(resultat.output)
+
+    for langue, table in (("en", EN), ("fr", FR)):
+        for morceau in _morceaux(table["contract_field_not_mapping_list"]):
+            assert morceau in sorties[langue], sorties[langue]
+    # Et le chemin du fichier reste devant la phrase : sans lui, l'auteur ne
+    # sait pas quel fichier corriger.
+    assert "meta.yml" in sorties["en"]
+
+
+def test_le_modele_ne_porte_aucune_phrase_traduite(tmp_path: Path) -> None:
+    """Le patron : des faits dans le modèle, la phrase dans la CLI."""
+    (tmp_path / "meta.yml").write_text(
+        META + "infra:\n  provider: [kvm, incus]\n  providers: []\n", encoding="utf-8"
+    )
+
+    with pytest.raises(ContractError) as capture:
+        RepoMetadata.from_yaml(tmp_path / "meta.yml")
+
+    exc = capture.value
+    assert exc.key == "contract_field_not_mapping"
+    assert exc.params["field"] == "infra.providers"
+    assert exc.source == tmp_path / "meta.yml"
+    # Le texte technique du journal ne doit contenir aucune phrase traduite.
+    assert "doit être" not in str(exc) and "must be" not in str(exc)
+
+
+# ── 3. un lab.yaml illisible reste interne ───────────────────────────────────
+
+def test_un_lab_yaml_illisible_ne_va_qu_au_journal(tmp_path: Path) -> None:
+    """Le tri de #139 : ce que personne n'affiche n'a pas à être traduit."""
+    (tmp_path / "meta.yml").write_text(META, encoding="utf-8")
+    dossier = tmp_path / "labs" / "demo" / "casse"
+    dossier.mkdir(parents=True)
+    (dossier / "lab.yaml").write_text("- une liste, pas un mapping\n", encoding="utf-8")
+
+    with pytest.raises(LabYamlError):
+        LabDefinition.from_yaml(dossier / "lab.yaml")
+
+    # Le scanner l'absorbe, et retient la raison pour le diagnostic.
+    scan = scan_catalog(tmp_path)
+    assert scan.labs == []
+    assert len(scan.illisibles) == 1
+    assert "LabYamlError" in scan.illisibles[0][1]
+
+
+def test_les_coercions_non_traduites_ne_servent_qu_au_lab_yaml() -> None:
+    """Le tri repose sur un fait vérifiable, pas sur une promesse de docstring.
+
+    `as_argv` et `as_argv_list` lèvent une `LabYamlError`, dont le texte n'est
+    pas traduit. Le jour où `models/repo.py` s'en servirait, un `meta.yml`
+    afficherait du français sous `DSOXLAB_LANG=en`, et le tri serait faux sans
+    que rien ne le dise.
+    """
+    repo_py = (Path(dsoxlab.__file__).parent / "models" / "repo.py").read_text(
+        encoding="utf-8"
+    )
+    assert "as_argv" not in repo_py
+
+
+def test_l_erreur_interne_reste_un_valueerror(tmp_path: Path) -> None:
+    """`discovery/scanner.py` ne rattrape que KeyError, ValueError et YAMLError.
+
+    Changer de classe sans hériter de `ValueError` ferait remonter un traceback
+    brut sur une commande sans rapport.
+    """
+    assert issubclass(LabYamlError, ValueError)
+    assert issubclass(ContractError, ValueError)
+
+
+# ── 4. toute clé employée existe des deux côtés ──────────────────────────────
+
+def _cles_employees() -> set[str]:
+    """Les clés i18n que les validators et le contrat passent à la CLI.
+
+    Lues dans la source plutôt que listées à la main : une clé ajoutée sans
+    traduction doit faire échouer ce test, pas attendre qu'un auteur la voie
+    s'afficher en clair.
+    """
+    racine = Path(dsoxlab.__file__).parent
+    fichiers = sorted((racine / "validators").glob("*.py")) + sorted(
+        (racine / "models").glob("*.py")
+    )
+    cles: set[str] = set()
+    for chemin in fichiers:
+        arbre = ast.parse(chemin.read_text(encoding="utf-8"))
+        for noeud in ast.walk(arbre):
+            if not isinstance(noeud, ast.Call):
+                continue
+            nom = getattr(noeud.func, "id", "") or getattr(noeud.func, "attr", "")
+            # `ContractError(source, field, key, …)` : la clé est en 3e position.
+            if nom == "ContractError" and len(noeud.args) >= 3:
+                argument = noeud.args[2]
+                if isinstance(argument, ast.Constant) and isinstance(argument.value, str):
+                    cles.add(argument.value)
+            for kw in noeud.keywords:
+                if (
+                    kw.arg == "key"
+                    and isinstance(kw.value, ast.Constant)
+                    and isinstance(kw.value.value, str)
+                ):
+                    cles.add(kw.value.value)
+            # `MetadataIssue("doc_url", "metadata_doc_url_scheme", {...})`
+            if nom == "MetadataIssue" and len(noeud.args) >= 2:
+                argument = noeud.args[1]
+                if isinstance(argument, ast.Constant) and isinstance(argument.value, str):
+                    cles.add(argument.value)
+    return cles
+
+
+def test_chaque_cle_employee_existe_en_anglais_et_en_francais() -> None:
+    cles = _cles_employees()
+    assert len(cles) > 20, f"lecture des sources trop maigre : {sorted(cles)}"
+    assert sorted(cle for cle in cles if cle not in EN) == []
+    assert sorted(cle for cle in cles if cle not in FR) == []
+
+
+def test_les_cles_du_contrat_ne_reclament_pas_le_chemin_du_fichier() -> None:
+    """La CLI encadre ces phrases du chemin ; le porter aussi le doublerait."""
+    for cle in (cle for cle in _cles_employees() if cle.startswith("contract_")):
+        assert "{path}" not in EN[cle] and "{path}" not in FR[cle], cle

--- a/tests/test_validators_content.py
+++ b/tests/test_validators_content.py
@@ -4,6 +4,10 @@ Un lien mort, un guide disparu, une solution en clair : rien de tout cela
 n'empêche un lab de s'exécuter. C'est précisément pourquoi ces défauts
 survivaient. Ces tests vérifient donc surtout que le contrôle *échoue* quand il
 le doit, et qu'il reste muet là où il n'a rien à dire.
+
+Depuis #139, ils vérifient **la clé et les faits**, jamais la phrase : celle-ci
+appartient aux tables de traduction, et l'y chercher ferait échouer la suite au
+premier mot reformulé.
 """
 
 from __future__ import annotations
@@ -40,7 +44,8 @@ class TestLiensInternes:
         )
         rapport = content.validate_internal_links(_lab(tmp_path))
         assert not rapport.ok
-        assert "../autre/lab.md" in rapport.issues[0].message
+        assert rapport.issues[0].key == "content_broken_links"
+        assert "../autre/lab.md" in rapport.issues[0].params["links"]
 
     def test_un_lien_valide_ne_dit_rien(self, tmp_path: Path) -> None:
         (tmp_path / "cible.md").write_text("cible", encoding="utf-8")
@@ -74,7 +79,7 @@ class TestSolutionsChiffrees:
         (sol / "solution.yaml").write_text("- name: en clair\n", encoding="utf-8")
         rapport = content.validate_solutions_encrypted(_lab(tmp_path), sol)
         assert not rapport.ok
-        assert "en clair" in rapport.issues[0].message
+        assert rapport.issues[0].key == "content_solution_plaintext"
 
     def test_une_solution_chiffree_passe(self, tmp_path: Path) -> None:
         sol = tmp_path / "solution"
@@ -109,7 +114,10 @@ class TestDocUrl:
             raise urllib.error.HTTPError("u", 404, "Not Found", {}, None)  # type: ignore[arg-type]
 
         monkeypatch.setattr(content.urllib.request, "urlopen", _404)
-        assert content.check_doc_url(_lab(tmp_path)) == "HTTP 404"
+        souci = content.check_doc_url(_lab(tmp_path))
+        assert souci is not None
+        assert souci.key == "content_doc_url_status"
+        assert souci.params["code"] == 404
 
     def test_head_refuse_mais_get_repond(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -132,12 +140,19 @@ class TestDocUrl:
             raise urllib.error.URLError("network is unreachable")
 
         monkeypatch.setattr(content.urllib.request, "urlopen", _boum)
-        motif = content.check_doc_url(_lab(tmp_path))
-        assert motif is not None and "injoignable" in motif
+        souci = content.check_doc_url(_lab(tmp_path))
+        assert souci is not None and souci.key == "content_doc_url_unreachable"
 
     def test_schema_inattendu(self, tmp_path: Path) -> None:
-        motif = content.check_doc_url(_lab(tmp_path, doc_url="ftp://exemple/guide"))
-        assert motif is not None and "ftp" in motif
+        souci = content.check_doc_url(_lab(tmp_path, doc_url="ftp://exemple/guide"))
+        assert souci is not None
+        assert souci.key == "content_doc_url_scheme"
+        assert souci.params["scheme"] == "ftp"
+
+    def test_sans_schema_du_tout(self, tmp_path: Path) -> None:
+        """Une clé à part : « (aucun) » serait le seul mot non traduit."""
+        souci = content.check_doc_url(_lab(tmp_path, doc_url="exemple.test/guide"))
+        assert souci is not None and souci.key == "content_doc_url_no_scheme"
 
     def test_sans_doc_url(self, tmp_path: Path) -> None:
         assert content.check_doc_url(_lab(tmp_path, doc_url="")) is None
@@ -182,7 +197,8 @@ class TestBareme:
     def test_un_test_de_plus_est_signale(self, tmp_path: Path) -> None:
         rapport = content.validate_scoring(self._lab_note(tmp_path, taches=5, tests=6))
         assert not rapport.ok
-        assert "5 tâche(s) notée(s) pour 6 test(s)" in rapport.issues[0].message
+        assert rapport.issues[0].key == "content_scoring_tasks_vs_tests"
+        assert rapport.issues[0].params == {"tasks": 5, "tests": 6}
 
     def test_un_pour_un_passe(self, tmp_path: Path) -> None:
         assert content.validate_scoring(self._lab_note(tmp_path, taches=5, tests=5)).ok
@@ -220,7 +236,8 @@ class TestPariteLangues:
         (tmp_path / "README.fr.md").write_text("cours", encoding="utf-8")
         rapport = content.validate_language_parity(_lab(tmp_path))
         assert not rapport.ok
-        assert "README.md" in rapport.issues[0].message
+        assert rapport.issues[0].key == "content_missing_english"
+        assert rapport.issues[0].params["name"] == "README.md"
 
     def test_les_deux_langues_presentes(self, tmp_path: Path) -> None:
         (tmp_path / "README.fr.md").write_text("cours", encoding="utf-8")
@@ -242,7 +259,8 @@ class TestCibles:
             self._lab_vm(tmp_path, "absent.lab"), {"present.lab"}
         )
         assert not rapport.ok
-        assert "absent.lab" in rapport.issues[0].message
+        assert rapport.issues[0].key == "content_target_host_unknown"
+        assert rapport.issues[0].params["host"] == "absent.lab"
 
     def test_hote_connu(self, tmp_path: Path) -> None:
         assert content.validate_targets(

--- a/uv.lock
+++ b/uv.lock
@@ -304,7 +304,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.59"
+version = "0.1.60"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
#101 avait étendu le garde-fou i18n au paquet et corrigé 43 chaînes, en excluant
délibérément deux zones. Voici la dette qu'il avait tracée, soldée : les
messages des validators et ceux du contrat venaient d'un champ `message` écrit
en français dans une dataclass, qu'aucun garde-fou ne pouvait voir. Ils
s'affichaient tels quels sous `DSOXLAB_LANG=en`, au pire moment : quand un
auteur découvre le contrat et que son catalogue est mal formé.

## Le tri des 24 `raise ValueError` de `models/`

Un seul critère, et il ne dépend pas du fichier source mais du **chemin
d'appel** : ce message atteint-il un humain qui lit l'interface ?

| | Combien | Où | Ce qu'elles deviennent |
|---|---|---|---|
| **À l'interface** | 17 | `repo.py` (8), `schema_version.py` (2), coercions partagées de `_contract.py` (7) | `ContractError`, qui porte `source`, `field`, une clé i18n et ses paramètres |
| **Internes** | 7 | `lab.py` (3), `as_argv`/`as_argv_list` (4) | `LabYamlError`, texte technique inchangé, avec la raison écrite dans la classe |

Les premières sont levées en lisant un `meta.yml` : `discovery/repo.py` laisse
remonter, `cli.py` affiche. Les secondes ne sont atteignables que depuis un
`lab.yaml`, dont `discovery/scanner.py` est le seul lecteur, et qui écarte le
lab en journalisant.

**Traduire dans le modèle aurait été la mauvaise correction** : cela aurait mis
de la langue là où il ne doit y avoir que des faits. C'est le patron de
`UnsupportedSchemaVersion` et `ProviderUnresolved` qui est étendu, pas un
nouveau : le modèle porte des données, la CLI compose la phrase et l'encadre du
chemin du fichier, qui n'entre donc dans aucune traduction.

## Ce qui rend le tri vérifiable plutôt que déclaratif

Un tri écrit dans un commentaire se périme sans bruit. Trois mécanismes le
tiennent :

- le garde-fou connaît `LabYamlError` par son nom : le jour où l'un de ces
  messages doit s'afficher, il change de classe et le garde-fou réclame sa clé ;
- un test mécanique interdit à `models/repo.py` d'importer `as_argv`, faute de
  quoi le classement deviendrait faux en silence ;
- `_HORS_PERIMETRE` passe de `("models/", "templates/demo/")` à
  `("templates/demo/",)`, et gagne un cinquième puits qui couvre les
  constructions de `*Issue`, valeurs de `params=` comprises.

**39 clés** ajoutées simultanément dans `en.py` et `fr.py` (12 `struct_*`,
5 `metadata_*`, 13 `content_*`, 9 `contract_*`).

## Un défaut trouvé en chemin

Un champ mal typé du `meta.yml` rendait un **traceback brut** sur `list-labs` :
le scanner relit ce fichier pour l'ordre des sections, et rien n'attrapait
l'erreur sur ce chemin, alors que `_read_repo` disait déjà une phrase ailleurs.
Corrigé dans `_catalogue()` et dans le filet de `main()`.

## Le rendu réel, sur un catalogue cassé jetable

`DSOXLAB_LANG=en` :

```
Keys nothing reads:
  ✘ labs/demo/premiers-pas/lab.yaml: 'sesion' is not part of the contract, and dsoxlab ignores it.
The closest key it does read at that level is 'section'.
Structure validation
└── ✘ demo-lab
    ├── Missing file: scenario.md
    ├── runtime.type is 'shell' but runtime.workdir is empty. Declare the work directory (e.g.
    │   workdir: challenge/work).
    └── A Makefile is not allowed in a lab: dsoxlab drives everything.

Metadata issues:
  ✘ demo-lab — doc_url: invalid URL (http/https scheme expected): ftp://example.org/docs/demo/
  ✘ demo-lab — lab_type: Invalid value 'examen'. Expected one of: capstone, challenge, lab
```

`DSOXLAB_LANG=fr` :

```
Clés que personne ne lit :
  ✘ labs/demo/premiers-pas/lab.yaml: « sesion » ne fait pas partie du contrat, et dsoxlab l'ignore.
La clé la plus proche qu'il lit vraiment, à ce niveau, est « section ».
Validation de structure
└── ✘ demo-lab
    ├── Fichier manquant : scenario.md
    ├── runtime.type est 'shell' mais runtime.workdir est vide. Déclare le répertoire de travail
    │   (ex. workdir: challenge/work).
    └── Makefile interdit dans un lab : dsoxlab pilote tout.

Problèmes de métadonnées :
  ✘ demo-lab — doc_url: URL invalide (schéma http/https attendu) : ftp://example.org/docs/demo/
  ✘ demo-lab — lab_type: Valeur invalide « examen ». Attendu, l'une de : capstone, challenge, lab
```

## Type of change

- [x] Bug fix

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` — All checks passed!
- [x] `uv run mypy src/dsoxlab` — no issues in 60 source files
- [x] `uv run pytest` — **573 passed** ; `tests_e2e` — 16 passed
- [x] Domain-agnostic ; aucun chemin personnel
- [x] `validate-structure` rc=**0** sur `linux-dsoxlab-training` (EN) et
      `terraform-training` (FR), après rebase. Ces dépôts n'ont reçu aucune
      écriture.

### When behavior changes

- [x] CHANGELOG EN + FR ; version **0.1.60** ; `uv.lock` régénéré

### When a command or option is added, removed or changed

- [x] 39 clés posées **simultanément** en EN et FR. Aucune commande ni option ne
      change, donc `fullhelp` est inchangé.

### When `.github/workflows/` is touched — N/A
### When the declarative contract changes

- [x] Le contrat ne change pas ; seule la **façon de dire** ce qu'il refuse
      change. Aucun `meta.yml` ni `lab.yaml` valide hier ne devient invalide.

## Mutation : six cassures, six rouges

1. un validator recompose sa phrase en dur → garde-fou + les deux tests de langue ;
2. le modèle recompose la phrase du `meta.yml` → garde-fou ;
3. une clé traduite d'un seul côté → parité des clés + test de langue ;
4. `LabYamlError` redevient un `ValueError` anonyme → garde-fou + test « ça ne va qu'au journal » ;
5. la CLI cesse de composer la phrase du contrat → test du `meta.yml` mal typé ;
6. `models/repo.py` importe `as_argv` → test qui tient le tri.

## Un test qui ne mordait pas, et comment il a été pris

La première version du test sur le `meta.yml` mal typé était **vacuous** :
l'ancre calculée valait une simple apostrophe, parce que le message commence par
son paramètre. Le test passait alors même que la CLI rendait un traceback. C'est
en jouant la commande réelle qu'il est tombé. Il compare désormais **tous** les
fragments fixes de la traduction, avec un garde-fou sur la quantité de texte
comparée, et la mutation n°5 prouve qu'il mord.

## Note de rebase

Écrite avant #149 et #150, la branche visait 0.1.59, entre-temps publiée. Elle
est rebasée sur `main` et renumérotée **0.1.60** ; les trois conflits étaient de
numérotation, aucun de fond. Cette version emporte donc aussi le classifier
`Python :: 3.14` posé par #150.

## Related issues

Closes #139
Suite directe de #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)