### PR TITLE
fix(runtimes/services): un conteneur arrêté se dit, au lieu d'accuser la commande (0.1.66)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,42 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.66] - 2026-08-24
+
+### Corrigé
+
+- **Un conteneur arrêté était rapporté comme une commande d'initialisation en
+  échec.** Quand `post_start` tombait sur un conteneur qui ne tournait plus,
+  Docker répondait `container <64 caractères hexadécimaux> is not running`, et
+  dsoxlab reprenait cette phrase dans « l'initialisation du service « x » a
+  échoué sur « y » ». Deux erreurs à la fois : cela envoyait chercher un défaut
+  dans une commande qui n'avait jamais été jouée, et cela désignait le conteneur
+  par un identifiant que personne n'avait jamais vu. Le message dit maintenant
+  que le conteneur s'est arrêté, donne son **code de sortie** et les **dix
+  dernières lignes de ses logs**, et nomme le conteneur tel qu'il a été déclaré.
+  Le contrôle n'a lieu qu'après l'échec d'un `docker exec` : un service sain
+  n'est jamais interrogé pour rien.
+
+- **Le contrôle de documentation était rouge chez le contributeur et vert en
+  intégration continue.** Il lisait tous les Markdown de la racine, y compris
+  ceux que git ne suit pas. Un `CLAUDE.md` citant `~/.config/dsoxlab/config.yaml`
+  pour dire que ce chemin n'existe pas encore suffisait à faire échouer deux
+  tests en local, là où l'intégration continue, qui n'a pas ce fichier, restait
+  verte. Le contrôle ne retient plus que les fichiers versionnés, et retombe sur
+  tout ce qu'il trouve s'il n'y a pas de dépôt git, pour qu'une archive extraite
+  ne rende pas le contrôle vert en le vidant.
+
+### Modifié
+
+- **Les deux tests d'intégration Docker de `services` déclarent enfin la sonde
+  `ready_exec` que le contrat recommande** (issue #155). Ils enchaînaient un
+  `docker exec` juste après `start()` sans que rien n'ait prouvé que le
+  conteneur pouvait en recevoir un : l'attente implicite tenait à la charge de
+  la machine. Leurs messages d'échec portent aussi l'état du conteneur, son code
+  de sortie et ses logs : un échec intermittent en intégration continue ne
+  laisse aucune autre trace, et un `assert x.ok` nu ne laissait rien à
+  diagnostiquer.
+
 ## [0.1.64] - 2026-08-24
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.66] - 2026-08-24
+
+### Fixed
+
+- **A stopped container was reported as a failed initialisation command.** When
+  `post_start` met a container that was no longer running, Docker answered
+  `container <64 hex characters> is not running`, and dsoxlab quoted it inside
+  "initialising service 'x' failed on 'y'". Two things were wrong at once: it
+  sent you looking for a defect in a command that had never been played, and it
+  named the container by an identifier you had never seen. The message now says
+  the container stopped, gives its **exit code** and the **last ten lines of its
+  logs**, and names the container the way you declared it. The check runs only
+  when a `docker exec` has actually failed, so a healthy service is never
+  interrogated for nothing.
+
+- **The documentation check was red on a contributor's machine and green in
+  CI.** It scanned every Markdown file at the repository root, including
+  unversioned ones. A `CLAUDE.md` mentioning `~/.config/dsoxlab/config.yaml` to
+  say the path does not exist yet was enough to fail two tests locally, while CI
+  — where that file does not exist — stayed green. The check now considers only
+  files git tracks, and falls back to scanning everything when there is no git
+  repository at all, so an extracted archive does not turn the control green by
+  emptying it.
+
+### Changed
+
+- **The two Docker integration tests of `services` now declare the `ready_exec`
+  probe the contract recommends** (issue #155). They enchained a `docker exec`
+  right after `start()` without anything having proved the container could
+  accept one: the implicit wait depended on how busy the machine was. Their
+  failure messages also carry the container state, its exit code and its logs —
+  an intermittent failure in CI leaves no other trace, and `assert x.ok` alone
+  left nothing to diagnose.
+
 ## [0.1.64] - 2026-08-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.64"
+version = "0.1.66"
 description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/generer-doc.py
+++ b/scripts/generer-doc.py
@@ -231,14 +231,45 @@ _SOUS_MAISON = re.compile(r"~/[A-Za-z0-9._/<>{}-]+")
 _FICHIER_DEPOT = re.compile(r"[A-Za-z0-9._/<>{}-]*\.dsoxlab[A-Za-z0-9._-]*")
 
 
+def _pages_versionnees() -> set[Path] | None:
+    """Les Markdown que git suit, ou None si la question n'a pas de sens ici.
+
+    None quand le dépôt n'est pas un dépôt git, ou que git est absent : le
+    contrôle retombe alors sur tout ce qu'il trouve, ce qui est le comportement
+    d'origine.
+    """
+    try:
+        res = subprocess.run(
+            ["git", "-C", str(RACINE), "ls-files", "-z", "--", "*.md"],
+            capture_output=True, text=True, check=False, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if res.returncode != 0:
+        return None
+    return {RACINE / nom for nom in res.stdout.split("\0") if nom}
+
+
 def documents_documentation() -> list[Path]:
     """Les pages de documentation, celles qui décrivent le produit d'aujourd'hui.
 
     Le CHANGELOG en est exclu : il raconte le passé, où un chemin retiré depuis
     a toute sa place.
+
+    Les fichiers **non versionnés** en sont exclus aussi, et pour la même raison
+    de fond : ils ne décrivent pas le produit. Un `CLAUDE.md` d'agent, un
+    brouillon de notes, tout Markdown que git ne suit pas vit sur une seule
+    machine. Les inclure rendait le contrôle rouge chez le contributeur et vert
+    en intégration continue, où ces fichiers n'existent pas : le pire écart
+    possible pour une porte de contribution, puisqu'il apprend à ne pas croire
+    la suite là où elle est justement censée faire foi.
     """
     pages = sorted(RACINE.glob("*.md")) + sorted((RACINE / "docs").rglob("*.md"))
-    return [p for p in pages if not p.name.startswith("CHANGELOG")]
+    pages = [p for p in pages if not p.name.startswith("CHANGELOG")]
+    versionnees = _pages_versionnees()
+    if versionnees is None:
+        return pages
+    return [p for p in pages if p in versionnees]
 
 
 def chemins_reels() -> tuple[set[str], set[str]]:

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -961,6 +961,10 @@ silent.
         "Service '{name}' failed to start:\n{detail}",
     "err_service_post_start_failed":
         "Initialising service '{name}' failed on « {command} »:\n{detail}",
+    "err_service_container_stopped":
+        "Service '{name}' is no longer running, so its initialisation cannot "
+        "be played.\nContainer {container}, exited with code {code}.\n"
+        "Last lines:\n{logs}",
     "err_vm_setup_missing":
         "Lab {lab_id} must ship setup.yaml at its root (dsoxlab contract for "
         "runtime: vm). Expected file: {path}",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -972,6 +972,10 @@ hors ligne, elle se tait.
         "Le démarrage du service « {name} » a échoué :\n{detail}",
     "err_service_post_start_failed":
         "L'initialisation du service « {name} » a échoué sur « {command} » :\n{detail}",
+    "err_service_container_stopped":
+        "Le service « {name} » ne tourne plus, son initialisation ne peut pas "
+        "être jouée.\nConteneur {container}, sorti avec le code {code}.\n"
+        "Dernières lignes :\n{logs}",
     "err_vm_setup_missing":
         "Le lab {lab_id} doit fournir setup.yaml à la racine (contrat dsoxlab "
         "pour runtime: vm). Fichier attendu : {path}",

--- a/src/dsoxlab/runtimes/services.py
+++ b/src/dsoxlab/runtimes/services.py
@@ -199,6 +199,21 @@ def _wait_ready(service: Service, name: str) -> None:
         ))
 
 
+def _diagnostic_arret(name: str) -> tuple[str, str]:
+    """Pourquoi ce conteneur n'est plus debout : code de sortie et dernières lignes.
+
+    Docker, lui, répond ``container <64 caractères hexadécimaux> is not
+    running`` : vrai, inexploitable, et cité tel quel il accuse la commande
+    qu'on essayait de jouer plutôt que l'arrêt qui l'empêche.
+    """
+    code = run_command(["docker", "inspect", "-f", "{{.State.ExitCode}}", name],
+                       check=False, timeout=15)
+    logs = run_command(["docker", "logs", "--tail", "10", name],
+                       check=False, timeout=15)
+    sortie = (logs.stdout or logs.stderr).strip()
+    return code.stdout.strip() or "?", sortie or "(aucune)"
+
+
 def _run_post_start(service: Service, name: str) -> None:
     """Joue les commandes d'initialisation DANS le conteneur, une fois prêt.
 
@@ -206,17 +221,34 @@ def _run_post_start(service: Service, name: str) -> None:
     garantit pas un service qui répond, et une initialisation jouée trop tôt
     échoue de façon intermittente — le pire des symptômes à diagnostiquer.
 
+    Un ``docker exec`` exige un conteneur debout. Quand il échoue, on regarde
+    donc **pourquoi avant d'accuser la commande** : si le conteneur s'est
+    arrêté, la réponse de Docker est ``container <64 caractères hexadécimaux>
+    is not running``, et la reprendre telle quelle envoie chercher un défaut
+    dans une commande qui n'a jamais été jouée. La cause utile est le code de
+    sortie et les logs du conteneur.
+
+    Le contrôle n'a lieu qu'en cas d'échec : le chemin nominal ne paie aucun
+    appel supplémentaire, et un conteneur sain n'est jamais interrogé pour rien.
+
     Sans shell (``docker exec`` reçoit l'argv tel quel), donc pas d'expansion ni
     de redirection : ce que le lab déclare est ce qui s'exécute.
     """
     for argv in service.post_start:
         res = run_command(["docker", "exec", name, *argv], check=False, timeout=120)
-        if not res.ok:
+        if res.ok:
+            continue
+        if not _is_running(name):
+            code, logs = _diagnostic_arret(name)
             raise ServiceError(_(
-                "err_service_post_start_failed",
-                name=service.name, command=" ".join(argv),
-                detail=(res.stderr or res.stdout).strip(),
+                "err_service_container_stopped",
+                name=service.name, container=name, code=code, logs=logs,
             ))
+        raise ServiceError(_(
+            "err_service_post_start_failed",
+            name=service.name, command=" ".join(argv),
+            detail=(res.stderr or res.stdout).strip(),
+        ))
 
 
 def start(service: Service, repo_id: str) -> str:

--- a/tests/test_documentation_synchrone.py
+++ b/tests/test_documentation_synchrone.py
@@ -461,3 +461,54 @@ def test_chaque_page_nomme_son_public(langue: str) -> None:
         f"pages qui ne nomment pas leur public : {sans_public}\n"
         "Ajoute une ligne « **Audience:** … » (ou « **Public :** … ») en tête."
     )
+
+
+def test_une_page_non_versionnee_ne_fait_pas_foi(
+    generateur: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Un Markdown que git ne suit pas ne décrit pas le produit, donc ne le juge pas.
+
+    Le cas réel : un `CLAUDE.md` d'agent, non versionné, cite
+    `~/.config/dsoxlab/config.yaml` pour dire que ce chemin n'existe pas encore.
+    Le contrôle le lisait comme une page de documentation et rendait la suite
+    **rouge chez le contributeur, verte en intégration continue**, où le fichier
+    n'existe pas. Un écart dans ce sens est le pire : il apprend à ne pas croire
+    la suite, à l'endroit précis où elle est censée faire foi.
+    """
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, timeout=30)
+    (tmp_path / "docs").mkdir()
+    versionnee = tmp_path / "README.md"
+    versionnee.write_text("page suivie\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "README.md"],
+                   check=True, timeout=30)
+    libre = tmp_path / "CLAUDE.md"
+    libre.write_text("cite `~/.config/dsoxlab/config.yaml`\n", encoding="utf-8")
+
+    monkeypatch.setattr(generateur, "RACINE", tmp_path)
+    pages = generateur.documents_documentation()
+
+    assert versionnee in pages, "une page suivie par git doit rester contrôlée"
+    assert libre not in pages, (
+        "un Markdown non versionné ne doit pas être lu comme de la documentation"
+    )
+
+
+def test_hors_depot_git_toutes_les_pages_comptent(
+    generateur: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Sans git, le contrôle retombe sur tout ce qu'il trouve plutôt que sur rien.
+
+    Une archive extraite, un export sans `.git` : filtrer sur `git ls-files` y
+    rendrait la liste vide, donc le contrôle vert à vide, ce qui est exactement
+    l'échec silencieux que ce fichier existe pour empêcher.
+    """
+    (tmp_path / "docs").mkdir()
+    page = tmp_path / "README.md"
+    page.write_text("hors dépôt\n", encoding="utf-8")
+
+    monkeypatch.setattr(generateur, "RACINE", tmp_path)
+
+    assert generateur._pages_versionnees() is None
+    assert page in generateur.documents_documentation()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -40,6 +40,25 @@ def _lab(tmp_path: Path, runtime_block: str) -> LabDefinition:
     return LabDefinition.from_yaml(path)
 
 
+def _etat_conteneur(nom: str) -> str:
+    """L'état d'un conteneur, à joindre au message d'un test d'intégration raté.
+
+    Un `assert lu.ok` nu laisse un échec qu'on ne peut ni comprendre ni
+    reproduire : le conteneur a disparu à la sortie du test, et il ne reste que
+    « c'était faux ». Sur une exécution d'intégration continue, c'est la seule
+    trace qu'on aura jamais du problème.
+    """
+    etat = run_command(
+        ["docker", "inspect", "-f", "{{.State.Status}} (code {{.State.ExitCode}})", nom],
+        check=False, timeout=15,
+    )
+    logs = run_command(["docker", "logs", "--tail", "10", nom], check=False, timeout=15)
+    return (
+        f"état du conteneur {nom} : {etat.stdout.strip() or etat.stderr.strip()}\n"
+        f"dernières lignes :\n{(logs.stdout or logs.stderr).strip() or '(aucune)'}"
+    )
+
+
 # ── Parsing du contrat ──────────────────────────────────────────────────────
 
 def test_services_absent_donne_liste_vide(tmp_path: Path) -> None:
@@ -464,6 +483,64 @@ def test_post_start_en_echec_leve_service_error(monkeypatch: pytest.MonkeyPatch)
     assert "permission denied" in str(exc.value)
 
 
+def test_conteneur_arrete_avant_post_start_dit_pourquoi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Un conteneur qui n'est plus debout se dit comme tel, pas comme une commande ratée.
+
+    Docker répond ``container <64 caractères hexadécimaux> is not running``.
+    Cité tel quel dans « l'initialisation a échoué sur … », il envoie chercher
+    un défaut dans une commande qui n'a jamais été jouée, et il désigne le
+    conteneur par un identifiant que l'utilisateur n'a jamais vu. La cause utile
+    est le code de sortie et les logs.
+    """
+    service = Service(
+        name="db", image="x",
+        post_start=[["init", "schema"], ["charger", "donnees"]],
+    )
+    appels: list[list[str]] = []
+
+    class _Res:
+        def __init__(self, ok: bool = True, stdout: str = "", stderr: str = "") -> None:
+            self.ok = ok
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _fausse(cmd: list[str], **kw: object) -> _Res:
+        appels.append(list(cmd))
+        if cmd[:2] == ["docker", "exec"]:
+            # Ce que Docker répond vraiment sur un conteneur arrêté.
+            return _Res(False, stderr=(
+                "Error response from daemon: container "
+                "9dad8320afa7b24a503f83632df49a1d4b5f49d04e166f20cdac38426825ca1b "
+                "is not running"
+            ))
+        if cmd[:3] == ["docker", "inspect", "-f"] and "ExitCode" in cmd[3]:
+            return _Res(stdout="137")
+        if cmd[:2] == ["docker", "logs"]:
+            return _Res(stdout="out of memory, killed")
+        return _Res()
+
+    monkeypatch.setattr(svc, "_is_running", lambda name: False)
+    monkeypatch.setattr(svc, "_exists", lambda name: False)
+    monkeypatch.setattr(svc, "run_command", _fausse)
+
+    with pytest.raises(svc.ServiceError) as exc:
+        svc.start(service, "repo")
+
+    message = str(exc.value)
+    assert "137" in message, "le code de sortie du conteneur doit être dit"
+    assert "out of memory" in message, "les dernières lignes doivent être données"
+    assert "dsoxlab-repo-db" in message, "le conteneur doit être nommé lisiblement"
+    # Et surtout : on n'accuse pas la commande, qui n'y est pour rien. Ni
+    # l'identifiant hexadécimal, que l'utilisateur n'a jamais vu.
+    assert "init schema" not in message
+    assert "9dad8320" not in message
+    # On s'arrête à la première : inutile de rejouer les suivantes sur un
+    # conteneur qu'on sait arrêté.
+    assert len([c for c in appels if c[:2] == ["docker", "exec"]]) == 1
+
+
 # ── Nommage des conteneurs ──────────────────────────────────────────────────
 
 def test_container_name_namespace_par_repo(tmp_path: Path) -> None:
@@ -563,6 +640,12 @@ def test_post_start_execute_vraiment_dans_le_conteneur() -> None:
     s = Service(
         name="pytest-poststart",
         image="nginx:alpine",
+        # Le contrat recommande une sonde jouée DANS le conteneur, et ce test
+        # illustre l'usage recommandé plutôt que de s'en dispenser : sans elle,
+        # `start` rend la main sans qu'aucune étape n'ait prouvé que le
+        # conteneur accepte un `docker exec`, et l'enchaînement devient une
+        # course qu'une machine chargée finit par perdre.
+        ready_exec=["true"],
         post_start=[["sh", "-c", "echo initialise > /preuve-post-start"]],
     )
     repo = "dsoxlab-test"
@@ -570,7 +653,10 @@ def test_post_start_execute_vraiment_dans_le_conteneur() -> None:
         name = svc.start(s, repo)
         lu = run_command(["docker", "exec", name, "cat", "/preuve-post-start"],
                          check=False, timeout=30)
-        assert lu.ok, f"le fichier posé par post_start est illisible : {lu.stderr}"
+        assert lu.ok, (
+            f"le fichier posé par post_start est illisible (code {lu.returncode}) :\n"
+            f"{lu.stderr}\n{_etat_conteneur(name)}"
+        )
         assert lu.stdout.strip() == "initialise"
     finally:
         svc.stop(s, repo)
@@ -584,23 +670,61 @@ def test_deux_services_se_joignent_par_leur_nom() -> None:
     font déjà) mais l'effet : depuis un conteneur, le nom de l'autre service se
     résout. Sur le bridge par défaut de Docker, cette résolution n'existe pas.
     """
-    db = Service(name="pytest-db", image="nginx:alpine")
-    app = Service(name="pytest-app", image="nginx:alpine")
+    # `ready_exec` comme le recommande le contrat : `start` ne rend la main
+    # qu'une fois le conteneur capable de recevoir un `docker exec`. Sans elle,
+    # la résolution était tentée sur deux conteneurs dont rien n'avait prouvé
+    # qu'ils étaient joignables, et l'attente implicite tenait au hasard de la
+    # charge de la machine.
+    db = Service(name="pytest-db", image="nginx:alpine", ready_exec=["true"])
+    app = Service(name="pytest-app", image="nginx:alpine", ready_exec=["true"])
     repo = "dsoxlab-test-net"
     try:
-        svc.start(db, repo)
+        nom_db = svc.start(db, repo)
         nom_app = svc.start(app, repo)
         resolu = run_command(
             ["docker", "exec", nom_app, "getent", "hosts", "pytest-db"],
             check=False, timeout=30,
         )
-        assert resolu.ok, "le nom du service voisin ne se résout pas"
+        assert resolu.ok, (
+            "le nom du service voisin ne se résout pas "
+            f"(code {resolu.returncode}) :\n{resolu.stderr}\n"
+            f"{_etat_conteneur(nom_app)}\n{_etat_conteneur(nom_db)}"
+        )
         assert "pytest-db" in resolu.stdout
     finally:
         svc.stop(app, repo)
         svc.stop(db, repo)
         run_command(["docker", "network", "rm", svc.network_name(repo)],
                     check=False, timeout=30)
+
+
+@pytest.mark.skipif(not svc.docker_available(), reason="Docker injoignable")
+def test_conteneur_mort_ne_avant_post_start_dit_pourquoi_en_vrai() -> None:
+    """Le diagnostic contre un vrai Docker, pas contre un mock qui dit oui.
+
+    Le cas se produit sans aucune charge : une image sans processus au long
+    cours (entrypoint qui rend la main, commande fautive) sort avant que
+    l'initialisation puisse être jouée. Le test mocké prouve le message ; celui-ci
+    prouve qu'il se déclenche sur le comportement réel de Docker.
+    """
+    s = Service(
+        name="pytest-mortne",
+        image="hello-world",
+        post_start=[["sh", "-c", "echo jamais-joue"]],
+    )
+    repo = "dsoxlab-test"
+    try:
+        with pytest.raises(svc.ServiceError) as exc:
+            svc.start(s, repo)
+        message = str(exc.value)
+        assert svc.container_name(repo, s) in message, (
+            "le message doit nommer le conteneur, pas son identifiant hexadécimal"
+        )
+        assert "jamais-joue" not in message, (
+            "on n'accuse pas une commande qui n'a pas pu être jouée"
+        )
+    finally:
+        svc.stop(s, repo)
 
 
 @pytest.mark.skipif(not svc.docker_available(), reason="Docker injoignable")

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.64"
+version = "0.1.66"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
L'issue #155 demandait de **mesurer avant de corriger**, et de ne pas allonger un
délai, qui est « la correction la plus tentante et la moins informative ». Cette
PR suit cet ordre, et le résultat de la mesure n'est pas celui qu'on attendait.

## Ce que la mesure a réfuté

| Hypothèse | Verdict |
|---|---|
| Fenêtre entre `docker run -d` et `docker exec` | **Réfutée** : conteneur déjà `running`, premier `exec` réussi en **0,08 s** au repos et **0,23 s** à load 15,8, sur 12 tours chacun |
| Image tirée du réseau au premier test | Réfutée : `nginx:alpine` et `hello-world` en cache local |
| Ordre des tests aléatoire | Réfutée : le dépôt n'a ni `pytest-randomly` ni `xdist` |
| Collision de conteneur ou de réseau | Réfutée : réseaux distincts (`dsoxlab-test` / `dsoxlab-test-net`), aucun parallélisme |

**L'occurrence exacte de l'issue n'a pas été reproduite** : trois exécutions de la
suite complète à load 46 sont restées vertes. D'où `Refs #155` et non `Closes` :
seules plusieurs semaines de `pre-push` diront si l'intermittence a disparu.

## Ce qu'elle a trouvé, et qui ne demande aucune charge

Quand `post_start` vise un conteneur qui n'est plus debout, Docker répond
`container <64 caractères hexadécimaux> is not running`. Cette phrase était
reprise telle quelle :

```
Le service « x » … a échoué sur « sh -c echo x » :
Error response from daemon: container 9dad8320afa7… is not running
```

Deux erreurs dans une seule ligne : elle **accuse une commande qui n'a jamais été
jouée**, et elle désigne le conteneur par un identifiant que l'utilisateur n'a
jamais vu. Désormais :

```
Le service « x » ne tourne plus, son initialisation ne peut pas être jouée.
Conteneur dsoxlab-diagnostic-local-diag-mortne, sorti avec le code 0.
Dernières lignes : …
```

Le contrôle n'a lieu **qu'après l'échec d'un `docker exec`** : le chemin nominal
ne paie aucun appel supplémentaire, et un service sain n'est jamais interrogé
pour rien. Une première version vérifiait avant, en réutilisant `_is_running` :
elle était fausse, parce que cette fonction répond à une autre question (« y
a-t-il un conteneur à réutiliser ? », avant le `run`), et elle a cassé un test
mocké. La mesure l'a attrapée.

## Les deux tests de l'issue

Ils déclarent enfin la sonde `ready_exec` que le contrat recommande, au lieu
d'enchaîner un `docker exec` que rien n'autorisait : l'attente implicite tenait à
la charge de la machine. **Aucun délai n'a été allongé.** Leurs messages portent
maintenant l'état du conteneur, son code de sortie et ses logs, parce qu'un échec
intermittent en intégration continue ne laisse aucune autre trace, et qu'un
`assert x.ok` nu ne laissait rien à diagnostiquer.

## Un défaut trouvé en chemin, qui empêchait la mesure

Deux tests de `test_documentation_synchrone.py` étaient **rouges chez le
contributeur et verts en intégration continue** : le contrôle lisait tous les
Markdown de la racine, y compris ceux que git ne suit pas. Un `CLAUDE.md` citant
`~/.config/dsoxlab/config.yaml` pour dire que ce chemin n'existe pas encore
suffisait à le faire échouer. Il ne retient plus que les fichiers versionnés, et
retombe sur tout ce qu'il trouve hors dépôt git, pour qu'une archive extraite ne
le rende pas vert en le vidant.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 60 source files*
- [x] `uv run pytest` : **633 passed** (629 avant, +4)
- [x] `uv run pytest tests_e2e` : **16 passed** sur la roue construite et installée
- [x] Les quinze hooks `pre-commit` passent, y compris le contrôle de documentation
- [x] Le moteur reste neutre vis-à-vis du domaine : le diff n'ajoute aucun nom de
      produit ni aucune catégorie de labs
- [x] Aucun chemin personnel, aucun hôte en dur
- [x] Testé sur **deux dépôts fournisseurs**, en visant le chemin modifié :
      - `ansible-training`, lab `vault-integration-hashicorp` (`ready_exec:
        vault status` **et** `post_start`) : service démarré, et le secret déposé
        par `post_start` relu dans le conteneur pour prouver l'effet, pas la forme
      - `terraform-training` (aucun bloc `infra:`), lab
        `aws-provider-aws-first-ec2` (`ready_exec` **sans** `post_start`) :
        service démarré, chemin sans initialisation inchangé
- [x] **Les deux corrections sont éprouvées par leur échec** : chacune neutralisée
      tour à tour pour vérifier que le test nouveau rougit, puis restaurée
- [x] **8 exécutions sur 8** de la suite complète sous charge (load jusqu'à
      **50,7**, 32 processus de calcul et 6 boucles d'appels Docker) sans un seul
      échec

### When behavior changes

- [x] CHANGELOG EN **et** FR ; version **0.1.66** ; `uv.lock` aligné

### When a command or option is added, removed or changed — N/A

Aucune commande ni option n'est touchée. La clé i18n nouvelle
(`err_service_container_stopped`) est posée dans **en.py et fr.py**, et le
message a été lu sous `DSOXLAB_LANG=en` comme sous `DSOXLAB_LANG=fr`.

### When `.github/workflows/` is touched — N/A

### When the declarative contract changes — N/A

Ni `meta.yml` ni `lab.yaml` ne gagnent de champ. `ready_exec` existait déjà, et
la documentation le décrivait déjà comme « le seul signal de disponibilité
fiable » : ce sont les tests du dépôt qui ne suivaient pas leur propre contrat.

## Note de version

**0.1.66 et non 0.1.65**, ce numéro appartenant à la PR #157, ouverte et
mergeable. Si #157 part la première, l'enchaînement est cohérent.

## Related issues

Refs #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)
