### PR TITLE
fix(scripts): le garde-fou de publication cesse de se tromper de question

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,31 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Corrigé
+
+- **Le garde-fou de publication n'était pas fiable, de deux façons, toutes deux
+  constatées en publiant les 0.1.65 et 0.1.66.** Il garde une publication qui ne
+  se défait pas, donc s'y tromper coûte plus cher qu'ailleurs. Rien ne change
+  dans la roue publiée : `scripts/` est de l'outillage de développement, d'où
+  l'absence de bump de version.
+
+  - *Il comptait les fichiers non suivis comme un arbre sale.* Ce dépôt porte en
+    permanence des nœuds `/dev/null` à sa racine (`.bashrc`, `.gitconfig`,
+    `.idea`, `.mcp.json`…), que `git status --porcelain` liste en non suivis. Le
+    contrôle passait donc ou échouait selon que ces montages étaient visibles à
+    cet instant, c'est-à-dire par intermittence, dans l'outil même qui garde une
+    publication définitive. Or un garde-fou qui se déclenche au hasard finit
+    contourné. Seules les modifications de fichiers **suivis** bloquent
+    désormais un tag ; les non suivis sont nommés dans un avertissement, parce
+    qu'un `git add` oublié est un vrai risque qu'aucun script ne peut trancher à
+    la place de qui écrit le code.
+  - *`--publiee <tag>` ignorait le tag qu'on lui donnait* et interrogeait PyPI
+    sur la version empaquetée du moment. Une fois la version suivante fusionnée,
+    `--publiee v0.1.65` annonçait « la version 0.1.66 est absente de PyPI » :
+    un verdict faux, sur une version pourtant bien livrée.
+
+  Le script n'avait aucun test. Il en a cinq, chacun rouge sans sa correction.
+
 ## [0.1.66] - 2026-08-24
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The release guard was unreliable in two ways, both observed while shipping
+  0.1.65 and 0.1.66.** It guards a publication that cannot be undone, so being
+  wrong costs more here than elsewhere. Nothing in the published wheel changes:
+  `scripts/` is development tooling, hence no version bump.
+
+  - *It counted untracked files as a dirty tree.* This repository permanently
+    carries `/dev/null` nodes at its root (`.bashrc`, `.gitconfig`, `.idea`,
+    `.mcp.json`…), which `git status --porcelain` lists as untracked. The check
+    therefore passed or failed depending on whether those mounts were visible
+    at that moment — intermittently, inside the very tool that guards a
+    definitive publication, and a guard that fires at random ends up bypassed.
+    Only **tracked** modifications block a tag now; untracked files are named in
+    a warning, because a forgotten `git add` is real but no script can decide it
+    for the author.
+  - *`--publiee <tag>` ignored the tag it was given* and queried PyPI for the
+    currently packaged version. Once the next version was merged, `--publiee
+    v0.1.65` announced "version 0.1.66 is absent from PyPI": a false verdict
+    about a version that had shipped correctly.
+
+  The script had no test at all. It now has five, each failing without its fix.
+
 ## [0.1.66] - 2026-08-24
 
 ### Fixed

--- a/scripts/check-release.py
+++ b/scripts/check-release.py
@@ -106,17 +106,32 @@ def version_empaquetee() -> str | None:
 
 
 def _verifier_arbre(r: Rapport) -> None:
-    # Ce contrôle est un garde-fou : « rien à signaler » y vaut feu vert. Un
-    # git en échec rendrait lui aussi une sortie vide, donc un feu vert, sur
-    # une machine où l'on ne sait en réalité rien de l'arbre. On lit le code
-    # retour pour distinguer les deux.
-    sortie = git_resultat("status", "--porcelain")
-    if sortie.returncode != 0:
+    """Ce que le tag figerait, et ce qu'il laisserait derrière lui.
+
+    Deux questions, et une seule bloque. Un fichier **suivi** modifié rend le
+    tag menteur : il figerait un commit qui ne correspond pas à ce qu'on a sous
+    les yeux. Un fichier **non suivi**, lui, n'entre dans aucun commit ; il ne
+    peut que signaler un `git add` oublié, ce qu'aucun script ne sait trancher à
+    la place de qui écrit le code.
+
+    Les confondre coûtait cher ici : l'environnement de ce dépôt monte en
+    permanence des nœuds `/dev/null` à la racine (`.bashrc`, `.gitconfig`,
+    `.idea`, `.mcp.json`…), que `git status --porcelain` liste en non suivis.
+    Le contrôle passait ou échouait selon que ces montages étaient visibles au
+    moment de l'appel, c'est-à-dire par intermittence, dans l'outil même qui
+    garde une publication définitive. Un garde-fou qui se déclenche au hasard
+    finit contourné, et c'est alors tout le contrôle qui ne sert plus.
+    """
+    # Garde-fou : « rien à signaler » vaut feu vert, or un git en échec rend lui
+    # aussi une sortie vide. On lit le code retour pour distinguer les deux.
+    suivis = git_resultat("status", "--porcelain", "--untracked-files=no")
+    if suivis.returncode != 0:
         r.ko(
             "Impossible de lire l'état de l'arbre de travail",
-            f"git status a échoué : {sortie.stderr.strip() or 'sans message'}",
+            f"git status a échoué : {suivis.stderr.strip() or 'sans message'}",
         )
-    elif sortie.stdout.strip():
+        return
+    if suivis.stdout.strip():
         r.ko(
             "L'arbre de travail n'est pas propre",
             "Committe ou remise tes modifications : le tag figerait un état "
@@ -124,6 +139,22 @@ def _verifier_arbre(r: Rapport) -> None:
         )
     else:
         r.ok("Arbre de travail propre")
+
+    tous = git_resultat("status", "--porcelain")
+    if tous.returncode != 0:
+        return
+    non_suivis = [
+        ligne[3:] for ligne in tous.stdout.splitlines() if ligne.startswith("?? ")
+    ]
+    if non_suivis:
+        apercu = ", ".join(sorted(non_suivis)[:6])
+        reste = f" (et {len(non_suivis) - 6} autres)" if len(non_suivis) > 6 else ""
+        r.note(
+            f"{len(non_suivis)} fichier(s) non suivi(s), qui n'iront pas dans le tag",
+            f"{apercu}{reste}\n"
+            "      Si l'un d'eux devait être publié, il manque un git add : "
+            "la version partirait sans lui.",
+        )
 
 
 def _verifier_branche(r: Rapport) -> None:
@@ -406,7 +437,15 @@ def main() -> int:
     tag = arguments[0] if arguments else f"v{version}"
 
     if "--publiee" in sys.argv:
-        return controler_publication(version, tag)
+        # La version à chercher sur PyPI est celle du tag qu'on vérifie, pas
+        # celle qu'on empaquette aujourd'hui. Les deux divergent dès qu'une
+        # autre version a été fusionnée depuis : `--publiee v0.1.65` sur un
+        # dépôt passé à 0.1.66 annonçait « la version 0.1.66 est absente de
+        # PyPI », un verdict faux sur une version pourtant bien livrée. Un
+        # contrôle d'après-publication qui parle d'autre chose que du tag qu'on
+        # lui donne ne contrôle rien.
+        publiee = arguments[0].lstrip("v") if arguments else version
+        return controler_publication(publiee, tag)
 
     print(f"\n{GRAS}Contrôle avant tag {tag}{RAZ}\n")
     r = Rapport()

--- a/tests/test_check_release.py
+++ b/tests/test_check_release.py
@@ -1,0 +1,145 @@
+"""Le garde-fou de publication doit être fiable avant d'être sévère.
+
+`scripts/check-release.py` est le dernier contrôle avant un tag, et un tag
+publie sur PyPI, où un numéro consommé ne se réutilise jamais. Un contrôle qui
+se trompe y coûte donc plus cher qu'ailleurs, et de deux façons opposées :
+
+- **trop sévère au hasard**, il finit contourné, et c'est alors l'ensemble des
+  contrôles qui ne sert plus à rien ;
+- **trop bavard sur la mauvaise version**, il rend un verdict qui ne parle pas
+  de ce qu'on lui a demandé.
+
+Ce module ferme les deux, chacun sur un défaut réellement observé le
+2026-08-24 pendant la publication des 0.1.65 et 0.1.66.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+RACINE = Path(__file__).resolve().parent.parent
+
+
+def _module() -> Any:
+    """Charge `scripts/check-release.py` (son nom porte un tiret)."""
+    chemin = RACINE / "scripts" / "check-release.py"
+    spec = importlib.util.spec_from_file_location("check_release", chemin)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cr() -> Any:
+    chemin = RACINE / "scripts" / "check-release.py"
+    if not chemin.is_file():
+        pytest.skip("script de release absent de ce dépôt")
+    return _module()
+
+
+def _resultat(sortie: str, code: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["git"], returncode=code,
+                                       stdout=sortie, stderr="")
+
+
+# ── L'arbre de travail : ce que le tag fige, et ce qu'il laisse ─────────────
+
+def test_un_fichier_non_suivi_ne_bloque_pas_le_tag(
+    cr: Any, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Un fichier hors index n'entre dans aucun commit : il ne peut rien fausser.
+
+    Le cas réel : l'environnement de ce dépôt monte des nœuds `/dev/null` à la
+    racine (`.bashrc`, `.gitconfig`, `.idea`…), que `git status --porcelain`
+    liste en non suivis. Le contrôle échouait donc selon que ces montages
+    étaient visibles au moment de l'appel, c'est-à-dire par intermittence.
+    """
+    def _git(*args: str) -> subprocess.CompletedProcess[str]:
+        if "--untracked-files=no" in args:
+            return _resultat("")           # aucun fichier suivi modifié
+        return _resultat("?? .bashrc\n?? .idea\n")
+
+    monkeypatch.setattr(cr, "git_resultat", _git)
+    r = cr.Rapport()
+    cr._verifier_arbre(r)
+
+    assert r.echecs == [], "des fichiers non suivis ne doivent pas bloquer un tag"
+    sortie = capsys.readouterr().out
+    assert ".bashrc" in sortie, "ils doivent tout de même être nommés"
+    assert "git add" in sortie, "et l'oubli possible doit être dit"
+
+
+def test_un_fichier_suivi_modifie_bloque_toujours(
+    cr: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """L'autre sens, et le seul qui compte : le tag figerait un état différent."""
+    def _git(*args: str) -> subprocess.CompletedProcess[str]:
+        return _resultat(" M src/dsoxlab/cli.py\n")
+
+    monkeypatch.setattr(cr, "git_resultat", _git)
+    r = cr.Rapport()
+    cr._verifier_arbre(r)
+
+    assert len(r.echecs) == 1
+
+
+def test_un_git_muet_est_un_echec_pas_un_feu_vert(
+    cr: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le garde-fou du garde-fou : sortie vide + code non nul ≠ arbre propre."""
+    monkeypatch.setattr(cr, "git_resultat", lambda *a: _resultat("", code=128))
+    r = cr.Rapport()
+    cr._verifier_arbre(r)
+
+    assert len(r.echecs) == 1
+
+
+# ── --publiee : le contrôle doit parler du tag qu'on lui donne ──────────────
+
+def test_publiee_verifie_la_version_du_tag_demande(
+    cr: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le dépôt avance ; le tag qu'on vérifie, lui, ne change pas.
+
+    Après le merge d'une version suivante, `--publiee v0.1.65` interrogeait PyPI
+    sur la version empaquetée du moment (0.1.66) et annonçait « la version
+    0.1.66 est absente de PyPI ». Verdict faux, sur une version bien livrée.
+    """
+    vues: dict[str, str] = {}
+
+    def _faux_controle(version: str, tag: str) -> int:
+        vues["version"] = version
+        vues["tag"] = tag
+        return 0
+
+    monkeypatch.setattr(cr, "version_empaquetee", lambda: "0.1.66")
+    monkeypatch.setattr(cr, "controler_publication", _faux_controle)
+    monkeypatch.setattr(cr.sys, "argv", ["check-release.py", "--publiee", "v0.1.65"])
+
+    assert cr.main() == 0
+    assert vues["tag"] == "v0.1.65"
+    assert vues["version"] == "0.1.65", (
+        "la version contrôlée doit venir du tag, pas du pyproject courant"
+    )
+
+
+def test_publiee_sans_argument_prend_la_version_empaquetee(
+    cr: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sans tag explicite, le cas courant ne change pas : on vérifie ce qu'on vient
+    de publier."""
+    vues: dict[str, str] = {}
+
+    monkeypatch.setattr(cr, "version_empaquetee", lambda: "0.1.66")
+    monkeypatch.setattr(cr, "controler_publication",
+                        lambda version, tag: (vues.update(version=version, tag=tag), 0)[1])
+    monkeypatch.setattr(cr.sys, "argv", ["check-release.py", "--publiee"])
+
+    assert cr.main() == 0
+    assert vues == {"version": "0.1.66", "tag": "v0.1.66"}


### PR DESCRIPTION
Deux défauts de `scripts/check-release.py`, constatés en publiant les 0.1.65 et
0.1.66. Ils n'ont rien cassé, mais ils usaient la confiance dans le seul contrôle
qui garde une publication définitive, **et un garde-fou auquel on ne croit plus
finit contourné** : c'est alors l'ensemble des contrôles qui ne sert plus.

## Le contrôle d'arbre comptait les fichiers non suivis

Ce dépôt porte en permanence des nœuds `/dev/null` à sa racine (`.bashrc`,
`.gitconfig`, `.idea`, `.mcp.json`…), que `git status --porcelain` liste en non
suivis, et que le `CLAUDE.md` mentionne déjà comme la raison d'interdire
`git add -A`. Le contrôle passait donc ou échouait **selon que ces montages
étaient visibles à cet instant** : par intermittence, dans l'outil qui garde une
publication qu'on ne peut pas défaire. Ce sont les 0.1.64 et 0.1.65 qui l'ont
montré, taguées quand le contrôle disait « arbre propre », suivies d'un refus
pour la 0.1.66 sans qu'un seul fichier suivi ait bougé.

Deux questions étaient confondues, et une seule bloque :

| | Effet sur le tag | Verdict |
|---|---|---|
| Fichier **suivi** modifié | le tag figerait un commit qui ne correspond pas à ce qu'on a sous les yeux | **échec**, inchangé |
| Fichier **non suivi** | n'entre dans aucun commit, donc le tag ne le fige pas | **avertissement nommé** |

L'avertissement ne disparaît pas dans le silence : il liste les fichiers et
rappelle qu'un `git add` oublié ferait partir la version sans eux. C'est un vrai
risque, mais aucun script ne peut le trancher à la place de qui écrit le code.

## `--publiee <tag>` ignorait le tag qu'on lui donnait

Il interrogeait PyPI sur la version empaquetée du moment. Une fois 0.1.66
fusionnée, `--publiee v0.1.65` répondait :

```
✔ Le tag v0.1.65 est sur origin
✔ Release GitHub v0.1.65 complète (3 artefacts)
✘ La version 0.1.66 est absente de PyPI
```

Verdict faux, sur une version pourtant bien livrée. Un contrôle
d'après-publication qui parle d'autre chose que du tag qu'on lui donne ne
contrôle rien. La version vient désormais du tag.

## Le script n'avait aucun test

Ce qui explique que les deux défauts aient tenu. Il en a **cinq**, dont trois sur
des comportements inchangés qu'il ne faut pas perdre :

- un `git` muet reste un **échec** et non un feu vert (sortie vide + code non
  nul ne valent pas « arbre propre ») ;
- un fichier suivi modifié bloque toujours ;
- `--publiee` sans argument continue de viser la version empaquetée.

Les deux autres sont **rouges sans leur correction**, vérifié en neutralisant
chacune tour à tour.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 60 source files*
- [x] `uv run pytest` : **655 passed** (650 avant, +5)
- [x] Les hooks `pre-commit` passent
- [x] Le moteur reste neutre vis-à-vis du domaine : `src/dsoxlab/` n'est pas touché
- [x] Aucun chemin personnel : le script résout sa racine depuis `__file__`
- [x] **Éprouvé par l'échec** : chaque correction neutralisée tour à tour pour
      voir son test rougir, puis restaurée
- [ ] Test manuel sur deux dépôts fournisseurs : **N/A**. Ce script ne lit aucun
      catalogue et n'est pas installé par `uv tool install` ; il s'exécute dans
      ce dépôt seulement. Il a en revanche été joué en conditions réelles sur les
      trois cas de la journée, `v0.1.65` et `v0.1.66` avant tag comme après
      publication.

### When behavior changes — pas de bump

- [x] CHANGELOG EN **et** FR, section `Unreleased`
- [ ] Bump de version : **volontairement absent.** `[tool.hatch.build.targets.wheel]`
      ne retient que `packages = ["src/dsoxlab"]`, donc `scripts/` n'est pas dans
      la roue publiée et rien ne change pour qui installe dsoxlab. Publier un
      numéro pour de l'outillage de développement donnerait une version dont le
      contenu installable est identique à la précédente.

### When a command or option is added, removed or changed — N/A

`check-release.py` est un script de développement, hors CLI : ni aide Typer, ni
clés i18n, ni `fullhelp`.

### When `.github/workflows/` is touched — N/A

### When the declarative contract changes — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
