### PR TITLE
feat(catalog): installer un catalogue, et l'utiliser depuis n'importe où (0.1.67)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,46 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.67] - 2026-08-24
+
+### Ajouté
+
+- **`dsoxlab catalog` : installer un catalogue, et l'utiliser depuis n'importe
+  où** (issue #78). Séparer le moteur des catalogues est une bonne décision
+  d'architecture, mais elle était entièrement à la charge de l'utilisateur :
+  rien ne disait quels catalogues existent, comment en installer un, ni qu'il
+  fallait lancer dsoxlab depuis l'intérieur du répertoire cloné. Cinq
+  sous-commandes comblent l'écart :
+
+  ```console
+  $ dsoxlab catalog list              # les connus, et ceux qui sont installés
+  $ dsoxlab catalog add linux         # le cloner, et le rendre actif
+  $ cd ~ && dsoxlab list-labs         # marche, sans se placer dedans
+  $ dsoxlab catalog use ansible       # changer l'actif
+  $ dsoxlab catalog update [<id>]     # en mettre un à jour, ou tous
+  $ dsoxlab catalog remove <id>       # en retirer un
+  ```
+
+  **Le répertoire courant reste prioritaire.** Le catalogue actif n'est consulté
+  qu'**après** la remontée depuis le répertoire de travail, jamais avant : qui
+  se place dans un catalogue cloné à la main s'attend à travailler dessus.
+  L'inverse ferait qu'un `catalog add` changerait silencieusement ce que fait un
+  `dsoxlab check` lancé dans un dépôt existant : un effet de bord muet, à
+  distance, et sur la commande qui note le travail.
+
+  Le registre des catalogues connus est un **manifeste packagé avec l'outil**
+  (`templates/catalogues.yml`), pas un service distant : un registre est un
+  composant à héberger, surveiller et maintenir disponible, pour un projet qui
+  compte aujourd'hui trois catalogues. Un manifeste versionné a de plus un
+  mérite qu'un service n'a pas — il est révisable en pull request : proposer un
+  catalogue tiers devient une contribution ordinaire. N'importe quelle URL git
+  est acceptée aussi, y compris absente du manifeste : le manifeste facilite la
+  découverte, il ne restreint rien.
+
+  Le moteur reste neutre vis-à-vis des domaines, et un test l'impose :
+  `services/catalog.py` ne contient aucun nom de domaine, seulement des
+  identifiants et des URL venus du manifeste ou de la ligne de commande.
+
 ### Corrigé
 
 - **Le garde-fou de publication n'était pas fiable, de deux façons, toutes deux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.67] - 2026-08-24
+
+### Added
+
+- **`dsoxlab catalog`: install a catalog, and use it from anywhere** (issue
+  #78). Separating the engine from the catalogs is a sound architectural
+  decision, but it was left entirely to the user: nothing said which catalogs
+  exist, how to install one, or that dsoxlab had to be run from inside the
+  cloned directory. Five subcommands close that gap:
+
+  ```console
+  $ dsoxlab catalog list              # known catalogs, and the installed ones
+  $ dsoxlab catalog add linux         # clone it, and make it active
+  $ cd ~ && dsoxlab list-labs         # works, with no cd into the catalog
+  $ dsoxlab catalog use ansible       # switch the active one
+  $ dsoxlab catalog update [<id>]     # update one, or all of them
+  $ dsoxlab catalog remove <id>       # remove one
+  ```
+
+  **The current directory keeps priority.** The active catalog is consulted
+  *after* walking up from the working directory, never before: someone sitting
+  in a hand-cloned catalog expects to work on that one. The reverse would mean
+  a `catalog add` silently changing what a `dsoxlab check` does inside an
+  existing repository — a side effect that is mute, remote, and on the command
+  that grades the work.
+
+  The registry of known catalogs is a **manifest packaged with the tool**
+  (`templates/catalogues.yml`), not a remote service: a registry is a component
+  to host, monitor and keep available, for a project that today has three
+  catalogs. A versioned manifest also has a merit a service does not — it is
+  reviewable in a pull request, so proposing a third-party catalog becomes an
+  ordinary contribution. Any git URL is accepted too, including one absent from
+  the manifest: the manifest aids discovery, it restricts nothing.
+
+  The engine stays domain-agnostic, and a test enforces it: `services/catalog.py`
+  contains no domain name at all, only ids and URLs read from the manifest or
+  the command line.
+
 ### Fixed
 
 - **The release guard was unreliable in two ways, both observed while shipping

--- a/docs/commands.fr.md
+++ b/docs/commands.fr.md
@@ -18,6 +18,11 @@ complet de la plateforme dans le terminal, `dsoxlab fullhelp`.
 
 | Commande | Rôle |
 | --- | --- |
+| `dsoxlab catalog add` | Installe un catalogue par son nom ou par l'URL de son dépôt. |
+| `dsoxlab catalog list` | Liste les catalogues connus et ceux qui sont installés. |
+| `dsoxlab catalog remove` | Retire un catalogue installé. |
+| `dsoxlab catalog update` | Met à jour un catalogue installé (tous, si aucun n'est nommé). |
+| `dsoxlab catalog use` | Choisit le catalogue actif, celui qu'on utilise hors de son répertoire. |
 | `dsoxlab challenge` | Affiche la mission du challenge (challenge/README.md). |
 | `dsoxlab check` | Exécute les tests, calcule le score (hints déduits) et enregistre le résultat. |
 | `dsoxlab clean` | Supprime toutes les ressources créées par le lab. |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,6 +17,11 @@ guide in the terminal, `dsoxlab fullhelp`.
 
 | Command | Purpose |
 | --- | --- |
+| `dsoxlab catalog add` | Install a catalogue by name, or by its repository URL. |
+| `dsoxlab catalog list` | List known catalogues and the ones installed. |
+| `dsoxlab catalog remove` | Remove an installed catalogue. |
+| `dsoxlab catalog update` | Update an installed catalogue (all of them if none is named). |
+| `dsoxlab catalog use` | Choose the active catalogue, the one used outside its directory. |
 | `dsoxlab challenge` | Display the challenge mission for this lab (challenge/README.md). |
 | `dsoxlab check` | Run tests, calculate score (hints deducted) and record result. |
 | `dsoxlab clean` | Remove all resources created by the lab. |

--- a/docs/files.fr.md
+++ b/docs/files.fr.md
@@ -42,6 +42,8 @@ sous `<catalogue>/ssh/id_ed25519` et son `.pub`, produite par
 | `~/.cache/dsoxlab/<catalog-id>/ssh_config` | Configuration OpenSSH générée pour les hôtes du lab | `XDG_CACHE_HOME` |
 | `~/.cache/dsoxlab/version-check.json` | Dernière version vue sur PyPI, et sa date | `XDG_CACHE_HOME` |
 | `~/.local/share/dsoxlab/demo/` | Catalogue de démonstration installé par `dsoxlab demo` | `XDG_DATA_HOME` |
+| `~/.local/share/dsoxlab/catalogs/` | Catalogues installés par `dsoxlab catalog add`, un sous-répertoire par identifiant | `XDG_DATA_HOME` |
+| `~/.local/state/dsoxlab/catalogue-actif` | Identifiant du catalogue actif, celui qu'on utilise sans se placer dans son répertoire | `XDG_STATE_HOME` |
 | `~/.ssh/config.d/<catalog-id>.conf` | Fragment SSH des hôtes du lab, pour que `ssh`, `scp` et votre IDE les atteignent par leur nom | aucune |
 
 `<catalog-id>` est le `repo.id` du `meta.yml` du catalogue. Le verrou retombe

--- a/docs/files.md
+++ b/docs/files.md
@@ -41,6 +41,8 @@ The private half must never be committed.
 | `~/.cache/dsoxlab/<catalog-id>/ssh_config` | generated OpenSSH config for the lab hosts | `XDG_CACHE_HOME` |
 | `~/.cache/dsoxlab/version-check.json` | last version seen on PyPI, and when | `XDG_CACHE_HOME` |
 | `~/.local/share/dsoxlab/demo/` | demonstration catalog installed by `dsoxlab demo` | `XDG_DATA_HOME` |
+| `~/.local/share/dsoxlab/catalogs/` | catalogs installed by `dsoxlab catalog add`, one subdirectory per id | `XDG_DATA_HOME` |
+| `~/.local/state/dsoxlab/catalogue-actif` | id of the active catalog, the one used without sitting in its directory | `XDG_STATE_HOME` |
 | `~/.ssh/config.d/<catalog-id>.conf` | SSH fragment for the lab hosts, so `ssh`, `scp` and your IDE reach them by name | none |
 
 `<catalog-id>` is `repo.id` from the catalog's `meta.yml`. The lock falls back

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.66"
+version = "0.1.67"
 description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/generer-doc.py
+++ b/scripts/generer-doc.py
@@ -147,7 +147,7 @@ from pathlib import Path
 from dsoxlab import config, locking, logging_setup
 from dsoxlab.discovery.repo import read_repo_metadata
 from dsoxlab.infra import inventory, terraform
-from dsoxlab.services import demo, update_check
+from dsoxlab.services import catalog, demo, update_check
 from dsoxlab.sessions import store
 from dsoxlab.templates import template_root
 
@@ -201,6 +201,8 @@ with tempfile.TemporaryDirectory() as tmp:
         locking.lock_path(racine),
         demo.destination(),
         update_check.cache_path(),
+        catalog.racine_catalogues(),
+        catalog._fichier_actif(),
     ))
 
 rendus.update(str(p) for p in maison.rglob("*"))

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -211,6 +211,17 @@ completion_app = typer.Typer(
 )
 app.add_typer(completion_app, name="completion")
 
+# ── Sous-application 'catalog' ────────────────────────────────────────────────
+
+catalog_app = typer.Typer(
+    name="catalog",
+    help=_("cmd_catalog_help"),
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+    cls=_I18nGroup,
+)
+app.add_typer(catalog_app, name="catalog")
+
 # ── Option globale lab-home ───────────────────────────────────────────────────
 
 LabHomeOption = Annotated[
@@ -3017,6 +3028,128 @@ def demo(
     # installé : elle ne peut donc pas décrire un lab qui n'y serait plus.
     premier = installation.labs[0] if installation.labs else ""
     info(_("demo_suite", path=str(installation.racine), lab=premier))
+
+
+# ── catalog ───────────────────────────────────────────────────────────────────
+
+@catalog_app.command("list", help=_("cmd_catalog_list_help"))
+def catalog_list(
+    as_json: Annotated[bool, typer.Option("--json", help=_("opt_json"))] = False,
+) -> None:
+    """Les catalogues connus, et ceux qui sont installés."""
+    from .i18n import get_lang
+    from .reporting.console import print_catalogues
+    from .services.catalog import installes, lire_manifeste
+
+    connus = lire_manifeste()
+    poses = installes()
+
+    if as_json:
+        machine.emit({
+            "schema": 1,
+            "known": [
+                {"id": c.id, "repository": c.depot,
+                 "description": c.description(get_lang())}
+                for c in connus
+            ],
+            "installed": [
+                {"id": p.id, "path": str(p.racine),
+                 "active": p.actif, "repository": p.depot}
+                for p in poses
+            ],
+        })
+        return
+
+    print_catalogues(connus, poses, get_lang())
+
+
+@catalog_app.command("add", help=_("cmd_catalog_add_help"))
+def catalog_add(
+    reference: Annotated[str, typer.Argument(help=_("arg_catalog_reference"))],
+    force: Annotated[
+        bool, typer.Option("--force", help=_("opt_catalog_force"))
+    ] = False,
+) -> None:
+    """Installe un catalogue et le rend actif."""
+    from .services.catalog import CatalogueError, ajouter, resoudre
+
+    try:
+        identifiant, url = resoudre(reference)
+        info(_("catalog_installation", name=identifiant, url=url))
+        pose = ajouter(reference, force=force)
+    except CatalogueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from None
+
+    success(_("catalog_installe", name=pose.id, path=str(pose.racine)))
+    info(_("catalog_installe_suite"))
+
+
+@catalog_app.command("update", help=_("cmd_catalog_update_help"))
+def catalog_update(
+    identifiant: Annotated[
+        str | None, typer.Argument(help=_("arg_catalog_id"))
+    ] = None,
+) -> None:
+    """Met à jour un catalogue, ou tous ceux qui sont installés."""
+    from .services.catalog import CatalogueError, installes, mettre_a_jour
+
+    cibles = [identifiant] if identifiant else [p.id for p in installes()]
+    if not cibles:
+        info(_("catalog_aucun_installe"))
+        return
+
+    echecs = 0
+    for cible in cibles:
+        try:
+            detail = mettre_a_jour(cible)
+        except CatalogueError as exc:
+            error(str(exc))
+            echecs += 1
+            continue
+        # git dit « Already up to date. » quand il n'a rien fait : le répéter
+        # tel quel obligerait à lire de l'anglais dans une session française.
+        if "up to date" in detail.lower() or not detail:
+            info(_("catalog_a_jour", name=cible))
+        else:
+            success(_("catalog_mis_a_jour", name=cible, detail=detail))
+
+    # Une mise à jour ratée parmi plusieurs doit se voir dans le code de
+    # retour : un script qui enchaîne ne lit pas l'écran.
+    if echecs:
+        raise typer.Exit(1)
+
+
+@catalog_app.command("remove", help=_("cmd_catalog_remove_help"))
+def catalog_remove(
+    identifiant: Annotated[str, typer.Argument(help=_("arg_catalog_id"))],
+) -> None:
+    """Retire un catalogue installé."""
+    from .services.catalog import CatalogueError, retirer
+
+    try:
+        racine = retirer(identifiant)
+    except CatalogueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from None
+
+    success(_("catalog_retire", name=identifiant, path=str(racine)))
+
+
+@catalog_app.command("use", help=_("cmd_catalog_use_help"))
+def catalog_use(
+    identifiant: Annotated[str, typer.Argument(help=_("arg_catalog_id"))],
+) -> None:
+    """Choisit le catalogue actif."""
+    from .services.catalog import CatalogueError, definir_actif
+
+    try:
+        racine = definir_actif(identifiant)
+    except CatalogueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from None
+
+    success(_("catalog_actif_defini", name=identifiant, path=str(racine)))
 
 
 # ── support ───────────────────────────────────────────────────────────────────

--- a/src/dsoxlab/config.py
+++ b/src/dsoxlab/config.py
@@ -220,7 +220,16 @@ def get_lab_home() -> Path:
 
     1. Variable d'environnement ``LAB_HOME`` (chemin explicite).
     2. Remontée depuis le CWD pour trouver ``meta.yml`` (mode framework).
-    3. CWD lui-même (fallback).
+    3. Le catalogue **actif**, celui que ``dsoxlab catalog add`` ou
+       ``catalog use`` a désigné.
+    4. CWD lui-même (fallback).
+
+    L'étape 3 vient **après** le CWD, et jamais avant : quelqu'un qui se place
+    dans un catalogue cloné à la main s'attend à travailler dessus, quel que
+    soit ce qu'il a installé par ailleurs. L'inverse ferait qu'un
+    ``catalog add`` changerait silencieusement ce que fait un ``dsoxlab check``
+    lancé dans un dépôt existant, ce qui est le pire des effets de bord : muet,
+    à distance, et sur la commande qui note le travail.
 
     `dsoxlab` étant installé globalement (ex. ``uv tool install``), il
     fonctionne depuis le CWD où l'apprenant s'est placé : un dépôt
@@ -241,6 +250,14 @@ def get_lab_home() -> Path:
         if parent == current:
             break
         current = parent
+
+    # Le catalogue actif, s'il en existe un. Import local : `services.catalog`
+    # importe ce module, et l'import au sommet serait circulaire.
+    from .services.catalog import racine_active
+
+    active = racine_active()
+    if active is not None:
+        return active
 
     # Fallback : CWD (utile pour les tests ou les dépôts sans meta.yml).
     return cwd

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -111,6 +111,65 @@ STRINGS: dict[str, str] = {
         "  dsoxlab course {lab}\n"
         "  dsoxlab run {lab}\n"
         "Then, once the mission is done: dsoxlab check {lab}",
+
+    # ── catalog: discover, install and locate a catalogue ───────────────────
+    "cmd_catalog_help":
+        "Discover, install and update lab catalogues.",
+    "cmd_catalog_list_help":
+        "List known catalogues and the ones installed.",
+    "cmd_catalog_add_help":
+        "Install a catalogue by name, or by its repository URL.",
+    "cmd_catalog_update_help":
+        "Update an installed catalogue (all of them if none is named).",
+    "cmd_catalog_remove_help":
+        "Remove an installed catalogue.",
+    "arg_catalog_reference":
+        "Id from the manifest (dsoxlab catalog list), or a git repository URL.",
+    "arg_catalog_id":
+        "Id of an installed catalogue.",
+    "cmd_catalog_use_help":
+        "Choose the active catalogue, the one used outside its directory.",
+    "opt_catalog_force":
+        "Reinstall over an existing catalogue (any work in it is lost).",
+    "catalog_titre_connus": "Known catalogues",
+    "catalog_titre_installes": "Installed catalogues",
+    "catalog_col_id": "Id",
+    "catalog_col_description": "Description",
+    "catalog_col_depot": "Repository",
+    "catalog_col_chemin": "Path",
+    "catalog_col_actif": "Active",
+    "catalog_aucun_installe":
+        "No catalogue installed. Install one: dsoxlab catalog add <id>",
+    "catalog_installation": "Installing {name} from {url}…",
+    "catalog_installe":
+        "Catalogue '{name}' installed in {path}, and made active.",
+    "catalog_installe_suite":
+        "It is usable from any directory:\n"
+        "  dsoxlab list-labs\n"
+        "  dsoxlab next",
+    "catalog_actif_defini": "Active catalogue: '{name}' ({path})",
+    "catalog_retire": "Catalogue '{name}' removed ({path}).",
+    "catalog_a_jour": "Catalogue '{name}' is up to date.",
+    "catalog_mis_a_jour": "Catalogue '{name}' updated: {detail}",
+    "catalog_inconnu":
+        "Unknown catalogue '{name}'. List them with dsoxlab catalog list, "
+        "or pass its repository URL.",
+    "catalog_absent":
+        "No catalogue '{name}' installed. See: dsoxlab catalog list",
+    "catalog_deja_installe":
+        "Catalogue '{name}' is already installed in {path}. "
+        "Update it (dsoxlab catalog update {name}), or reinstall with --force, "
+        "which loses the progress and the work it holds.",
+    "catalog_clone_echec":
+        "Cloning {url} failed:\n{detail}",
+    "catalog_sans_meta":
+        "Repository {url} has no meta.yml at its root: it is not a dsoxlab "
+        "catalogue.",
+    "catalog_id_invalide":
+        "'{name}' cannot be used as a catalogue id.",
+    "catalog_update_echec":
+        "Updating '{name}' failed:\n{detail}",
+
     "cmd_support_help":
         "Produce an anonymised diagnostic report, ready to paste into an issue.",
     "opt_support_log_lines":
@@ -391,6 +450,17 @@ Each lab declares:
   [cyan]demo[/cyan]                 Install a demonstration catalog and a first lab you can
                        play right away, with nothing to clone or provision.
     [dim]--force[/dim]              Reinstall over it (loses progress).
+
+  [cyan]catalog list[/cyan]         Known catalogues, and the ones installed.
+    [dim]--json[/dim]               Machine document instead of tables.
+  [cyan]catalog add <id|url>[/cyan] Installs a catalogue and makes it active. The id comes
+                       from the packaged manifest; any git URL is accepted too,
+                       the manifest restricts nothing.
+    [dim]--force[/dim]              Reinstall over it (loses progress).
+  [cyan]catalog use <id>[/cyan]     Chooses the active catalogue, the one used without
+                       having to sit in its directory.
+  [cyan]catalog update [id][/cyan]  Updates one installed catalogue, or all of them.
+  [cyan]catalog remove <id>[/cyan]  Removes an installed catalogue.
 
   [cyan]provision[/cyan]            Bring up the infrastructure for vm labs (terraform apply).
                        Refuses to start when machines left by a failed

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -112,6 +112,65 @@ STRINGS: dict[str, str] = {
         "  dsoxlab course {lab}\n"
         "  dsoxlab run {lab}\n"
         "Puis, une fois la mission remplie : dsoxlab check {lab}",
+
+    # ── catalog : découvrir, installer et retrouver un catalogue ────────────
+    "cmd_catalog_help":
+        "Découvre, installe et met à jour les catalogues de labs.",
+    "cmd_catalog_list_help":
+        "Liste les catalogues connus et ceux qui sont installés.",
+    "cmd_catalog_add_help":
+        "Installe un catalogue par son nom ou par l'URL de son dépôt.",
+    "cmd_catalog_update_help":
+        "Met à jour un catalogue installé (tous, si aucun n'est nommé).",
+    "cmd_catalog_remove_help":
+        "Retire un catalogue installé.",
+    "arg_catalog_reference":
+        "Identifiant du manifeste (dsoxlab catalog list), ou URL d'un dépôt git.",
+    "arg_catalog_id":
+        "Identifiant d'un catalogue installé.",
+    "cmd_catalog_use_help":
+        "Choisit le catalogue actif, celui qu'on utilise hors de son répertoire.",
+    "opt_catalog_force":
+        "Réinstaller par-dessus un catalogue déjà présent (le travail y est perdu).",
+    "catalog_titre_connus": "Catalogues connus",
+    "catalog_titre_installes": "Catalogues installés",
+    "catalog_col_id": "Identifiant",
+    "catalog_col_description": "Description",
+    "catalog_col_depot": "Dépôt",
+    "catalog_col_chemin": "Chemin",
+    "catalog_col_actif": "Actif",
+    "catalog_aucun_installe":
+        "Aucun catalogue installé. Installe-en un : dsoxlab catalog add <id>",
+    "catalog_installation": "Installation de {name} depuis {url}…",
+    "catalog_installe":
+        "Catalogue « {name} » installé dans {path}, et rendu actif.",
+    "catalog_installe_suite":
+        "Il est utilisable depuis n'importe quel répertoire :\n"
+        "  dsoxlab list-labs\n"
+        "  dsoxlab next",
+    "catalog_actif_defini": "Catalogue actif : « {name} » ({path})",
+    "catalog_retire": "Catalogue « {name} » retiré ({path}).",
+    "catalog_a_jour": "Catalogue « {name} » à jour.",
+    "catalog_mis_a_jour": "Catalogue « {name} » mis à jour : {detail}",
+    "catalog_inconnu":
+        "Catalogue « {name} » inconnu. Liste-les : dsoxlab catalog list, "
+        "ou donne l'URL de son dépôt.",
+    "catalog_absent":
+        "Aucun catalogue « {name} » installé. Vois : dsoxlab catalog list",
+    "catalog_deja_installe":
+        "Le catalogue « {name} » est déjà installé dans {path}. "
+        "Mets-le à jour (dsoxlab catalog update {name}), ou réinstalle-le "
+        "avec --force, ce qui perd la progression et le travail qui s'y trouvent.",
+    "catalog_clone_echec":
+        "Le clone de {url} a échoué :\n{detail}",
+    "catalog_sans_meta":
+        "Le dépôt {url} ne porte pas de meta.yml à sa racine : ce n'est pas "
+        "un catalogue dsoxlab.",
+    "catalog_id_invalide":
+        "« {name} » ne peut pas servir d'identifiant de catalogue.",
+    "catalog_update_echec":
+        "La mise à jour de « {name} » a échoué :\n{detail}",
+
     "cmd_support_help":
         "Produit un rapport de diagnostic anonymisé, à coller dans une issue.",
     "opt_support_log_lines":
@@ -394,6 +453,17 @@ Chaque lab déclare :
   [cyan]demo[/cyan]                 Installe un catalogue de démonstration et un premier lab
                        jouable immédiatement, sans rien cloner ni provisionner.
     [dim]--force[/dim]              Réinstalle par-dessus (perd la progression).
+
+  [cyan]catalog list[/cyan]         Les catalogues connus, et ceux qui sont installés.
+    [dim]--json[/dim]               Document machine plutôt que tableaux.
+  [cyan]catalog add <id|url>[/cyan] Installe un catalogue et le rend actif. L'identifiant
+                       vient du manifeste packagé ; une URL git quelconque est
+                       acceptée aussi, le manifeste ne restreint rien.
+    [dim]--force[/dim]              Réinstalle par-dessus (perd la progression).
+  [cyan]catalog use <id>[/cyan]     Choisit le catalogue actif, celui qu'on utilise sans
+                       avoir à se placer dans son répertoire.
+  [cyan]catalog update [id][/cyan]  Met à jour un catalogue installé, ou tous.
+  [cyan]catalog remove <id>[/cyan]  Retire un catalogue installé.
 
   [cyan]provision[/cyan]            Monte l'infrastructure des labs vm (terraform apply).
                        Refuse de démarrer quand des machines laissées par un

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -21,6 +21,7 @@ from rich.tree import Tree
 from ..i18n import _
 from ..models.course import CourseManifest, CourseSection
 from ..models.lab import LabDefinition
+from ..services.catalog import CatalogueConnu, CatalogueInstalle
 from ..services.doctor import STATE_CHOICE_REQUIRED, Check, DoctorReport
 from ..services.progress_service import build_progress, exam_verdict
 from ..validators.structure import StructureReport
@@ -312,6 +313,39 @@ def _doctor_table(title: str, checks: list[Check], *, blocking: bool) -> Table:
         remediation = "" if check.ok else f"[dim]{check.remediation}[/dim]"
         table.add_row(check.label, status, check.detail, remediation)
     return table
+
+
+def print_catalogues(
+    connus: list[CatalogueConnu],
+    installes: list[CatalogueInstalle],
+    lang: str,
+) -> None:
+    """Les catalogues connus, puis ceux qui sont installés.
+
+    Deux tableaux plutôt qu'une colonne « installé ? » : les deux listes ne se
+    recouvrent pas nécessairement, un catalogue pouvant être installé depuis une
+    URL absente du manifeste.
+    """
+    if connus:
+        table = Table(title=_("catalog_titre_connus"), show_header=True)
+        table.add_column(_("catalog_col_id"))
+        table.add_column(_("catalog_col_description"))
+        table.add_column(_("catalog_col_depot"), style="dim")
+        for connu in connus:
+            table.add_row(connu.id, connu.description(lang), connu.depot)
+        console.print(table)
+
+    if not installes:
+        console.print(f"[dim]{_('catalog_aucun_installe')}[/dim]")
+        return
+
+    table = Table(title=_("catalog_titre_installes"), show_header=True)
+    table.add_column(_("catalog_col_id"))
+    table.add_column(_("catalog_col_actif"), justify="center")
+    table.add_column(_("catalog_col_chemin"), style="dim")
+    for pose in installes:
+        table.add_row(pose.id, "✔" if pose.actif else "", str(pose.racine))
+    console.print(table)
 
 
 def print_doctor(report: DoctorReport) -> None:

--- a/src/dsoxlab/services/catalog.py
+++ b/src/dsoxlab/services/catalog.py
@@ -1,0 +1,286 @@
+"""Découvrir, installer et retrouver les catalogues de labs.
+
+Le moteur et les catalogues sont séparés à dessein, mais cette séparation était
+entièrement à la charge de l'utilisateur : rien ne disait quels catalogues
+existent, comment en installer un, ni où se placer pour l'utiliser. Il fallait
+avoir lu le README, retenu une URL, et compris que la découverte se fait depuis
+le répertoire courant.
+
+Trois emplacements, et chacun pour une raison :
+
+- le **manifeste** des catalogues connus est packagé avec l'outil, donc révisable
+  en pull request (`templates/catalogues.yml`) ;
+- les catalogues **installés** vivent sous ``XDG_DATA_HOME``, comme le catalogue
+  de démonstration : ce sont des contenus que l'utilisateur modifie et dont il
+  attend qu'ils survivent, pas des caches recalculables ;
+- le catalogue **actif** est un état, donc sous ``XDG_STATE_HOME`` : le perdre ne
+  coûte qu'un ``dsoxlab catalog use``, jamais du travail.
+
+Ce module reste neutre vis-à-vis des domaines : il ne connaît que des
+identifiants et des URL, tous venus du manifeste ou de la ligne de commande.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from ..config import xdg_data_home, xdg_state_home
+from ..i18n import _
+from ..templates import catalogues_manifeste
+from ..utils.shell import run_command
+
+#: Un identifiant de catalogue sert de nom de répertoire : on le borne pour
+#: qu'il ne puisse ni remonter l'arborescence, ni porter d'espace.
+_ID_VALIDE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+#: Ce qui ressemble à une URL de dépôt plutôt qu'à un identifiant du manifeste.
+_URL = re.compile(r"^(https?://|git@|ssh://|git://|file://)")
+
+
+class CatalogueError(RuntimeError):
+    """Une opération de catalogue a échoué, avec un message déjà traduit."""
+
+
+@dataclass(frozen=True)
+class CatalogueConnu:
+    """Une entrée du manifeste packagé."""
+
+    id: str
+    depot: str
+    description_en: str = ""
+    description_fr: str = ""
+
+    def description(self, lang: str) -> str:
+        return self.description_fr if lang == "fr" else self.description_en
+
+
+@dataclass(frozen=True)
+class CatalogueInstalle:
+    """Un catalogue présent sur le disque."""
+
+    id: str
+    racine: Path
+    actif: bool
+    depot: str | None = None
+
+
+def racine_catalogues() -> Path:
+    """Où les catalogues installés vivent."""
+    return xdg_data_home() / "dsoxlab" / "catalogs"
+
+
+def _fichier_actif() -> Path:
+    """Le fichier qui retient le catalogue actif.
+
+    Un fichier d'une ligne plutôt qu'une entrée dans un format structuré : ce
+    qu'il porte tient en un identifiant, et il doit rester lisible et
+    supprimable à la main quand quelque chose va mal.
+    """
+    return xdg_state_home() / "dsoxlab" / "catalogue-actif"
+
+
+def lire_manifeste() -> list[CatalogueConnu]:
+    """Les catalogues connus, lus dans le manifeste packagé.
+
+    Un manifeste illisible ne doit pas emporter la commande : l'utilisateur peut
+    toujours installer un catalogue par son URL, et `catalog list` doit encore
+    pouvoir montrer ce qui est installé.
+    """
+    chemin = catalogues_manifeste()
+    try:
+        document = yaml.safe_load(chemin.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return []
+    entrees = document.get("catalogues")
+    if not isinstance(entrees, list):
+        return []
+
+    connus: list[CatalogueConnu] = []
+    for entree in entrees:
+        if not isinstance(entree, dict):
+            continue
+        identifiant = entree.get("id")
+        depot = entree.get("depot")
+        if not isinstance(identifiant, str) or not isinstance(depot, str):
+            continue
+        connus.append(CatalogueConnu(
+            id=identifiant,
+            depot=depot,
+            description_en=str(entree.get("description_en") or ""),
+            description_fr=str(entree.get("description_fr") or ""),
+        ))
+    return connus
+
+
+def _est_un_catalogue(racine: Path) -> bool:
+    """Un catalogue est un répertoire qui porte un ``meta.yml``.
+
+    Même critère que la découverte par le répertoire courant : un répertoire
+    laissé par un clone interrompu n'en est pas un, et ne doit pas être proposé.
+    """
+    return (racine / "meta.yml").is_file()
+
+
+def _origine(racine: Path) -> str | None:
+    """L'URL d'origine d'un catalogue cloné, si git la connaît."""
+    res = run_command(
+        ["git", "-C", str(racine), "remote", "get-url", "origin"],
+        check=False, timeout=15,
+    )
+    return res.stdout.strip() if res.ok and res.stdout.strip() else None
+
+
+def installes() -> list[CatalogueInstalle]:
+    """Les catalogues présents sur le disque, l'actif marqué comme tel."""
+    racine = racine_catalogues()
+    if not racine.is_dir():
+        return []
+    actif = nom_actif()
+    trouves: list[CatalogueInstalle] = []
+    for chemin in sorted(racine.iterdir()):
+        if not chemin.is_dir() or not _est_un_catalogue(chemin):
+            continue
+        trouves.append(CatalogueInstalle(
+            id=chemin.name,
+            racine=chemin,
+            actif=chemin.name == actif,
+            depot=_origine(chemin),
+        ))
+    return trouves
+
+
+def nom_actif() -> str | None:
+    """L'identifiant du catalogue actif, ou None.
+
+    Un actif qui ne correspond plus à rien d'installé est traité comme absent :
+    l'utilisateur a pu retirer le répertoire à la main, et une commande ne doit
+    pas échouer sur un état que l'outil peut recalculer.
+    """
+    fichier = _fichier_actif()
+    try:
+        nom = fichier.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not nom or not _ID_VALIDE.match(nom):
+        return None
+    return nom if _est_un_catalogue(racine_catalogues() / nom) else None
+
+
+def racine_active() -> Path | None:
+    """La racine du catalogue actif, si elle existe encore."""
+    nom = nom_actif()
+    return racine_catalogues() / nom if nom else None
+
+
+def definir_actif(identifiant: str) -> Path:
+    """Rend un catalogue actif. Il doit être installé."""
+    racine = racine_catalogues() / identifiant
+    if not _ID_VALIDE.match(identifiant) or not _est_un_catalogue(racine):
+        raise CatalogueError(_("catalog_absent", name=identifiant))
+    fichier = _fichier_actif()
+    fichier.parent.mkdir(parents=True, exist_ok=True)
+    fichier.write_text(identifiant + "\n", encoding="utf-8")
+    return racine
+
+
+def _oublier_actif_si(identifiant: str) -> None:
+    """Retire la marque d'actif si elle désigne ce catalogue."""
+    fichier = _fichier_actif()
+    try:
+        if fichier.read_text(encoding="utf-8").strip() == identifiant:
+            fichier.unlink()
+    except OSError:
+        return
+
+
+def _identifiant_depuis_url(url: str) -> str:
+    """Déduit un identifiant du dernier segment d'une URL de dépôt."""
+    segment = url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
+    identifiant = segment.lower()
+    if not _ID_VALIDE.match(identifiant):
+        raise CatalogueError(_("catalog_id_invalide", name=segment))
+    return identifiant
+
+
+def resoudre(reference: str) -> tuple[str, str]:
+    """Rend (identifiant, url) pour un nom du manifeste ou une URL brute.
+
+    Une URL absente du manifeste est acceptée : le manifeste facilite la
+    découverte, il ne restreint pas ce qu'on peut installer.
+    """
+    if _URL.match(reference):
+        return _identifiant_depuis_url(reference), reference
+    for connu in lire_manifeste():
+        if connu.id == reference:
+            return connu.id, connu.depot
+    raise CatalogueError(_("catalog_inconnu", name=reference))
+
+
+def ajouter(reference: str, *, force: bool = False) -> CatalogueInstalle:
+    """Installe un catalogue par clone, et le rend actif.
+
+    Le rendre actif est le geste qui évite d'avoir à se placer dans son
+    répertoire ensuite : sans lui, l'installation ne changerait rien à ce que
+    l'utilisateur doit savoir.
+    """
+    identifiant, url = resoudre(reference)
+    destination = racine_catalogues() / identifiant
+
+    if destination.exists():
+        if not force:
+            # Ne pas écraser : ce répertoire porte la progression et le travail.
+            raise CatalogueError(_("catalog_deja_installe",
+                                   name=identifiant, path=str(destination)))
+        shutil.rmtree(destination)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    res = run_command(
+        ["git", "clone", "--depth", "1", url, str(destination)],
+        check=False, timeout=900,
+    )
+    if not res.ok:
+        # Un clone à moitié fait laisserait un répertoire qui n'est pas un
+        # catalogue, que `list` montrerait comme installé.
+        shutil.rmtree(destination, ignore_errors=True)
+        raise CatalogueError(_("catalog_clone_echec",
+                               url=url, detail=res.stderr.strip()))
+
+    if not _est_un_catalogue(destination):
+        shutil.rmtree(destination, ignore_errors=True)
+        raise CatalogueError(_("catalog_sans_meta", url=url))
+
+    definir_actif(identifiant)
+    return CatalogueInstalle(id=identifiant, racine=destination,
+                             actif=True, depot=url)
+
+
+def mettre_a_jour(identifiant: str) -> str:
+    """Met un catalogue à jour, et rend ce que git a fait."""
+    racine = racine_catalogues() / identifiant
+    if not _ID_VALIDE.match(identifiant) or not _est_un_catalogue(racine):
+        raise CatalogueError(_("catalog_absent", name=identifiant))
+
+    res = run_command(
+        ["git", "-C", str(racine), "pull", "--ff-only"],
+        check=False, timeout=600,
+    )
+    if not res.ok:
+        raise CatalogueError(_("catalog_update_echec",
+                               name=identifiant,
+                               detail=(res.stderr or res.stdout).strip()))
+    return res.stdout.strip()
+
+
+def retirer(identifiant: str) -> Path:
+    """Retire un catalogue du disque."""
+    racine = racine_catalogues() / identifiant
+    if not _ID_VALIDE.match(identifiant) or not racine.is_dir():
+        raise CatalogueError(_("catalog_absent", name=identifiant))
+    shutil.rmtree(racine)
+    _oublier_actif_si(identifiant)
+    return racine

--- a/src/dsoxlab/templates/__init__.py
+++ b/src/dsoxlab/templates/__init__.py
@@ -56,6 +56,22 @@ def demo_catalog() -> Path:
     return template_root() / "demo"
 
 
+def catalogues_manifeste() -> Path:
+    """Le manifeste des catalogues connus, packagé avec l'outil.
+
+    C'est une **donnée**, pas de la logique : le moteur y lit des noms, des URL
+    et des descriptions, sans jamais en tirer de décision propre à un domaine.
+    L'agnosticisme tient à cette frontière, et un `if id == "linux"` dans le
+    code la romprait.
+
+    Packagé plutôt que distant, parce qu'un registre est un service à héberger
+    et à maintenir disponible pour trois catalogues, et parce qu'un fichier
+    versionné se révise en pull request : proposer un catalogue tiers devient
+    une contribution ordinaire.
+    """
+    return template_root() / "catalogues.yml"
+
+
 def terraform_template(provider: str) -> Path:
     """Retourne le chemin du template Terraform pour un provider.
 

--- a/src/dsoxlab/templates/catalogues.yml
+++ b/src/dsoxlab/templates/catalogues.yml
@@ -1,0 +1,33 @@
+# Catalogues connus de dsoxlab.
+#
+# Ce fichier est une DONNÉE, pas de la logique : le moteur ne lit ici que des
+# noms, des URL et des descriptions, et n'en tire aucune décision propre à un
+# domaine. Écrire `if nom == "linux"` dans le code romprait l'agnosticisme que
+# ce fichier existe précisément pour préserver.
+#
+# Pourquoi un fichier packagé plutôt qu'un registre distant : un registre est un
+# service à héberger, surveiller et maintenir disponible, pour un projet qui
+# compte aujourd'hui trois catalogues. Un manifeste versionné a de plus un
+# mérite qu'un service n'a pas — il est révisable en pull request : proposer un
+# catalogue tiers devient une contribution ordinaire, relue comme le reste.
+#
+# `dsoxlab catalog add <url>` accepte n'importe quelle URL git, y compris
+# absente d'ici : ce fichier facilite la découverte, il ne restreint rien.
+
+schema_version: 1
+
+catalogues:
+  - id: linux
+    depot: https://github.com/stephrobert/linux-dsoxlab-training
+    description_en: Linux administration, RHCSA and LFCS
+    description_fr: Administration Linux, RHCSA et LFCS
+
+  - id: ansible
+    depot: https://github.com/stephrobert/ansible-training
+    description_en: Ansible, from first playbook to collections
+    description_fr: Ansible, du premier playbook aux collections
+
+  - id: terraform
+    depot: https://github.com/stephrobert/terraform-training
+    description_en: Terraform and infrastructure as code
+    description_fr: Terraform et l'infrastructure as code

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,307 @@
+"""Découvrir, installer et retrouver un catalogue de labs (issue #78).
+
+La séparation moteur / catalogues est une bonne décision d'architecture, mais
+elle était entièrement à la charge de l'utilisateur : rien ne disait quels
+catalogues existent, comment en installer un, ni où se placer pour l'utiliser.
+
+Ce module couvre les cinq commandes et, surtout, la **résolution** : c'est elle
+qui touche `get_lab_home()`, donc le chemin critique de toutes les autres
+commandes. Deux invariants s'y opposent et doivent tenir ensemble :
+
+- un catalogue installé se trouve depuis n'importe quel répertoire ;
+- le répertoire courant reste prioritaire, pour qu'aucun catalogue déjà cloné
+  ne cesse de fonctionner du jour où l'on en installe un autre.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from dsoxlab.config import get_lab_home
+from dsoxlab.services import catalog
+
+
+@pytest.fixture(autouse=True)
+def xdg_jetable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Un XDG jetable : aucun test ne doit écrire dans le vrai ~/.local."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.delenv("LAB_HOME", raising=False)
+    return tmp_path
+
+
+def _depot_git(racine: Path, *, avec_meta: bool = True) -> Path:
+    """Un dépôt git local qui tient lieu de catalogue distant."""
+    racine.mkdir(parents=True, exist_ok=True)
+    if avec_meta:
+        (racine / "meta.yml").write_text(
+            "repo:\n  id: essai\n  category: essai\n", encoding="utf-8")
+    else:
+        (racine / "LISEZMOI.md").write_text("pas un catalogue\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q", str(racine)], check=True, timeout=30)
+    subprocess.run(["git", "-C", str(racine), "add", "-A"], check=True, timeout=30)
+    subprocess.run(
+        ["git", "-C", str(racine), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-qm", "initial"],
+        check=True, timeout=30,
+    )
+    return racine
+
+
+# ── Le manifeste packagé ────────────────────────────────────────────────────
+
+def test_le_manifeste_packagé_est_lisible() -> None:
+    """Garde-fou : un manifeste illisible rendrait tous les tests suivants vides."""
+    connus = catalog.lire_manifeste()
+    assert connus, "le manifeste packagé doit déclarer au moins un catalogue"
+    assert all(c.id and c.depot for c in connus)
+
+
+def test_le_moteur_ne_code_aucun_nom_de_catalogue() -> None:
+    """L'invariant du projet : la spécificité vit dans la donnée, pas dans le code.
+
+    Le manifeste cite « linux », « ansible », « terraform » ; le code, jamais.
+    Un `if identifiant == "linux"` rouvrirait le couplage que la séparation
+    moteur / catalogues existe pour empêcher.
+    """
+    source = Path(catalog.__file__).read_text(encoding="utf-8").lower()
+    for domaine in ("linux", "ansible", "kubernetes", "terraform"):
+        assert domaine not in source, f"« {domaine} » est cité dans services/catalog.py"
+
+
+# ── add : le cas nominal, et les deux cas que l'issue exige ─────────────────
+
+def test_add_installe_et_rend_actif(tmp_path: Path) -> None:
+    distant = _depot_git(tmp_path / "distant" / "essai-labs")
+
+    pose = catalog.ajouter(f"file://{distant}")
+
+    assert pose.actif
+    assert (pose.racine / "meta.yml").is_file()
+    assert catalog.nom_actif() == "essai-labs"
+
+
+def test_add_sur_un_catalogue_deja_installe_refuse_sans_force(tmp_path: Path) -> None:
+    """Le répertoire porte la progression et le travail : on ne l'écrase pas."""
+    distant = _depot_git(tmp_path / "distant" / "essai-labs")
+    catalog.ajouter(f"file://{distant}")
+
+    # Une trace du travail de l'apprenant, que --force perdrait.
+    (catalog.racine_catalogues() / "essai-labs" / ".dsoxlab.db").write_text(
+        "progression", encoding="utf-8")
+
+    with pytest.raises(catalog.CatalogueError) as exc:
+        catalog.ajouter(f"file://{distant}")
+    assert "essai-labs" in str(exc.value)
+    assert (catalog.racine_catalogues() / "essai-labs" / ".dsoxlab.db").is_file()
+
+
+def test_add_avec_force_reinstalle(tmp_path: Path) -> None:
+    distant = _depot_git(tmp_path / "distant" / "essai-labs")
+    catalog.ajouter(f"file://{distant}")
+    (catalog.racine_catalogues() / "essai-labs" / ".dsoxlab.db").write_text(
+        "progression", encoding="utf-8")
+
+    catalog.ajouter(f"file://{distant}", force=True)
+
+    assert not (catalog.racine_catalogues() / "essai-labs" / ".dsoxlab.db").exists()
+
+
+@pytest.mark.parametrize(("url", "attendu"), [
+    ("https://github.com/org/linux-labs", "linux-labs"),
+    ("https://github.com/org/linux-labs.git", "linux-labs"),
+    ("https://github.com/org/linux-labs/", "linux-labs"),
+    ("git@github.com:org/Linux-Labs.git", "linux-labs"),
+    ("file:///chemin/vers/essai-labs", "essai-labs"),
+])
+def test_l_identifiant_se_deduit_de_l_url(url: str, attendu: str) -> None:
+    """Le `.git` d'une URL de clone ne doit pas devenir un nom de répertoire."""
+    identifiant, depot = catalog.resoudre(url)
+    assert identifiant == attendu
+    assert depot == url, "l'URL est passée telle quelle à git"
+
+
+def test_une_url_dont_le_segment_est_inutilisable_est_refusee() -> None:
+    with pytest.raises(catalog.CatalogueError):
+        catalog.resoudre("https://github.com/org/..")
+
+
+def test_un_identifiant_du_manifeste_donne_son_depot() -> None:
+    connu = catalog.lire_manifeste()[0]
+    identifiant, depot = catalog.resoudre(connu.id)
+    assert (identifiant, depot) == (connu.id, connu.depot)
+
+
+def test_add_d_un_catalogue_inconnu_le_dit(tmp_path: Path) -> None:
+    with pytest.raises(catalog.CatalogueError) as exc:
+        catalog.ajouter("catalogue-qui-n-existe-pas")
+    assert "catalogue-qui-n-existe-pas" in str(exc.value)
+
+
+def test_add_d_un_depot_sans_meta_ne_laisse_rien(tmp_path: Path) -> None:
+    """Un dépôt git quelconque n'est pas un catalogue, et un demi-clone non plus.
+
+    Sans ce nettoyage, `catalog list` montrerait comme installé un répertoire
+    qu'aucune commande ne sait lire.
+    """
+    distant = _depot_git(tmp_path / "distant" / "pas-un-catalogue", avec_meta=False)
+
+    with pytest.raises(catalog.CatalogueError):
+        catalog.ajouter(f"file://{distant}")
+
+    assert not (catalog.racine_catalogues() / "pas-un-catalogue").exists()
+
+
+# ── list, use, update, remove ───────────────────────────────────────────────
+
+def test_list_montre_l_installe_et_marque_l_actif(tmp_path: Path) -> None:
+    assert catalog.installes() == []
+
+    premier = _depot_git(tmp_path / "distant" / "un")
+    second = _depot_git(tmp_path / "distant" / "deux")
+    catalog.ajouter(f"file://{premier}")
+    catalog.ajouter(f"file://{second}")
+
+    poses = {p.id: p for p in catalog.installes()}
+    assert set(poses) == {"un", "deux"}
+    # Le dernier installé est l'actif : c'est le geste que l'utilisateur vient
+    # de faire, et celui dont il attend l'effet.
+    assert poses["deux"].actif and not poses["un"].actif
+
+
+def test_use_change_l_actif(tmp_path: Path) -> None:
+    premier = _depot_git(tmp_path / "distant" / "un")
+    second = _depot_git(tmp_path / "distant" / "deux")
+    catalog.ajouter(f"file://{premier}")
+    catalog.ajouter(f"file://{second}")
+
+    catalog.definir_actif("un")
+
+    assert catalog.nom_actif() == "un"
+
+
+def test_use_sur_un_catalogue_absent_le_dit(tmp_path: Path) -> None:
+    with pytest.raises(catalog.CatalogueError) as exc:
+        catalog.definir_actif("jamais-installe")
+    assert "jamais-installe" in str(exc.value)
+
+
+def test_remove_retire_et_oublie_l_actif(tmp_path: Path) -> None:
+    distant = _depot_git(tmp_path / "distant" / "essai-labs")
+    catalog.ajouter(f"file://{distant}")
+
+    catalog.retirer("essai-labs")
+
+    assert catalog.installes() == []
+    assert catalog.nom_actif() is None, (
+        "un actif qui désigne un catalogue retiré doit être oublié"
+    )
+
+
+def test_retirer_un_catalogue_absent_le_dit(tmp_path: Path) -> None:
+    with pytest.raises(catalog.CatalogueError):
+        catalog.retirer("jamais-installe")
+
+
+def test_update_rend_ce_que_git_a_fait(tmp_path: Path) -> None:
+    distant = _depot_git(tmp_path / "distant" / "essai-labs")
+    catalog.ajouter(f"file://{distant}")
+
+    detail = catalog.mettre_a_jour("essai-labs")
+
+    assert "up to date" in detail.lower() or detail == ""
+
+
+def test_mettre_a_jour_un_catalogue_absent_le_dit(tmp_path: Path) -> None:
+    with pytest.raises(catalog.CatalogueError):
+        catalog.mettre_a_jour("jamais-installe")
+
+
+# ── La résolution : le cœur de l'issue ──────────────────────────────────────
+
+def test_un_catalogue_actif_est_trouve_depuis_n_importe_ou(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le critère de l'issue : plus besoin de se placer dans le répertoire."""
+    distant = _depot_git(tmp_path / "distant" / "essai-labs")
+    pose = catalog.ajouter(f"file://{distant}")
+
+    ailleurs = tmp_path / "un-repertoire-quelconque"
+    ailleurs.mkdir()
+    monkeypatch.chdir(ailleurs)
+
+    assert get_lab_home() == pose.racine
+
+
+def test_le_repertoire_courant_reste_prioritaire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aucun catalogue déjà cloné ne cesse de fonctionner.
+
+    L'inverse ferait qu'un `catalog add` changerait silencieusement ce que fait
+    un `dsoxlab check` lancé dans un dépôt existant : un effet de bord muet, à
+    distance, et sur la commande qui note le travail.
+    """
+    distant = _depot_git(tmp_path / "distant" / "essai-labs")
+    catalog.ajouter(f"file://{distant}")
+
+    sur_place = tmp_path / "catalogue-clone-a-la-main"
+    sur_place.mkdir()
+    (sur_place / "meta.yml").write_text("repo:\n  id: local\n", encoding="utf-8")
+    monkeypatch.chdir(sur_place)
+
+    assert get_lab_home() == sur_place.resolve()
+
+
+def test_lab_home_reste_au_dessus_de_tout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    distant = _depot_git(tmp_path / "distant" / "essai-labs")
+    catalog.ajouter(f"file://{distant}")
+
+    force = tmp_path / "force"
+    force.mkdir()
+    monkeypatch.setenv("LAB_HOME", str(force))
+
+    assert get_lab_home() == force.resolve()
+
+
+def test_sans_catalogue_actif_on_retombe_sur_le_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ailleurs = tmp_path / "vide"
+    ailleurs.mkdir()
+    monkeypatch.chdir(ailleurs)
+
+    assert get_lab_home() == ailleurs.resolve()
+
+
+def test_un_actif_qui_ne_correspond_plus_a_rien_est_ignore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """L'utilisateur a pu retirer le répertoire à la main.
+
+    Une commande ne doit pas échouer sur un état que l'outil sait recalculer.
+    """
+    fichier = catalog._fichier_actif()
+    fichier.parent.mkdir(parents=True, exist_ok=True)
+    fichier.write_text("disparu\n", encoding="utf-8")
+
+    ailleurs = tmp_path / "vide"
+    ailleurs.mkdir()
+    monkeypatch.chdir(ailleurs)
+
+    assert catalog.nom_actif() is None
+    assert get_lab_home() == ailleurs.resolve()
+
+
+@pytest.mark.parametrize("mauvais", ["../evade", "/absolu", "avec espace", ""])
+def test_un_identifiant_ne_peut_pas_sortir_du_repertoire(
+    mauvais: str,
+) -> None:
+    """Un identifiant sert de nom de répertoire : il ne doit rien pouvoir remonter."""
+    with pytest.raises(catalog.CatalogueError):
+        catalog.definir_actif(mauvais)

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.66"
+version = "0.1.67"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Séparer le moteur des catalogues est une bonne décision d'architecture, mais elle
était **entièrement à la charge de l'utilisateur** : rien ne disait quels
catalogues existent, comment en installer un, ni qu'il fallait lancer dsoxlab
depuis l'intérieur du répertoire cloné. `dsoxlab demo` avait retiré l'urgence en
0.1.45 ; il restait le passage du lab de démonstration à un vrai catalogue.

```console
$ dsoxlab catalog list              # les connus, et ceux qui sont installés
$ dsoxlab catalog add linux         # le cloner, et le rendre actif
$ cd ~ && dsoxlab list-labs         # marche, sans se placer dedans
$ dsoxlab catalog use ansible       # changer l'actif
$ dsoxlab catalog update [<id>]     # en mettre un à jour, ou tous
$ dsoxlab catalog remove <id>       # en retirer un
```

## La décision de conception : l'ordre de résolution

C'est elle qui touche `get_lab_home()`, donc le chemin critique de **toutes** les
autres commandes. Deux invariants s'y opposent et devaient tenir ensemble.

```
LAB_HOME (variable d'environnement)
  ↓ sinon
répertoire courant, en remontant jusqu'à un meta.yml
  ↓ sinon
catalogue ACTIF
  ↓ sinon
répertoire courant (repli inchangé)
```

**Le catalogue actif vient après le répertoire courant, jamais avant.** Qui se
place dans un catalogue cloné à la main s'attend à travailler dessus. L'inverse
ferait qu'un `catalog add` changerait silencieusement ce que fait un `dsoxlab
check` lancé dans un dépôt existant : un effet de bord muet, à distance, et sur
la commande qui note le travail. Deux tests tiennent chacun un bout, et un
troisième vérifie que `LAB_HOME` reste au-dessus de tout.

## Un manifeste packagé, pas un registre

Le registre des catalogues connus est un fichier livré avec l'outil
(`templates/catalogues.yml`). Un registre distant serait un composant à héberger,
surveiller et maintenir disponible, pour un projet qui compte aujourd'hui trois
catalogues. Un manifeste versionné a de plus un mérite qu'un service n'a pas :
**il est révisable en pull request**, donc proposer un catalogue tiers devient
une contribution ordinaire, relue comme le reste.

N'importe quelle URL git est acceptée, **y compris absente du manifeste** : il
facilite la découverte, il ne restreint rien. L'identifiant est alors déduit du
dernier segment de l'URL, `.git` retiré.

## L'agnosticisme, tenu par un test

`services/catalog.py` ne contient **aucun** nom de domaine : seulement des
identifiants et des URL, tous venus du manifeste ou de la ligne de commande. Un
test le vérifie en relisant le source du module, plutôt que de s'en remettre à la
vigilance :

```python
source = Path(catalog.__file__).read_text(encoding="utf-8").lower()
for domaine in ("linux", "ansible", "kubernetes", "terraform"):
    assert domaine not in source
```

## Deux refus qui valent d'être connus

- **`catalog add` sur un catalogue déjà installé échoue** au lieu d'écraser : le
  répertoire porte la progression et le travail. `--force` le fait, et le dit.
- **Un dépôt sans `meta.yml` à sa racine est refusé**, et son clone retiré. Sans
  ce nettoyage, `catalog list` montrerait comme installé un répertoire qu'aucune
  commande ne sait lire.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 61 source files*
- [x] `uv run pytest` : **685 passed** (655 avant, **+30**)
- [x] `uv run pytest tests_e2e` : **18 passed** sur la roue construite et installée
- [x] Les hooks `pre-commit` passent
- [x] Le moteur reste neutre vis-à-vis du domaine — vérifié par un test, pas par relecture
- [x] Aucun chemin personnel ; `pathlib.Path` partout ; les emplacements passent
      par `xdg_data_home()` et `xdg_state_home()` déjà en place
- [x] Testé sur **deux dépôts fournisseurs**, parcours complet joué de bout en bout :
      - `ansible-training` installé par URL, puis `list-labs` **depuis `/tmp`**,
        sans `cd` : les labs s'affichent
      - `terraform-training` (aucun bloc `infra:`) : depuis son répertoire, ce
        sont bien **ses 87 labs** qui sortent, pas ceux du catalogue actif

### When behavior changes

- [x] CHANGELOG EN **et** FR ; version **0.1.67** ; `uv.lock` aligné

### When a command or option is added, removed or changed

- [x] Clés i18n dans **en.py et fr.py**, aide des commandes **et** des arguments
- [x] Section `catalog` ajoutée au `fullhelp` **EN et FR**
- [x] `docs/commands.md` et `docs/commands.fr.md` régénérés par le générateur
- [x] Les nouveaux emplacements sont documentés dans `docs/files.md` / `.fr.md`,
      et le relevé de `scripts/generer-doc.py` étendu pour que le contrôle
      « les chemins cités existent dans le code » porte aussi sur eux
- [x] Joué sous `DSOXLAB_LANG=en` et `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched — N/A

### When the declarative contract changes — N/A

`meta.yml` et `lab.yaml` ne gagnent aucun champ : un catalogue reste ce qu'il
était, un dépôt portant un `meta.yml` à sa racine.

## Un faux positif de `trufflehog` rencontré en chemin

Le hook a refusé le commit sur **deux noms de fonctions de test** :

```
✅ Found verified result 🐷🔑
Detector Type: Lob
Raw result: test_remove_d_un_catalogue_absent_le_dit
```

Le détecteur *Lob* (service d'impression postale) reconnaît les clés de test à
leur préfixe `test_`, et un nom de fonction de 40 caractères lui suffit. Six tests
**déjà dans le dépôt** ont exactement la même forme : c'est structurel, pas
propre à cette PR.

J'ai **renommé mes deux tests** plutôt que de toucher à un hook de sécurité, ce
qui n'est pas ma décision. La correction durable serait
`--exclude-detectors=lob` dans `.pre-commit-config.yaml` : le projet n'utilise pas
Lob, donc l'exclure ne réduit en rien la protection réelle. À votre main.

## Related issues

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
