### PR TITLE
fix(tests): un nom de test cesse de passer pour une clé d'API

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -11,6 +11,27 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Corrigé
 
+- **Un nom de fonction de test pouvait faire échouer le commit pour fuite de
+  secret.** Le hook `trufflehog` tourne avec `--results=verified`, ce qui est la
+  bonne exigence : il ne bloque que sur un secret vérifié. Mais son détecteur
+  *Lob* reconnaît les clés de test de ce service à leur seul préfixe `test_`, et
+  une clé Lob de test est vérifiée **sans appel réseau**. Mesuré contre la
+  commande exacte du hook : un nom de **quarante caractères précisément** le
+  déclenche, 39 et 41 non.
+
+  Sept noms de tests du dépôt portaient déjà cette forme. Aucun n'avait jamais
+  rien déclenché, le hook ne lisant que le diff : ils attendaient le premier
+  contributeur qui toucherait à leur fichier. Ils sont renommés, et un test
+  refuse désormais cette longueur dans `tests/`, `tests_e2e/` et `fuzz/`, pour
+  que le défaut se dise là, en une seconde et avec sa raison, plutôt qu'au
+  `pre-push` sous les traits d'une fuite de secret.
+
+  **Le détecteur n'a pas été exclu.** Retirer Lob aurait réglé le symptôme en
+  retirant une capacité de détection, pour un service que le projet n'utilise pas
+  aujourd'hui mais dont rien ne dit qu'il ne l'utilisera jamais. Renommer coûte
+  un mot et n'enlève rien au scan.
+
+
 - **Le garde-fou de publication n'était pas fiable, de deux façons, toutes deux
   constatées en publiant les 0.1.65 et 0.1.66.** Il garde une publication qui ne
   se défait pas, donc s'y tromper coûte plus cher qu'ailleurs. Rien ne change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A test function name could fail the commit as a leaked secret.** The
+  `trufflehog` hook runs with `--results=verified`, which is the right bar: it
+  blocks on verified secrets only. But its *Lob* detector recognises that
+  service's test keys by their `test_` prefix alone, and a Lob test key is
+  verified **without any network call**. Measured against the hook's exact
+  command: a name of **exactly 40 characters** trips it, 39 and 41 do not.
+
+  Seven test names in this repository already had that shape. None had ever
+  fired, because the hook only reads the diff — they were waiting for the first
+  contributor to touch their file. They are renamed, and a test now refuses that
+  length across `tests/`, `tests_e2e/` and `fuzz/`, so the defect states itself
+  here, in a second and with its reason, instead of at `pre-push` disguised as a
+  secret leak.
+
+  **The detector was not excluded.** Dropping Lob would have fixed the symptom by
+  removing a detection capability, for a service this project does not use today
+  but may use tomorrow. Renaming costs one word and takes nothing away from the
+  scan.
+
+
 - **The release guard was unreliable in two ways, both observed while shipping
   0.1.65 and 0.1.66.** It guards a publication that cannot be undone, so being
   wrong costs more here than elsewhere. Nothing in the published wheel changes:

--- a/tests/test_cloud_init_templates.py
+++ b/tests/test_cloud_init_templates.py
@@ -44,7 +44,7 @@ def test_every_mapped_distro_has_a_cloud_init(provider: str) -> None:
         assert path.is_file(), f"{provider}: {distro} -> {stem}.yaml.tmpl absent"
 
 
-def test_debian12_supported_on_all_providers() -> None:
+def test_debian12_is_supported_on_all_providers() -> None:
     """debian12 doit être mappé partout, vers le cloud-init debian."""
     for provider in PROVIDERS:
         mapping = _distro_to_template(provider)

--- a/tests/test_convention_de_nommage.py
+++ b/tests/test_convention_de_nommage.py
@@ -1,0 +1,81 @@
+"""La porte de contribution ne doit pas se refermer sur un faux positif.
+
+Le hook `trufflehog` du dépôt est réglé sur `--results=verified` : il ne bloque
+que sur un secret **vérifié**, ce qui est la bonne exigence. Mais son détecteur
+*Lob* reconnaît les clés de test de ce service à leur seul préfixe `test_`, et
+une clé Lob de test est vérifiée **sans appel réseau**, par nature.
+
+Conséquence mesurée le 2026-08-24, en soumettant des noms de longueurs
+croissantes à la commande exacte du hook :
+
+    longueur | déclenche ?
+    ---------+-------------
+       39    | non
+       40    | OUI     ← `test_` suivi de 35 caractères
+       41    | non
+
+Un nom de fonction de test de quarante caractères suffit donc à faire échouer un
+commit, avec un message qui parle de clé d'API. Six tests du dépôt portaient déjà
+cette forme sans jamais rien déclencher, parce que le hook ne lit que le diff :
+ils auraient bloqué le premier contributeur qui aurait touché à leur fichier.
+
+**Pourquoi un test plutôt qu'une exclusion du détecteur.** Exclure Lob aurait
+réglé le symptôme en retirant une capacité de détection, pour un service que le
+projet n'utilise pas aujourd'hui mais dont rien ne dit qu'il ne l'utilisera
+jamais. Renommer coûte un mot, ne retire rien au scan, et ce contrôle-ci fait
+que le défaut se dit ici — en une seconde, avec sa raison — plutôt qu'au
+`pre-push`, sous les traits d'une fuite de secret.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+RACINE = Path(__file__).resolve().parent.parent
+
+#: Longueur exacte qui fait reconnaître un nom de fonction comme une clé Lob de
+#: test. Mesurée, pas déduite : 39 et 41 passent, 40 seul déclenche.
+_LONGUEUR_INTERDITE = 40
+
+_DEFINITION = re.compile(r"^\s*def (test_[a-z0-9_]+)\s*\(", re.MULTILINE)
+
+#: Les suites dont les fichiers passent par le hook. `fuzz/` en est, ses
+#: harnais étant du code versionné comme le reste.
+_SUITES = ("tests", "tests_e2e", "fuzz")
+
+
+def test_aucun_nom_de_test_ne_ressemble_a_une_cle_lob() -> None:
+    """Aucun nom de fonction de test ne doit faire exactement quarante caractères."""
+    fautifs: list[str] = []
+    for suite in _SUITES:
+        racine = RACINE / suite
+        if not racine.is_dir():
+            continue
+        for source in sorted(racine.rglob("*.py")):
+            texte = source.read_text(encoding="utf-8")
+            for nom in _DEFINITION.findall(texte):
+                if len(nom) == _LONGUEUR_INTERDITE:
+                    relatif = source.relative_to(RACINE)
+                    fautifs.append(f"{relatif}::{nom}")
+
+    assert not fautifs, (
+        "Ces noms font exactement "
+        f"{_LONGUEUR_INTERDITE} caractères, ce que le détecteur Lob de "
+        "trufflehog prend pour une clé de test vérifiée :\n  "
+        + "\n  ".join(fautifs)
+        + "\n\nAjoute ou retire un mot. Le hook pre-commit refuserait le commit "
+        "en parlant d'une fuite de secret, ce qui n'aide personne à comprendre."
+    )
+
+
+def test_le_controle_voit_bien_les_fichiers_de_test() -> None:
+    """Garde-fou : une expression cassée rendrait le contrôle vert à vide.
+
+    C'est le même piège que partout ailleurs dans ce dépôt : un contrôle qui ne
+    mesure plus rien est pire qu'un contrôle absent, parce qu'il rassure.
+    """
+    trouves = 0
+    for source in sorted((RACINE / "tests").rglob("*.py")):
+        trouves += len(_DEFINITION.findall(source.read_text(encoding="utf-8")))
+    assert trouves > 300, f"seulement {trouves} fonctions de test vues"

--- a/tests/test_guide_service.py
+++ b/tests/test_guide_service.py
@@ -79,7 +79,7 @@ def test_the_page_itself_is_untouched() -> None:
     )
 
 
-def test_source_and_medium_can_be_overridden() -> None:
+def test_source_and_medium_can_both_be_overridden() -> None:
     """A web front-end may want to distinguish itself from the CLI."""
     url = guide_url(_lab(), source="dsoxlab-web", medium="lms")
     assert url is not None

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -72,7 +72,7 @@ def test_a_lab_carries_what_an_editor_needs(capsys) -> None:
     assert lab["best_score"] == {"points": 60, "max": 100}
 
 
-def test_a_lab_never_attempted_is_not_a_zero(capsys) -> None:
+def test_a_lab_never_attempted_is_not_a_zero_score(capsys) -> None:
     """Distinguer « jamais tenté » de « tenté et raté » : ce n'est pas pareil."""
     machine.emit({"labs": [machine.lab_dict(_lab(), None)]})
 

--- a/tests/test_shell_fixtures.py
+++ b/tests/test_shell_fixtures.py
@@ -89,7 +89,7 @@ def test_a_fixture_escaping_the_workdir_is_refused(tmp_path: Path) -> None:
     assert list(work.iterdir()) == [], "nothing may be copied from outside fixtures/"
 
 
-def test_an_absolute_fixture_path_is_refused(tmp_path: Path) -> None:
+def test_an_absolute_fixture_path_is_always_refused(tmp_path: Path) -> None:
     lab = _lab(tmp_path, ["/etc/hostname"])
 
     ShellRuntime().start(lab)

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -44,7 +44,7 @@ class TestParseVersion:
     def test_decoupe(self, brut: str, attendu: tuple[int, int, int]) -> None:
         assert update_check.parse_version(brut) == attendu
 
-    def test_ordre_numerique_et_non_alphabetique(self) -> None:
+    def test_ordre_numerique_et_non_pas_alphabetique(self) -> None:
         """0.1.9 < 0.1.24, ce qu'une comparaison de chaînes rate."""
         assert update_check.parse_version("0.1.9") < update_check.parse_version("0.1.24")
 

--- a/tests/test_yaml_contract.py
+++ b/tests/test_yaml_contract.py
@@ -85,7 +85,7 @@ def test_empty_validation_block_falls_back_to_defaults(tmp_path: Path) -> None:
         ("skills is a scalar", VALID_LAB.replace("skills: [demo]", "skills: 42")),
     ],
 )
-def test_malformed_lab_stays_within_contract(tmp_path: Path, label: str, document: str) -> None:
+def test_a_malformed_lab_stays_within_contract(tmp_path: Path, label: str, document: str) -> None:
     """Un lab.yaml hostile est rejeté DANS le contrat, jamais en AttributeError."""
     lab_yaml = _write(tmp_path, "lab.yaml", document)
     with pytest.raises(CONTRACT_EXCEPTIONS):
@@ -135,7 +135,7 @@ def test_empty_host_fields_fall_back_to_defaults(tmp_path: Path) -> None:
     assert host.ip == ""  # et surtout pas la chaîne "None"
 
 
-def test_invalid_translation_file_is_ignored(tmp_path: Path) -> None:
+def test_an_invalid_translation_file_is_ignored(tmp_path: Path) -> None:
     """Un lab.<lang>.yaml non-mapping ne doit pas casser le lab de base."""
     _write(tmp_path, "lab.yaml", VALID_LAB)
     _write(tmp_path, "lab.fr.yaml", "- pas un mapping\n")


### PR DESCRIPTION
Le hook `trufflehog` tourne avec `--results=verified`, ce qui est **la bonne
exigence** : il ne bloque que sur un secret vérifié. Mais son détecteur *Lob*
reconnaît les clés de test de ce service à leur seul préfixe `test_`, et une clé
Lob de test est vérifiée **sans appel réseau**, par nature. Un nom de fonction
Python suffit donc à faire échouer un commit, avec un message qui parle de fuite
de secret :

```
✅ Found verified result 🐷🔑
Detector Type: Lob
Raw result: test_remove_d_un_catalogue_absent_le_dit
File: tests/test_catalog.py
```

## Mesuré, pas supposé

Des noms de longueurs croissantes soumis à **la commande exacte du hook**, dans
un dépôt jetable :

```
longueur | déclenche ?
---------+-------------
   38    | non
   39    | non
   40    | OUI     ← test_ suivi de 35 caractères
   41    | non
   42    | non
```

Quarante caractères précisément. Ni un de plus, ni un de moins.

## Sept noms attendaient leur contributeur

Ils étaient déjà dans le dépôt et n'avaient **jamais rien déclenché**, parce que
le hook ne lit que le diff (`--since-commit HEAD`). Ils attendaient simplement le
premier contributeur qui toucherait à leur fichier :

| Fichier | Nom |
|---|---|
| `tests/test_json_output.py` | `test_a_lab_never_attempted_is_not_a_zero` |
| `tests/test_cloud_init_templates.py` | `test_debian12_supported_on_all_providers` |
| `tests/test_yaml_contract.py` | `test_malformed_lab_stays_within_contract` |
| `tests/test_yaml_contract.py` | `test_invalid_translation_file_is_ignored` |
| `tests/test_guide_service.py` | `test_source_and_medium_can_be_overridden` |
| `tests/test_shell_fixtures.py` | `test_an_absolute_fixture_path_is_refused` |
| `tests/test_update_check.py` | `test_ordre_numerique_et_non_alphabetique` |

**Le septième a été trouvé par le contrôle, pas par moi.** Mon inventaire à la
main cherchait `^def test_` et manquait donc les méthodes de classe, indentées.
C'est exactement la raison d'être d'un contrôle automatique.

## Le détecteur n'a pas été exclu, et c'est le point

`--exclude-detectors=lob` aurait réglé le symptôme **en retirant une capacité de
détection**, pour un service que le projet n'utilise pas aujourd'hui mais dont
rien ne dit qu'il ne l'utilisera jamais. Renommer coûte un mot et n'enlève rien
au scan.

À la place, un test refuse cette longueur dans `tests/`, `tests_e2e/` et `fuzz/`.
Le défaut se dit désormais **en une seconde, avec sa raison et le geste à faire**,
plutôt qu'au `pre-push` sous les traits d'une fuite de secret :

```
Ces noms font exactement 40 caractères, ce que le détecteur Lob de
trufflehog prend pour une clé de test vérifiée :
  tests/test_exemple.py::test_abcde_abcde_abcde_abcde_abcde_abcde

Ajoute ou retire un mot. Le hook pre-commit refuserait le commit en
parlant d'une fuite de secret, ce qui n'aide personne à comprendre.
```

Le contrôle porte **son propre garde-fou** : une expression cassée le rendrait
vert à vide, donc un second test vérifie qu'il voit bien plus de trois cents
fonctions. C'est le même piège que partout ailleurs dans ce dépôt, un contrôle
qui ne mesure plus rien étant pire qu'un contrôle absent, parce qu'il rassure.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 60 source files*
- [x] `uv run pytest` : **657 passed** (655 avant, +2)
- [x] Les hooks `pre-commit` passent, **trufflehog compris**, sur un commit qui
      touche pourtant sept fichiers de test
- [x] **Éprouvé par l'échec** : un nom fautif glissé dans la suite fait rougir le
      contrôle, son retrait le fait repasser au vert
- [x] `src/dsoxlab/` n'est pas touché : aucun risque de régression fonctionnelle
- [ ] Test manuel sur deux dépôts fournisseurs : **N/A**, ce changement ne touche
      que la suite de tests du moteur

### When behavior changes — pas de bump

- [x] CHANGELOG EN **et** FR, section `Unreleased`
- [ ] Bump de version : **volontairement absent**, rien ne change dans la roue
      publiée (`packages = ["src/dsoxlab"]`)

### When a command or option is added, removed or changed — N/A
### When `.github/workflows/` is touched — N/A

Le hook vit dans `.pre-commit-config.yaml`, et il n'est **pas modifié** : c'est
tout l'objet de cette PR.

### When the declarative contract changes — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
