### PR TITLE
fix(scripts): ne pas savoir si la CI est verte n'est pas un feu vert

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,26 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Corrigé
+
+- **Le garde-fou de publication donnait son feu vert quand il ne pouvait pas
+  mesurer.** La publication de la 0.1.67 l'a montré : `gh` a été injoignable un
+  instant, le contrôle de CI s'est dégradé en note — qui n'empêche rien — et le
+  script a conclu « Tout est bon » alors que la CI tournait encore. Ne pas
+  savoir si la CI est verte appelle la même décision que savoir qu'elle ne l'est
+  pas : ne pas taguer, PyPI étant définitif. Un état de CI illisible vaut
+  désormais une **attente** (sortie 2), comme une CI encore en cours.
+
+  `--ci-verifiee` existe pour le cas où `gh` est absent ou muet : il transforme
+  cette attente en note assumée, pour que l'affirmation soit celle d'un humain
+  et qu'elle se voie. Il ne peut pas couvrir une CI qui a répondu rouge.
+
+  Deux découvertes en corrigeant : `check=False` ne couvre que le code de
+  retour, donc un `gh` absent du `PATH` levait `FileNotFoundError` et détruisait
+  tout le rapport, y compris les sept contrôles qui avaient répondu. Et le
+  script n'avait toujours aucun test là-dessus ; il en a cinq de plus.
+
+
 ## [0.1.67] - 2026-08-24
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The release guard gave a green light when it could not measure.** Publishing
+  0.1.67 made it visible: `gh` was unreachable for a moment, the CI check
+  degraded to a note — which blocks nothing — and the script concluded "all
+  good" while the CI was still running. Not knowing whether the CI is green
+  calls for the same decision as knowing it is not: do not tag, since PyPI is
+  final. An unreadable CI state is now a **wait** (exit 2), like a CI still in
+  flight.
+
+  `--ci-verifiee` exists for the case where `gh` is absent or mute: it turns
+  that wait into an assumed note, so the affirmation is a human's and says so.
+  It cannot cover a CI that answered red.
+
+  Two more things surfaced while fixing it: `check=False` covers the return code
+  only, so a `gh` missing from `PATH` raised `FileNotFoundError` and destroyed
+  the whole report — including the seven checks that had answered. And the
+  script still had no test for any of this; it now has five more.
+
+
 ## [0.1.67] - 2026-08-24
 
 ### Added

--- a/scripts/check-release.py
+++ b/scripts/check-release.py
@@ -17,10 +17,16 @@ Usage :
     python3 scripts/check-release.py           # déduit la version du pyproject
     python3 scripts/check-release.py v0.1.28   # vérifie un tag précis
     python3 scripts/check-release.py --publiee # APRÈS le tag : est-ce arrivé ?
+    python3 scripts/check-release.py --ci-verifiee   # CI vue verte à la main
 
 Sortie 0 : le tag peut être posé, la commande exacte est affichée.
 Sortie 1 : au moins un contrôle a échoué, chacun dit quoi corriger.
 Sortie 2 : rien n'est faux, mais il est trop tôt. Relancer plus tard.
+
+``--ci-verifiee`` n'existe que pour le cas où `gh` est absent ou muet. Sans lui,
+une CI dont l'état n'a pas pu être lu vaut « trop tôt » et non « tout est bon » :
+ne pas savoir et savoir que ce n'est pas vert appellent la même décision, celle
+de ne pas taguer.
 """
 
 from __future__ import annotations
@@ -254,23 +260,55 @@ def _verifier_pypi(r: Rapport, version: str) -> None:
         r.ok(f"La version {version} est libre sur PyPI")
 
 
-def _verifier_ci(r: Rapport) -> None:
+#: Ce qu'on répond quand l'état de la CI n'a pas pu être lu.
+#:
+#: « Je ne sais pas si elle est verte » est **indiscernable**, pour la décision
+#: à prendre, de « elle ne l'est pas encore » : dans les deux cas on ne doit pas
+#: taguer, puisque PyPI est définitif. C'était pourtant une simple note, qui
+#: n'empêche rien — le script a donc annoncé « Tout est bon » le 2026-08-24
+#: alors que la CI de la 0.1.67 tournait encore, faute d'avoir pu joindre `gh`.
+#: Un garde-fou qui, ne pouvant mesurer, conclut au vert est exactement l'échec
+#: muet que ce dépôt combat partout ailleurs.
+_SANS_GH = (
+    "Vérifie l'état de la CI à la main, puis relance. Si `gh` n'est pas "
+    "disponible ici, relance avec --ci-verifiee une fois que tu l'as vue verte : "
+    "le drapeau dit que c'est toi qui l'affirmes."
+)
+
+
+def _verifier_ci(r: Rapport, *, ci_verifiee: bool = False) -> None:
     # RELEASING demande d'attendre une CI verte : le tag construit depuis ce
     # commit, et PyPI ne se rattrape pas.
     sha = git("rev-parse", "HEAD")
-    # check=False : `gh` absent ou non authentifié est un cas prévu, traité
-    # deux lignes plus bas en « état de la CI inconnu ».
-    sortie = subprocess.run(
-        ["gh", "run", "list", "--commit", sha, "--json", "conclusion,name,status"],
-        cwd=RACINE, capture_output=True, text=True, check=False,
-    )
+    # `check=False` ne couvre QUE le code de retour : un `gh` absent du PATH
+    # lève FileNotFoundError, et le script mourait alors sur un traceback au
+    # lieu de rendre son rapport. Le commentaire affirmait pourtant que le cas
+    # était prévu — il ne l'était que pour un gh présent mais non authentifié.
+    try:
+        sortie = subprocess.run(
+            ["gh", "run", "list", "--commit", sha, "--json", "conclusion,name,status"],
+            cwd=RACINE, capture_output=True, text=True, check=False,
+        )
+    except OSError:
+        if ci_verifiee:
+            r.note("CI déclarée verte à la main", "gh introuvable ; --ci-verifiee.")
+        else:
+            r.attendre("gh introuvable, état de la CI inconnu", _SANS_GH)
+        return
+
     if sortie.returncode != 0 or not sortie.stdout.strip():
-        r.note("État de la CI inconnu", "gh indisponible : vérifie à la main.")
+        if ci_verifiee:
+            r.note("CI déclarée verte à la main", "gh indisponible ; --ci-verifiee.")
+        else:
+            r.attendre("État de la CI inconnu", _SANS_GH)
         return
     try:
         runs = json.loads(sortie.stdout)
     except ValueError:
-        r.note("État de la CI illisible", "Vérifie à la main.")
+        if ci_verifiee:
+            r.note("CI déclarée verte à la main", "réponse de gh illisible ; --ci-verifiee.")
+        else:
+            r.attendre("État de la CI illisible", _SANS_GH)
         return
     en_cours = [x["name"] for x in runs if x.get("status") != "completed"]
     echoues = [
@@ -433,8 +471,10 @@ def main() -> int:
     if version is None:
         print(f"{ROUGE}pyproject.toml ne déclare aucune version.{RAZ}")
         return 1
-    arguments = [a for a in sys.argv[1:] if a != "--publiee"]
+    drapeaux = {"--publiee", "--ci-verifiee"}
+    arguments = [a for a in sys.argv[1:] if a not in drapeaux]
     tag = arguments[0] if arguments else f"v{version}"
+    ci_verifiee = "--ci-verifiee" in sys.argv
 
     if "--publiee" in sys.argv:
         # La version à chercher sur PyPI est celle du tag qu'on vérifie, pas
@@ -455,7 +495,7 @@ def main() -> int:
     _verifier_changelog(r, version)
     _verifier_lock(r, version)
     _verifier_pypi(r, version)
-    _verifier_ci(r)
+    _verifier_ci(r, ci_verifiee=ci_verifiee)
 
     print()
     if r.echecs:

--- a/tests/test_check_release.py
+++ b/tests/test_check_release.py
@@ -143,3 +143,86 @@ def test_publiee_sans_argument_prend_la_version_empaquetee(
 
     assert cr.main() == 0
     assert vues == {"version": "0.1.66", "tag": "v0.1.66"}
+
+
+# ── L'état de la CI : ne pas savoir n'est pas savoir que c'est vert ─────────
+
+def _sans_gh(cr: Any, monkeypatch: pytest.MonkeyPatch, *, erreur: Exception | None = None,
+             code: int = 1, sortie: str = "") -> None:
+    """Simule un `gh` indisponible, de l'une des trois façons observées."""
+    def _run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if erreur is not None:
+            raise erreur
+        return subprocess.CompletedProcess(args=["gh"], returncode=code,
+                                           stdout=sortie, stderr="")
+    monkeypatch.setattr(cr.subprocess, "run", _run)
+    monkeypatch.setattr(cr, "git", lambda *a: "sha")
+
+
+def test_gh_muet_fait_attendre_au_lieu_de_conclure(
+    cr: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le défaut vécu en publiant la 0.1.67.
+
+    Le script a annoncé « Tout est bon » alors que la CI tournait encore, faute
+    d'avoir pu joindre `gh`. Ne pas savoir si la CI est verte appelle la même
+    décision que savoir qu'elle ne l'est pas : ne pas taguer, PyPI étant
+    définitif.
+    """
+    _sans_gh(cr, monkeypatch)
+    r = cr.Rapport()
+    cr._verifier_ci(r)
+
+    assert r.attentes, "un état inconnu doit valoir « trop tôt »"
+    assert not r.echecs
+
+
+def test_gh_introuvable_ne_leve_pas(
+    cr: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`check=False` ne couvre que le code de retour, pas l'absence du binaire.
+
+    Un contributeur sans `gh` recevait un FileNotFoundError et perdait tout le
+    rapport, y compris les sept contrôles qui, eux, avaient répondu.
+    """
+    _sans_gh(cr, monkeypatch, erreur=FileNotFoundError(2, "No such file", "gh"))
+    r = cr.Rapport()
+    cr._verifier_ci(r)
+
+    assert r.attentes
+    assert not r.echecs
+
+
+def test_ci_verifiee_assume_l_affirmation(
+    cr: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le drapeau matérialise le geste : c'est l'humain qui affirme, et ça se voit."""
+    _sans_gh(cr, monkeypatch)
+    r = cr.Rapport()
+    cr._verifier_ci(r, ci_verifiee=True)
+
+    assert not r.attentes and not r.echecs
+
+
+def test_une_ci_en_cours_fait_toujours_attendre(
+    cr: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Garde-fou : le comportement d'origine ne doit pas se perdre."""
+    _sans_gh(cr, monkeypatch, code=0,
+             sortie='[{"name": "CI", "status": "in_progress", "conclusion": null}]')
+    r = cr.Rapport()
+    cr._verifier_ci(r)
+
+    assert r.attentes and not r.echecs
+
+
+def test_une_ci_en_echec_reste_un_echec(
+    cr: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Et --ci-verifiee ne doit pas pouvoir la couvrir : gh a répondu, il dit rouge."""
+    rouge = '[{"name": "CI", "status": "completed", "conclusion": "failure"}]'
+    for drapeau in (False, True):
+        _sans_gh(cr, monkeypatch, code=0, sortie=rouge)
+        r = cr.Rapport()
+        cr._verifier_ci(r, ci_verifiee=drapeau)
+        assert r.echecs, f"une CI rouge doit bloquer (ci_verifiee={drapeau})"


### PR DESCRIPTION
La publication de la 0.1.67 a montré le défaut en conditions réelles. `gh` a été
injoignable un instant, le contrôle de CI s'est dégradé en **note** — qui
n'empêche rien — et le script a conclu :

```
  ! État de la CI inconnu
      gh indisponible : vérifie à la main.

Tout est bon. Pose le tag :
```

**alors que la CI tournait encore** :

```console
$ gh run list --branch main --limit 5
in_progress    feat(catalog): installer un catalogue…   CI   main   push
```

Sans une vérification à la main, un tag partait sur un commit dont rien ne
prouvait qu'il compilait. Et PyPI ne se rattrape pas.

## Ne pas savoir, et savoir que ce n'est pas vert

Ces deux états appellent **la même décision** : ne pas taguer. Les distinguer
dans le rapport a du sens ; les distinguer dans le verdict n'en a aucun. Un état
de CI illisible vaut donc désormais une **attente** (sortie 2), comme une CI
encore en vol.

C'est exactement le mal que ce script combat partout ailleurs, et qu'il portait
lui-même : un garde-fou qui, faute de pouvoir mesurer, conclut au vert.

## `--ci-verifiee`, pour que l'affirmation ait un auteur

Le drapeau existe pour le cas où `gh` est absent ou muet — un contributeur sans
`gh`, un sandbox qui bloque sa configuration. Il transforme l'attente en note
assumée : l'affirmation devient celle d'un humain, et **elle se voit dans le
rapport**.

```console
$ python3 scripts/check-release.py --ci-verifiee
  ! CI déclarée verte à la main
      gh introuvable ; --ci-verifiee.
```

Il **ne peut pas** couvrir une CI qui a répondu rouge : quand `gh` parle, c'est
lui qui fait foi. Un test le vérifie dans les deux positions du drapeau.

## Un quatrième défaut, trouvé en corrigeant

`check=False` ne couvre **que le code de retour**. Un `gh` absent du `PATH` lève
`FileNotFoundError`, et le script mourait alors sur un traceback, détruisant tout
le rapport — y compris les sept contrôles qui, eux, avaient répondu :

```console
$ PATH=/usr/bin:/bin python3 scripts/check-release.py
FileNotFoundError: [Errno 2] No such file or directory: 'gh'
```

Le commentaire affirmait pourtant que le cas était prévu. Il ne l'était que pour
un `gh` présent mais non authentifié.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 61 source files*
- [x] `uv run pytest` : **692 passed** (687 avant, +5)
- [x] Les hooks `pre-commit` passent
- [x] **Éprouvé par l'échec** : les deux corrections neutralisées tour à tour,
      chaque test nouveau rougit, puis repasse au vert
- [x] Éprouvé aussi **en conditions réelles**, avec `PATH` réduit pour faire
      disparaître `gh` : attente sans drapeau, note assumée avec
- [x] `src/dsoxlab/` n'est pas touché
- [ ] Test manuel sur deux dépôts fournisseurs : **N/A**, `scripts/` ne lit aucun
      catalogue et ne s'exécute que dans ce dépôt

### When behavior changes — pas de bump

- [x] CHANGELOG EN **et** FR, section `Unreleased`
- [ ] Bump : **volontairement absent**, `scripts/` n'est pas dans la roue publiée

### When a command or option is added, removed or changed — N/A

`--ci-verifiee` est une option d'un script de développement, hors CLU : ni aide
Typer, ni clés i18n, ni `fullhelp`. Elle est documentée dans l'en-tête du script,
avec la raison d'être qui la borne.

### When `.github/workflows/` is touched — N/A
### When the declarative contract changes — N/A

## Les cinq tests

Trois figent le comportement nouveau, **deux figent l'ancien** pour qu'il ne se
perde pas : une CI en cours fait toujours attendre, une CI en échec bloque
toujours. C'est la troisième PR consécutive sur ce script, et il n'avait aucun
test il y a deux heures ; il en a dix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
