### PR TITLE
feat(status): où en est le lab, calculé à un seul endroit (0.1.68)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,46 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.68] - 2026-08-24
+
+### Ajouté
+
+- **`dsoxlab status` répond à « où en suis-je ? »** (issue #80). L'état d'un lab
+  existait, mais éparpillé : le contexte actif dans un JSON, la note dans une
+  base SQLite, le répertoire de travail sur le disque, les conteneurs chez
+  Docker. Chaque commande en reconstituait un morceau à sa façon, donc aucune ne
+  pouvait répondre. Un seul service le calcule désormais, et cinq états le
+  nomment :
+
+  | `state` | Ce qu'il veut dire |
+  | --- | --- |
+  | `not_started` | rien n'est préparé |
+  | `ready` | environnement prêt, rien n'y a été touché |
+  | `in_progress` | le travail a commencé |
+  | `validated` | une note a été obtenue |
+  | `degraded` | un service déclaré ne tourne plus |
+
+  **`ready` et `in_progress` se distinguent par le travail lui-même**, et non
+  par le fait d'avoir joué `run` : celui-ci retient une empreinte du répertoire
+  de travail, et l'état la compare. Ajouter un fichier, en modifier un, en vider
+  un, tout compte. Sur un lab `vm`, le travail se fait sur la machine, où aucune
+  empreinte locale ne le verrait, et le `detail` le dit plutôt que de laisser
+  croire à une mesure qui n'a pas eu lieu.
+
+  `degraded` prime sur tout, parce que c'est le seul état qui appelle un geste
+  immédiat. Un service jamais démarré n'est **pas** une dégradation : c'est le
+  cas normal avant le premier `run`, et les confondre ferait virer au rouge tout
+  lab à service.
+
+### Modifié
+
+- **`dsoxlab status` ne vérifie plus la connectivité SSH ; `dsoxlab infra
+  status` s'en charge.** Le nom qui devait porter « où en suis-je ? » était pris
+  par une commande d'infrastructure, sans rien à dire sur un catalogue sans bloc
+  `infra:`. Lancé sans lab actif, `status` nomme désormais la nouvelle commande,
+  pour que personne ne cherche un comportement qui a déménagé.
+
+
 ### Corrigé
 
 - **Le garde-fou de publication donnait son feu vert quand il ne pouvait pas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.68] - 2026-08-24
+
+### Added
+
+- **`dsoxlab status` answers "where am I?"** (issue #80). The state of a lab
+  existed, but scattered: the active context in a JSON file, the score in
+  SQLite, the working directory on disk, the containers in Docker. Every command
+  rebuilt a piece of it its own way, so none could answer. One service computes
+  it now, and five states name it:
+
+  | `state` | Meaning |
+  | --- | --- |
+  | `not_started` | nothing is prepared |
+  | `ready` | environment prepared, untouched |
+  | `in_progress` | work has started |
+  | `validated` | a score was obtained |
+  | `degraded` | a declared service no longer runs |
+
+  **`ready` and `in_progress` differ by the work itself**, not by whether `run`
+  was played: `run` records a fingerprint of the working directory, and the state
+  compares against it. Adding a file, changing one, emptying one — all count. On
+  a `vm` lab the work happens on the machine, where no local fingerprint would
+  see it, and `detail` says so rather than implying a measurement that did not
+  happen.
+
+  `degraded` wins over everything, because it is the only state calling for an
+  immediate gesture. A service that was never started is **not** degraded: that
+  is the normal case before the first `run`, and confusing the two would turn
+  every service lab red.
+
+### Changed
+
+- **`dsoxlab status` no longer checks SSH connectivity; `dsoxlab infra status`
+  does.** The name that should carry "where am I?" was taken by an
+  infrastructure command, useless on a catalog with no `infra:` block. Running
+  `status` with no active lab now names the new command, so nobody hunts for a
+  behaviour that moved.
+
+
 ### Fixed
 
 - **The release guard gave a green light when it could not measure.** Publishing

--- a/docs/commands.fr.md
+++ b/docs/commands.fr.md
@@ -35,6 +35,7 @@ complet de la plateforme dans le terminal, `dsoxlab fullhelp`.
 | `dsoxlab fullhelp` | Affiche le guide complet de la plateforme (concepts, workflow, commandes). |
 | `dsoxlab guide` | Ouvre le guide en ligne du lab dans le navigateur. |
 | `dsoxlab hint` | Affiche le prochain indice du challenge (déduit des points au score final). |
+| `dsoxlab infra status` | Vérifie la connectivité SSH des hôtes déclarés dans meta.yml, et nomme la cause quand l'un reste muet. |
 | `dsoxlab install` | Déprécié : utilise « dsoxlab completion install ». Installe l'auto-complétion. |
 | `dsoxlab instructor bootstrap` | Génère la clé SSH du lab (si absente) et vérifie que terraform/ansible-runner sont installés. |
 | `dsoxlab list-labs` | Liste tous les labs disponibles (filtrés par contexte actif si défini). |
@@ -46,7 +47,7 @@ complet de la plateforme dans le terminal, `dsoxlab fullhelp`.
 | `dsoxlab scores` | Affiche l'historique des scores enregistrés. |
 | `dsoxlab show` | Affiche le détail et le statut d'un lab. |
 | `dsoxlab ssh` | Ouvre une session SSH interactive sur un hôte du lab. |
-| `dsoxlab status` | Vérifie la connectivité SSH des hôtes déclarés dans meta.yml, et nomme la cause quand l'un reste muet. |
+| `dsoxlab status` | Où en est le lab actif : non commencé, prêt, en cours, validé. |
 | `dsoxlab submit` | Soumission finale : lance les tests, enregistre le score, puis tapez 'exit' pour quitter la session. |
 | `dsoxlab support` | Produit un rapport de diagnostic anonymisé, à coller dans une issue. |
 | `dsoxlab use` | Définit le contexte actif (section et/ou niveau par défaut). Utilisez --reset pour l'effacer. |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,6 +34,7 @@ guide in the terminal, `dsoxlab fullhelp`.
 | `dsoxlab fullhelp` | Show the complete platform guide (concepts, workflow, commands). |
 | `dsoxlab guide` | Open the lab's online guide in your web browser. |
 | `dsoxlab hint` | Show the next challenge hint (deducts points from final score). |
+| `dsoxlab infra status` | Check SSH connectivity to all hosts declared in meta.yml, and name the cause when one stays silent. |
 | `dsoxlab install` | Deprecated: use `dsoxlab completion install`. Installs shell completion. |
 | `dsoxlab instructor bootstrap` | Generate the lab SSH key (if missing) and check that terraform/ansible-runner are installed. |
 | `dsoxlab list-labs` | List all available labs (filtered by active context if set). |
@@ -45,7 +46,7 @@ guide in the terminal, `dsoxlab fullhelp`.
 | `dsoxlab scores` | Show recorded scores history. |
 | `dsoxlab show` | Show details and status of a lab. |
 | `dsoxlab ssh` | Open an interactive SSH session on a lab host. |
-| `dsoxlab status` | Check SSH connectivity to all hosts declared in meta.yml, and name the cause when one stays silent. |
+| `dsoxlab status` | Where the active lab stands: not started, ready, in progress, validated. |
 | `dsoxlab submit` | Final submission: run tests, record score, then type 'exit' to leave the session. |
 | `dsoxlab support` | Produce an anonymised diagnostic report, ready to paste into an issue. |
 | `dsoxlab use` | Sets the active context (section and/or default level). Use --reset to clear it. |

--- a/docs/files.fr.md
+++ b/docs/files.fr.md
@@ -43,6 +43,7 @@ sous `<catalogue>/ssh/id_ed25519` et son `.pub`, produite par
 | `~/.cache/dsoxlab/version-check.json` | Dernière version vue sur PyPI, et sa date | `XDG_CACHE_HOME` |
 | `~/.local/share/dsoxlab/demo/` | Catalogue de démonstration installé par `dsoxlab demo` | `XDG_DATA_HOME` |
 | `~/.local/share/dsoxlab/catalogs/` | Catalogues installés par `dsoxlab catalog add`, un sous-répertoire par identifiant | `XDG_DATA_HOME` |
+| `~/.local/state/dsoxlab/<catalog-id>/labs/` | Points de départ du travail, pour distinguer un lab *prêt* d'un lab *en cours* | `XDG_STATE_HOME` |
 | `~/.local/state/dsoxlab/catalogue-actif` | Identifiant du catalogue actif, celui qu'on utilise sans se placer dans son répertoire | `XDG_STATE_HOME` |
 | `~/.ssh/config.d/<catalog-id>.conf` | Fragment SSH des hôtes du lab, pour que `ssh`, `scp` et votre IDE les atteignent par leur nom | aucune |
 

--- a/docs/files.md
+++ b/docs/files.md
@@ -42,6 +42,7 @@ The private half must never be committed.
 | `~/.cache/dsoxlab/version-check.json` | last version seen on PyPI, and when | `XDG_CACHE_HOME` |
 | `~/.local/share/dsoxlab/demo/` | demonstration catalog installed by `dsoxlab demo` | `XDG_DATA_HOME` |
 | `~/.local/share/dsoxlab/catalogs/` | catalogs installed by `dsoxlab catalog add`, one subdirectory per id | `XDG_DATA_HOME` |
+| `~/.local/state/dsoxlab/<catalog-id>/labs/` | work starting points, to tell a *ready* lab from one *in progress* | `XDG_STATE_HOME` |
 | `~/.local/state/dsoxlab/catalogue-actif` | id of the active catalog, the one used without sitting in its directory | `XDG_STATE_HOME` |
 | `~/.ssh/config.d/<catalog-id>.conf` | SSH fragment for the lab hosts, so `ssh`, `scp` and your IDE reach them by name | none |
 

--- a/docs/machine-output.fr.md
+++ b/docs/machine-output.fr.md
@@ -234,6 +234,51 @@ La commande sort en 1 quand `ok` vaut faux, et rend le document quand même.
 
 ## `status`
 
+L'état du lab actif, ou de celui qu'on nomme.
+
+```json
+{
+  "schema": 1,
+  "lab": "l2-swap-management",
+  "state": "in_progress",
+  "label": "en cours",
+  "detail": "Le travail a commencé dans /chemin/challenge/work",
+  "best_score": null,
+  "max_score": null
+}
+```
+
+| Champ | Type | Sens |
+| --- | --- | --- |
+| `lab` | chaîne ou null | l'identifiant du lab ; `null` quand aucun n'est actif |
+| `state` | chaîne ou null | un **jeton stable**, voir la table ci-dessous |
+| `label` | chaîne | le même état, traduit, pour les yeux |
+| `detail` | chaîne | ce qui a été observé, et le geste qui suit |
+| `best_score` / `max_score` | entier ou null | la meilleure note obtenue, s'il y en a une |
+
+| `state` | Ce qu'il veut dire |
+| --- | --- |
+| `not_started` | rien n'est préparé pour ce lab |
+| `ready` | l'environnement est prêt, et rien n'y a été touché |
+| `in_progress` | le travail a commencé |
+| `validated` | une note a été obtenue |
+| `degraded` | un service déclaré ne tourne plus : le lab est injouable en l'état |
+
+`state` et `label` sont séparés à dessein. Une intégration qui filtre sur
+« validé » ne doit pas dépendre de la langue de qui a lancé la commande : le
+jeton ne bouge pas, le libellé suit `DSOXLAB_LANG`.
+
+`ready` et `in_progress` ne diffèrent que par le contenu du répertoire de
+travail, comparé à l'empreinte que `run` a retenue au moment de le préparer.
+Sur un lab `vm`, ce travail se fait sur la machine et aucune empreinte locale ne
+le verrait : l'état y vaut `in_progress` dès la préparation, et le `detail` le
+dit plutôt que de laisser croire à une mesure qui n'a pas eu lieu.
+
+## `infra status`
+
+Portait le nom `status` jusqu'en 0.1.67.
+
+
 ```json
 {
   "schema": 1,

--- a/docs/machine-output.md
+++ b/docs/machine-output.md
@@ -232,6 +232,51 @@ The command exits 1 when `ok` is false, and still prints the document.
 
 ## `status`
 
+The state of the active lab, or of the one you name.
+
+```json
+{
+  "schema": 1,
+  "lab": "l2-swap-management",
+  "state": "in_progress",
+  "label": "in progress",
+  "detail": "Work started in /path/challenge/work",
+  "best_score": null,
+  "max_score": null
+}
+```
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `lab` | string or null | the lab id; `null` when no lab is active |
+| `state` | string or null | a **stable token**, see the table below |
+| `label` | string | the same state, translated, for eyes |
+| `detail` | string | what was observed, and the gesture that follows |
+| `best_score` / `max_score` | integer or null | the best score obtained, if any |
+
+| `state` | What it means |
+| --- | --- |
+| `not_started` | nothing is prepared for this lab |
+| `ready` | the environment is prepared, and untouched |
+| `in_progress` | work has started |
+| `validated` | a score has been obtained |
+| `degraded` | a declared service no longer runs: the lab cannot be played as is |
+
+`state` and `label` are separate on purpose. An integration filtering on
+"validated" must not depend on the language of whoever ran the command: the
+token does not move, the label follows `DSOXLAB_LANG`.
+
+`ready` and `in_progress` differ only by the contents of the working directory,
+compared with the fingerprint `run` recorded when preparing it. On a `vm` lab
+that work happens on the machine, where no local fingerprint would see it: the
+state is `in_progress` from preparation onward, and `detail` says so rather than
+implying a measurement that did not happen.
+
+## `infra status`
+
+Was named `status` until 0.1.67.
+
+
 ```json
 {
   "schema": 1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.67"
+version = "0.1.68"
 description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/generer-doc.py
+++ b/scripts/generer-doc.py
@@ -147,7 +147,7 @@ from pathlib import Path
 from dsoxlab import config, locking, logging_setup
 from dsoxlab.discovery.repo import read_repo_metadata
 from dsoxlab.infra import inventory, terraform
-from dsoxlab.services import catalog, demo, update_check
+from dsoxlab.services import catalog, demo, lab_state, update_check
 from dsoxlab.sessions import store
 from dsoxlab.templates import template_root
 
@@ -203,6 +203,7 @@ with tempfile.TemporaryDirectory() as tmp:
         update_check.cache_path(),
         catalog.racine_catalogues(),
         catalog._fichier_actif(),
+        lab_state._empreintes_dir(racine),
     ))
 
 rendus.update(str(p) for p in maison.rglob("*"))

--- a/src/dsoxlab/cli.py
+++ b/src/dsoxlab/cli.py
@@ -222,6 +222,17 @@ catalog_app = typer.Typer(
 )
 app.add_typer(catalog_app, name="catalog")
 
+# ── Sous-application 'infra' ──────────────────────────────────────────────────
+
+infra_app = typer.Typer(
+    name="infra",
+    help=_("cmd_infra_help"),
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+    cls=_I18nGroup,
+)
+app.add_typer(infra_app, name="infra")
+
 # ── Option globale lab-home ───────────────────────────────────────────────────
 
 LabHomeOption = Annotated[
@@ -932,10 +943,10 @@ def run(
             if lab.runtime.type.value in ("vm", "kvm", "incus"):
                 _run_ansible_with_progress(
                     lab.path / "setup.yaml",
-                    lambda cb: run_lab(lab, target_name=target, on_event=cb),
+                    lambda cb: run_lab(lab, target_name=target, on_event=cb, root=root),
                 )
             else:
-                run_lab(lab, target_name=target)
+                run_lab(lab, target_name=target, root=root)
         except Interrupted as exc:
             _interrompu(exc, f"dsoxlab run {lab.id}")
         except InfraNotProvisioned:
@@ -2646,8 +2657,59 @@ def _run_terraform_with_progress(
     return state["result"]
 
 
-@app.command("status", help=_("cmd_status_help"))
+@app.command("status", help=_("cmd_lab_status_help"))
 def status(
+    lab_id: Annotated[str | None, typer.Argument(help=_("arg_lab_id_optionnel"))] = None,
+    lab_home: LabHomeOption = None,
+    as_json: Annotated[bool, typer.Option("--json", help=_("opt_json"))] = False,
+) -> None:
+    """Où en est le lab actif, ou celui qu'on nomme."""
+    from .services.lab_state import calculer
+
+    root = _root(lab_home)
+    lang = _lang(root)
+    ctx = read_context(root)
+    effective_id = lab_id or ctx.active_lab
+
+    if not effective_id:
+        # Sans lab actif, dire quoi faire — et nommer la commande qui portait
+        # ce nom jusqu'en 0.1.67, pour qui la cherche encore ici.
+        if as_json:
+            machine.emit({"schema": 1, "lab": None, "state": None})
+            return
+        info(_("status_aucun_lab_actif"))
+        info(_("status_voir_infra"))
+        return
+
+    try:
+        lab = _lab(root, effective_id, lang)
+    except ValueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from None
+
+    repo_meta = _read_repo(root)
+    repo_id = repo_meta.id if repo_meta else root.name
+    etat = calculer(root, lab, repo_id)
+
+    if as_json:
+        machine.emit({
+            "schema": 1,
+            "lab": lab.id,
+            "state": etat.state,
+            "label": etat.label,
+            "detail": etat.detail,
+            "best_score": etat.best_score,
+            "max_score": etat.max_score,
+        })
+        return
+
+    from .reporting.console import print_lab_state
+
+    print_lab_state(etat)
+
+
+@infra_app.command("status", help=_("cmd_status_help"))
+def infra_status(
     lab_home: LabHomeOption = None,
     as_json: Annotated[bool, typer.Option("--json", help=_("opt_json"))] = False,
 ) -> None:

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -113,6 +113,32 @@ STRINGS: dict[str, str] = {
         "Then, once the mission is done: dsoxlab check {lab}",
 
     # ── catalog: discover, install and locate a catalogue ───────────────────
+    "cmd_lab_status_help":
+        "Where the active lab stands: not started, ready, in progress, validated.",
+    "arg_lab_id_optionnel":
+        "Lab id. Defaults to the active lab.",
+    "lab_state_not_started": "not started",
+    "lab_state_not_started_detail":
+        "Nothing is prepared yet. Start with: dsoxlab run {lab}",
+    "lab_state_ready": "ready",
+    "lab_state_ready_detail": "Environment prepared, untouched: {path}",
+    "lab_state_in_progress": "in progress",
+    "lab_state_in_progress_detail": "Work started in {path}",
+    "lab_state_in_progress_vm":
+        "Prepared; the work happens on the lab machine.",
+    "lab_state_validated": "validated",
+    "lab_state_validated_detail": "Score obtained: {score} / {max}",
+    "lab_state_degraded": "degraded",
+    "lab_state_degraded_detail":
+        "A declared service is no longer running: {services}. "
+        "Restart it with: dsoxlab run <lab>",
+    "status_aucun_lab_actif":
+        "No active lab in this catalog. Pick one: dsoxlab run <lab>",
+    "status_voir_infra":
+        "For the infrastructure state, it is now: dsoxlab infra status",
+    "status_titre": "Lab state",
+    "cmd_infra_help": "Infrastructure commands for the catalog.",
+
     "cmd_catalog_help":
         "Discover, install and update lab catalogues.",
     "cmd_catalog_list_help":
@@ -468,11 +494,19 @@ Each lab declares:
                        names the command that removes them.
     [dim]--host <fqdn>[/dim]         Target a single machine. Repeatable.
 
-  [cyan]status[/cyan]               Check SSH connectivity of the declared hosts, and say why
+  [cyan]status [lab][/cyan]         Where the active lab stands, or the one you name:
+                       [bold]not started[/bold], [bold]ready[/bold], [bold]in progress[/bold], [bold]validated[/bold], or
+                       [bold]degraded[/bold] when a declared service no longer runs. Ready
+                       and in progress differ by the contents of the working
+                       directory, compared with what [cyan]run[/cyan] had put there.
+    [dim]--json[/dim]               The state under a stable key, readable without translating.
+
+  [cyan]infra status[/cyan]         Check SSH connectivity of the declared hosts, and say why
                        one stays silent. On a provider whose machine state can
                        be queried, the hypervisor is [bold]asked[/bold]: a domain that
                        does not exist, one that is stopped and one that is
                        booting call for three different gestures.
+                       [dim]Was named « status » until 0.1.67.[/dim]
     [dim]--json[/dim]               Host reachability, as a document.
 
   [cyan]ssh <host>[/cyan]           Open an interactive session on a lab host.

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -114,6 +114,32 @@ STRINGS: dict[str, str] = {
         "Puis, une fois la mission remplie : dsoxlab check {lab}",
 
     # ── catalog : découvrir, installer et retrouver un catalogue ────────────
+    "cmd_lab_status_help":
+        "Où en est le lab actif : non commencé, prêt, en cours, validé.",
+    "arg_lab_id_optionnel":
+        "Identifiant du lab. Par défaut, le lab actif.",
+    "lab_state_not_started": "non commencé",
+    "lab_state_not_started_detail":
+        "Rien n'est encore préparé. Commence : dsoxlab run {lab}",
+    "lab_state_ready": "prêt",
+    "lab_state_ready_detail": "Environnement préparé, rien n'y a été touché : {path}",
+    "lab_state_in_progress": "en cours",
+    "lab_state_in_progress_detail": "Le travail a commencé dans {path}",
+    "lab_state_in_progress_vm":
+        "Préparé, le travail se fait sur la machine du lab.",
+    "lab_state_validated": "validé",
+    "lab_state_validated_detail": "Note obtenue : {score} / {max}",
+    "lab_state_degraded": "dégradé",
+    "lab_state_degraded_detail":
+        "Un service déclaré ne tourne plus : {services}. "
+        "Relance-le : dsoxlab run <lab>",
+    "status_aucun_lab_actif":
+        "Aucun lab actif dans ce catalogue. Choisis-en un : dsoxlab run <lab>",
+    "status_voir_infra":
+        "Pour l'état de l'infrastructure, c'est désormais : dsoxlab infra status",
+    "status_titre": "État du lab",
+    "cmd_infra_help": "Commandes d'infrastructure du catalogue.",
+
     "cmd_catalog_help":
         "Découvre, installe et met à jour les catalogues de labs.",
     "cmd_catalog_list_help":
@@ -471,11 +497,19 @@ Chaque lab déclare :
                        hyperviseur, et nomme la commande qui les retire.
     [dim]--host <fqdn>[/dim]         Ne cible qu'une machine. Répétable.
 
-  [cyan]status[/cyan]               Vérifie la connectivité SSH des hôtes déclarés, et dit
+  [cyan]status [lab][/cyan]         Où en est le lab actif, ou celui qu'on nomme :
+                       [bold]non commencé[/bold], [bold]prêt[/bold], [bold]en cours[/bold], [bold]validé[/bold], ou [bold]dégradé[/bold]
+                       quand un service déclaré ne tourne plus. Prêt et en cours
+                       se distinguent par le contenu du répertoire de travail,
+                       comparé à ce que [cyan]run[/cyan] y avait posé.
+    [dim]--json[/dim]               L'état sous une clé stable, lisible sans traduire.
+
+  [cyan]infra status[/cyan]         Vérifie la connectivité SSH des hôtes déclarés, et dit
                        pourquoi l'un reste muet. Sur un provider dont l'état des
                        machines est interrogeable, l'hyperviseur est [bold]interrogé[/bold] :
                        un domaine absent, un domaine arrêté et un domaine qui
                        boote appellent trois gestes différents.
+                       [dim]Portait le nom « status » jusqu'en 0.1.67.[/dim]
     [dim]--json[/dim]               La joignabilité des hôtes, en document.
 
   [cyan]ssh <hote>[/cyan]           Ouvre une session interactive sur un hôte du lab.

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -23,6 +23,7 @@ from ..models.course import CourseManifest, CourseSection
 from ..models.lab import LabDefinition
 from ..services.catalog import CatalogueConnu, CatalogueInstalle
 from ..services.doctor import STATE_CHOICE_REQUIRED, Check, DoctorReport
+from ..services.lab_state import LabState
 from ..services.progress_service import build_progress, exam_verdict
 from ..validators.structure import StructureReport
 
@@ -346,6 +347,26 @@ def print_catalogues(
     for pose in installes:
         table.add_row(pose.id, "✔" if pose.actif else "", str(pose.racine))
     console.print(table)
+
+
+def print_lab_state(etat: LabState) -> None:
+    """L'état d'un lab, en un panneau qui tient à l'écran.
+
+    La couleur suit le verdict et non l'avancement : un lab dégradé appelle un
+    geste immédiat, un lab validé n'en appelle aucun, et les deux intermédiaires
+    disent seulement où on en est.
+    """
+    couleurs = {
+        "not_started": "dim",
+        "ready": "cyan",
+        "in_progress": "yellow",
+        "validated": "green",
+        "degraded": "red",
+    }
+    teinte = couleurs.get(etat.state, "white")
+    corps = f"[bold {teinte}]{etat.label}[/bold {teinte}]\n{etat.detail}"
+    console.print(Panel(corps, title=f"{_('status_titre')} — {etat.lab_id}",
+                        border_style=teinte, expand=False))
 
 
 def print_doctor(report: DoctorReport) -> None:

--- a/src/dsoxlab/services/lab_service.py
+++ b/src/dsoxlab/services/lab_service.py
@@ -173,10 +173,22 @@ def run_lab(
     target_name: str | None = None,
     *,
     on_event: EventCallback | None = None,
+    root: Path | None = None,
 ) -> None:
-    """Prépare et démarre l'environnement du lab (setup uniquement)."""
+    """Prépare et démarre l'environnement du lab (setup uniquement).
+
+    ``root`` sert à retenir le point de départ du travail, ce qui permet à
+    ``dsoxlab status`` de distinguer plus tard un lab *prêt* d'un lab *en
+    cours*. Il est optionnel pour ne casser aucun appelant, et l'enregistrement
+    n'a lieu qu'**après** un démarrage réussi : marquer un départ qui n'a pas eu
+    lieu ferait dire « en cours » d'un lab que rien n'a préparé.
+    """
     runtime = _manager.get(lab)
     runtime.start(lab, target_name, on_event=on_event)
+    if root is not None:
+        from .lab_state import enregistrer_depart
+
+        enregistrer_depart(root, lab)
 
 
 def open_lab_session(lab: LabDefinition) -> None:

--- a/src/dsoxlab/services/lab_state.py
+++ b/src/dsoxlab/services/lab_state.py
@@ -1,0 +1,229 @@
+"""L'état d'un lab, calculé à un seul endroit.
+
+« Où en suis-je ? » n'avait pas de réponse dans l'outil. L'état existait, mais
+éparpillé : le contexte actif dans un JSON, la note dans une base SQLite, le
+répertoire de travail sur le disque, les conteneurs chez Docker. Chaque commande
+en reconstituait un morceau à sa façon, donc aucune ne pouvait répondre.
+
+Cinq états, et une seule fonction qui les calcule :
+
+    non commencé ──run──▶ prêt ──travail──▶ en cours ──note──▶ validé
+                             │                  │                │
+                             └──────────────────┴────────────────┘
+                                    dépendance tombée
+                                            ▼
+                                        dégradé
+
+``dégradé`` n'est pas une étape du parcours mais un constat qui se superpose : un
+service déclaré qui ne tourne plus rend le lab injouable, quel que soit
+l'avancement. Il prime donc sur les autres, parce que c'est la seule information
+qui appelle un geste immédiat.
+
+**Le jeton et le libellé sont séparés**, comme pour ``doctor`` : ``state`` est
+stable et se lit sans traduire, ``label`` est traduit et se lit avec les yeux.
+Une intégration qui filtre sur « validé » ne doit pas dépendre de la langue de
+qui a lancé la commande.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..config import xdg_state_home
+from ..i18n import _
+from ..locking import lock_identity
+from ..models.lab import LabDefinition
+from ..models.runtime import RuntimeType
+from ..sessions import store
+
+#: Rien n'a encore été préparé pour ce lab.
+NOT_STARTED = "not_started"
+#: L'environnement est prêt, et rien n'y a été touché.
+READY = "ready"
+#: Le travail a commencé : le répertoire de travail diffère de ce que `run` y a posé.
+IN_PROGRESS = "in_progress"
+#: Une note a été obtenue par `check` ou `submit`.
+VALIDATED = "validated"
+#: Une dépendance déclarée est tombée : le lab est injouable en l'état.
+DEGRADED = "degraded"
+
+#: Ordre de parcours, pour les affichages qui veulent une progression.
+ETATS = (NOT_STARTED, READY, IN_PROGRESS, VALIDATED)
+
+
+@dataclass(frozen=True)
+class LabState:
+    """L'état d'un lab, et de quoi le dire à un humain comme à un programme."""
+
+    lab_id: str
+    state: str
+    label: str
+    detail: str
+    best_score: int | None = None
+    max_score: int | None = None
+
+
+def _empreintes_dir(root: Path) -> Path:
+    """Où les empreintes de départ sont retenues.
+
+    Sous ``XDG_STATE_HOME`` et non dans le lab : c'est un état recalculable,
+    dont la perte coûte au pire un état affiché « prêt » là où le travail avait
+    commencé. L'écrire dans le catalogue le ferait apparaître dans un
+    ``git status``, ou pire, dans un commit d'apprenant.
+    """
+    return xdg_state_home() / "dsoxlab" / lock_identity(root) / "labs"
+
+
+def _empreinte_workdir(workdir: Path) -> str:
+    """Empreinte du contenu d'un répertoire de travail.
+
+    Les chemins **et** le contenu : renommer un fichier est un travail, en vider
+    un aussi. Les mtimes en sont exclus à dessein, une copie ou un `touch` ne
+    devant pas passer pour du travail.
+    """
+    digest = hashlib.sha256()
+    if not workdir.is_dir():
+        return ""
+    for chemin in sorted(workdir.rglob("*")):
+        relatif = chemin.relative_to(workdir).as_posix()
+        digest.update(relatif.encode("utf-8"))
+        if chemin.is_file():
+            try:
+                digest.update(chemin.read_bytes())
+            except OSError:
+                # Un fichier illisible reste une différence observable : on note
+                # son chemin, déjà pris en compte, et on continue.
+                continue
+    return digest.hexdigest()
+
+
+#: Marque posée pour un lab dont le travail n'est pas observable localement.
+_PREPARE = "prepare"
+
+
+def enregistrer_depart(root: Path, lab: LabDefinition) -> None:
+    """Retient le point de départ au moment où `run` vient de préparer le lab.
+
+    Sans lui, « en cours » serait indistinguable de « prêt » : un répertoire de
+    travail existe dès que `run` l'a créé, qu'on y ait touché ou non.
+
+    Pour un lab ``shell``, ce point de départ est l'empreinte du travail. Pour un
+    lab ``vm``, le travail se fait sur la machine et aucune empreinte locale ne
+    le verrait : on retient alors une simple marque, qui dit que la préparation
+    a eu lieu et rien de plus.
+    """
+    if lab.runtime.type is RuntimeType.SHELL:
+        workdir = (lab.path / lab.runtime.workdir).resolve()
+        contenu = _empreinte_workdir(workdir)
+    else:
+        contenu = _PREPARE
+    fichier = _empreintes_dir(root) / f"{lab.id}.sha256"
+    fichier.parent.mkdir(parents=True, exist_ok=True)
+    fichier.write_text(contenu + "\n", encoding="utf-8")
+
+
+def _depart_connu(root: Path, lab_id: str) -> str | None:
+    fichier = _empreintes_dir(root) / f"{lab_id}.sha256"
+    try:
+        return fichier.read_text(encoding="utf-8").strip() or None
+    except OSError:
+        return None
+
+
+def oublier_depart(root: Path, lab_id: str) -> None:
+    """Efface le point de départ, quand `clean` ou `reset` défait la préparation."""
+    fichier = _empreintes_dir(root) / f"{lab_id}.sha256"
+    try:
+        fichier.unlink()
+    except OSError:
+        return
+
+
+def _services_degrades(lab: LabDefinition, repo_id: str) -> list[str]:
+    """Les services déclarés qui ne tournent plus.
+
+    On n'interroge Docker que si le lab en déclare : un catalogue sans service
+    ne doit pas payer un appel, ni virer au rouge parce que Docker est absent
+    d'une machine qui n'en a pas besoin.
+    """
+    if not lab.runtime.services:
+        return []
+    from ..runtimes import services as svc
+
+    if not svc.docker_available():
+        return []
+    tombes: list[str] = []
+    for service in lab.runtime.services:
+        etat = svc.status(service, repo_id)
+        # `absent` n'est pas une dégradation : le lab n'a simplement pas été
+        # démarré. C'est un service qui a existé puis s'est arrêté qui l'est.
+        if etat.detail == "stopped":
+            tombes.append(service.name)
+    return tombes
+
+
+def calculer(root: Path, lab: LabDefinition, repo_id: str) -> LabState:
+    """L'état d'un lab, et lui seul : aucune commande ne doit le recalculer.
+
+    L'ordre des questions est l'ordre de ce qui prime. Une dégradation d'abord,
+    puisqu'elle appelle un geste immédiat quel que soit l'avancement ; la note
+    ensuite, parce qu'un lab validé le reste ; puis le travail, puis la simple
+    préparation.
+    """
+    scores = store.get_best_scores(root, [lab.id])
+    meilleur, maximum = scores.get(lab.id, (None, None))
+
+    tombes = _services_degrades(lab, repo_id)
+    if tombes:
+        return LabState(
+            lab_id=lab.id, state=DEGRADED,
+            label=_("lab_state_degraded"),
+            detail=_("lab_state_degraded_detail", services=", ".join(sorted(tombes))),
+            best_score=meilleur, max_score=maximum,
+        )
+
+    if meilleur is not None:
+        return LabState(
+            lab_id=lab.id, state=VALIDATED,
+            label=_("lab_state_validated"),
+            detail=_("lab_state_validated_detail", score=meilleur, max=maximum),
+            best_score=meilleur, max_score=maximum,
+        )
+
+    if lab.runtime.type is RuntimeType.SHELL:
+        workdir = (lab.path / lab.runtime.workdir).resolve()
+        if not workdir.is_dir():
+            return LabState(
+                lab_id=lab.id, state=NOT_STARTED,
+                label=_("lab_state_not_started"),
+                detail=_("lab_state_not_started_detail", lab=lab.id),
+            )
+        depart = _depart_connu(root, lab.id)
+        if depart is not None and depart != _empreinte_workdir(workdir):
+            return LabState(
+                lab_id=lab.id, state=IN_PROGRESS,
+                label=_("lab_state_in_progress"),
+                detail=_("lab_state_in_progress_detail", path=str(workdir)),
+            )
+        return LabState(
+            lab_id=lab.id, state=READY,
+            label=_("lab_state_ready"),
+            detail=_("lab_state_ready_detail", path=str(workdir)),
+        )
+
+    # Runtime vm : le travail se fait sur la machine, hors de portée d'une
+    # empreinte locale. Le point de départ enregistré par `run` dit donc
+    # seulement que la préparation a eu lieu.
+    if _depart_connu(root, lab.id) is not None:
+        return LabState(
+            lab_id=lab.id, state=IN_PROGRESS,
+            label=_("lab_state_in_progress"),
+            detail=_("lab_state_in_progress_vm"),
+        )
+    return LabState(
+        lab_id=lab.id, state=NOT_STARTED,
+        label=_("lab_state_not_started"),
+        detail=_("lab_state_not_started_detail", lab=lab.id),
+    )

--- a/tests/test_etat_libvirt.py
+++ b/tests/test_etat_libvirt.py
@@ -700,7 +700,7 @@ def test_status_json_porte_l_etat_de_chaque_domaine(
     )
     ssh_muet("No route to host")
 
-    resultat = runner.invoke(app, ["status", "--json", "--lab-home", str(depot)])
+    resultat = runner.invoke(app, ["infra", "status", "--json", "--lab-home", str(depot)])
 
     doc = json.loads(resultat.stdout)
     par_hote = {h["fqdn"]: h for h in doc["hosts"]}
@@ -730,7 +730,7 @@ def test_status_nomme_la_cause_et_le_geste(
     )
     ssh_muet("No route to host")
 
-    resultat = runner.invoke(app, ["status", "--lab-home", str(depot)])
+    resultat = runner.invoke(app, ["infra", "status", "--lab-home", str(depot)])
 
     sortie = _texte(resultat)
     assert resultat.exit_code == 1
@@ -750,7 +750,7 @@ def test_status_dit_qu_il_n_a_pas_pu_regarder(
     monkeypatch.setattr(libvirt, "run_command", virsh_injoignable)
     ssh_muet("Connection refused")
 
-    resultat = runner.invoke(app, ["status", "--lab-home", str(depot)])
+    resultat = runner.invoke(app, ["infra", "status", "--lab-home", str(depot)])
 
     sortie = _texte(resultat)
     assert resultat.exit_code == 1, "un diagnostic impossible n'est pas un plantage"
@@ -770,7 +770,7 @@ def test_status_le_dit_aussi_quand_le_provider_n_a_pas_d_etat(
     monkeypatch.setenv("DSOXLAB_PROVIDER", "incus")
     ssh_muet("No route to host")
 
-    resultat = runner.invoke(app, ["status", "--lab-home", str(depot)])
+    resultat = runner.invoke(app, ["infra", "status", "--lab-home", str(depot)])
 
     sortie = _texte(resultat)
     assert resultat.exit_code == 1

--- a/tests/test_lab_state.py
+++ b/tests/test_lab_state.py
@@ -1,0 +1,278 @@
+"""L'état d'un lab, et le chemin qui y mène (issue #80).
+
+« Où en suis-je ? » n'avait pas de réponse : l'état existait, éparpillé entre un
+JSON, une base SQLite, un répertoire de travail et Docker. Ce module éprouve la
+fonction qui le calcule, **une transition par test**, et surtout ce qui les
+sépare :
+
+- *prêt* et *en cours* ne diffèrent que par le contenu du répertoire de travail,
+  comparé au point de départ que `run` a retenu ;
+- *validé* prime sur les deux, une note obtenue ne se perdant pas ;
+- *dégradé* prime sur tout, parce que c'est le seul état qui appelle un geste
+  immédiat.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dsoxlab.models.lab import LabDefinition
+from dsoxlab.services import lab_state
+from dsoxlab.sessions import store
+
+_BASE = """\
+id: l1-demo
+title: Demo lab
+level: beginner
+skills: [demo]
+distros: [any]
+doc_url: https://example.org/docs/demo/
+"""
+
+
+@pytest.fixture(autouse=True)
+def xdg_jetable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Les empreintes vont sous XDG : aucun test n'écrit dans le vrai ~/.local."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+
+def _depot(tmp_path: Path) -> Path:
+    racine = tmp_path / "catalogue"
+    (racine / "labs").mkdir(parents=True, exist_ok=True)
+    (racine / "meta.yml").write_text(
+        "repo:\n  id: essai\n  category: essai\n", encoding="utf-8")
+    return racine
+
+
+def _lab_shell(tmp_path: Path, *, workdir: str = "challenge/work") -> LabDefinition:
+    racine = _depot(tmp_path) / "labs" / "l1-demo"
+    racine.mkdir(parents=True, exist_ok=True)
+    (racine / "lab.yaml").write_text(
+        _BASE + f"runtime:\n  type: shell\n  workdir: {workdir}\n", encoding="utf-8")
+    return LabDefinition.from_yaml(racine / "lab.yaml")
+
+
+def _lab_vm(tmp_path: Path) -> LabDefinition:
+    racine = _depot(tmp_path) / "labs" / "l1-demo"
+    racine.mkdir(parents=True, exist_ok=True)
+    (racine / "lab.yaml").write_text(
+        _BASE
+        + "runtime:\n  type: vm\n  targets:\n    - name: t\n      host: h.lab\n",
+        encoding="utf-8",
+    )
+    return LabDefinition.from_yaml(racine / "lab.yaml")
+
+
+# ── Les transitions, une par test ───────────────────────────────────────────
+
+def test_sans_rien_le_lab_n_est_pas_encore_commence(tmp_path: Path) -> None:
+    lab = _lab_shell(tmp_path)
+    etat = lab_state.calculer(_depot(tmp_path), lab, "essai")
+
+    assert etat.state == lab_state.NOT_STARTED
+    assert lab.id in etat.detail, "le message doit nommer le lab à lancer"
+
+
+def test_apres_run_le_lab_est_pret(tmp_path: Path) -> None:
+    racine = _depot(tmp_path)
+    lab = _lab_shell(tmp_path)
+    (lab.path / "challenge" / "work").mkdir(parents=True)
+    lab_state.enregistrer_depart(racine, lab)
+
+    assert lab_state.calculer(racine, lab, "essai").state == lab_state.READY
+
+
+def test_un_travail_touche_fait_passer_en_cours(tmp_path: Path) -> None:
+    """La distinction qui motive tout le mécanisme.
+
+    Un répertoire de travail existe dès que `run` l'a créé : sans point de
+    départ, « en cours » serait indistinguable de « prêt ».
+    """
+    racine = _depot(tmp_path)
+    lab = _lab_shell(tmp_path)
+    travail = lab.path / "challenge" / "work"
+    travail.mkdir(parents=True)
+    (travail / "main.tf").write_text("resource {}\n", encoding="utf-8")
+    lab_state.enregistrer_depart(racine, lab)
+
+    assert lab_state.calculer(racine, lab, "essai").state == lab_state.READY
+
+    (travail / "main.tf").write_text("resource { modifie }\n", encoding="utf-8")
+
+    assert lab_state.calculer(racine, lab, "essai").state == lab_state.IN_PROGRESS
+
+
+def test_un_fichier_ajoute_compte_comme_du_travail(tmp_path: Path) -> None:
+    racine = _depot(tmp_path)
+    lab = _lab_shell(tmp_path)
+    travail = lab.path / "challenge" / "work"
+    travail.mkdir(parents=True)
+    lab_state.enregistrer_depart(racine, lab)
+
+    (travail / "reponse.txt").write_text("ma réponse\n", encoding="utf-8")
+
+    assert lab_state.calculer(racine, lab, "essai").state == lab_state.IN_PROGRESS
+
+
+def test_une_note_obtenue_vaut_valide(tmp_path: Path) -> None:
+    racine = _depot(tmp_path)
+    lab = _lab_shell(tmp_path)
+    (lab.path / "challenge" / "work").mkdir(parents=True)
+    lab_state.enregistrer_depart(racine, lab)
+    store.record_result(racine, lab_id=lab.id, section="essai",
+                        score=80, max_score=100,
+                        passed_tests=4, total_tests=5,
+                        hints_used=0)
+
+    etat = lab_state.calculer(racine, lab, "essai")
+
+    assert etat.state == lab_state.VALIDATED
+    assert etat.best_score == 80 and etat.max_score == 100
+
+
+def test_valide_prime_sur_le_travail_en_cours(tmp_path: Path) -> None:
+    """Une note ne se perd pas parce qu'on retouche ensuite au travail."""
+    racine = _depot(tmp_path)
+    lab = _lab_shell(tmp_path)
+    travail = lab.path / "challenge" / "work"
+    travail.mkdir(parents=True)
+    lab_state.enregistrer_depart(racine, lab)
+    store.record_result(racine, lab_id=lab.id, section="essai",
+                        score=80, max_score=100,
+                        passed_tests=4, total_tests=5,
+                        hints_used=0)
+    (travail / "encore.txt").write_text("je continue\n", encoding="utf-8")
+
+    assert lab_state.calculer(racine, lab, "essai").state == lab_state.VALIDATED
+
+
+def test_un_service_tombe_rend_le_lab_degrade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le seul état qui appelle un geste immédiat prime sur tous les autres."""
+    racine = _depot(tmp_path) / "labs" / "l1-demo"
+    racine.mkdir(parents=True, exist_ok=True)
+    (racine / "lab.yaml").write_text(
+        _BASE
+        + "runtime:\n  type: shell\n  workdir: challenge/work\n"
+        + "  services:\n    - name: db\n      image: postgres:16\n",
+        encoding="utf-8",
+    )
+    lab = LabDefinition.from_yaml(racine / "lab.yaml")
+    depot = _depot(tmp_path)
+    store.record_result(depot, lab_id=lab.id, section="essai",
+                        score=100, max_score=100,
+                        passed_tests=5, total_tests=5,
+                        hints_used=0)
+
+    from dsoxlab.runtimes import services as svc
+
+    monkeypatch.setattr(svc, "docker_available", lambda: True)
+    monkeypatch.setattr(svc, "status", lambda service, repo: svc.ServiceStatus(
+        name=service.name, container="c", running=False, detail="stopped"))
+
+    etat = lab_state.calculer(depot, lab, "essai")
+
+    assert etat.state == lab_state.DEGRADED
+    assert "db" in etat.detail, "le message doit nommer le service tombé"
+
+
+def test_un_service_jamais_demarre_n_est_pas_une_degradation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`absent` veut dire « pas encore lancé », pas « tombé ».
+
+    Les confondre ferait virer au rouge tout lab à service jamais démarré,
+    c'est-à-dire le cas normal avant le premier `run`.
+    """
+    racine = _depot(tmp_path) / "labs" / "l1-demo"
+    racine.mkdir(parents=True, exist_ok=True)
+    (racine / "lab.yaml").write_text(
+        _BASE
+        + "runtime:\n  type: shell\n  workdir: challenge/work\n"
+        + "  services:\n    - name: db\n      image: postgres:16\n",
+        encoding="utf-8",
+    )
+    lab = LabDefinition.from_yaml(racine / "lab.yaml")
+
+    from dsoxlab.runtimes import services as svc
+
+    monkeypatch.setattr(svc, "docker_available", lambda: True)
+    monkeypatch.setattr(svc, "status", lambda service, repo: svc.ServiceStatus(
+        name=service.name, container="c", running=False, detail="absent"))
+
+    assert lab_state.calculer(_depot(tmp_path), lab, "essai").state != lab_state.DEGRADED
+
+
+def test_docker_absent_ne_degrade_aucun_lab(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Une machine sans Docker n'est pas un lab cassé : on ne sait simplement rien."""
+    racine = _depot(tmp_path) / "labs" / "l1-demo"
+    racine.mkdir(parents=True, exist_ok=True)
+    (racine / "lab.yaml").write_text(
+        _BASE
+        + "runtime:\n  type: shell\n  workdir: challenge/work\n"
+        + "  services:\n    - name: db\n      image: postgres:16\n",
+        encoding="utf-8",
+    )
+    lab = LabDefinition.from_yaml(racine / "lab.yaml")
+
+    from dsoxlab.runtimes import services as svc
+
+    monkeypatch.setattr(svc, "docker_available", lambda: False)
+
+    assert lab_state.calculer(_depot(tmp_path), lab, "essai").state != lab_state.DEGRADED
+
+
+# ── Le runtime vm : le travail est hors de portée d'une empreinte locale ────
+
+def test_un_lab_vm_non_prepare_n_est_pas_commence(tmp_path: Path) -> None:
+    lab = _lab_vm(tmp_path)
+
+    assert lab_state.calculer(_depot(tmp_path), lab, "essai").state == lab_state.NOT_STARTED
+
+
+def test_un_lab_vm_prepare_est_en_cours(tmp_path: Path) -> None:
+    """Faute de pouvoir observer le travail sur la machine, la préparation suffit.
+
+    Le détail le dit plutôt que de laisser croire à une mesure qui n'a pas eu
+    lieu.
+    """
+    racine = _depot(tmp_path)
+    lab = _lab_vm(tmp_path)
+    lab_state.enregistrer_depart(racine, lab)
+
+    etat = lab_state.calculer(racine, lab, "essai")
+
+    assert etat.state == lab_state.IN_PROGRESS
+
+
+def test_oublier_le_depart_ramene_a_non_commence(tmp_path: Path) -> None:
+    """Ce que `clean` et `reset` doivent pouvoir faire : défaire la préparation."""
+    racine = _depot(tmp_path)
+    lab = _lab_vm(tmp_path)
+    lab_state.enregistrer_depart(racine, lab)
+
+    lab_state.oublier_depart(racine, lab.id)
+
+    assert lab_state.calculer(racine, lab, "essai").state == lab_state.NOT_STARTED
+
+
+def test_les_empreintes_ne_sont_pas_ecrites_dans_le_catalogue(tmp_path: Path) -> None:
+    """Un état recalculable n'a rien à faire dans un dépôt versionné.
+
+    L'y écrire le ferait apparaître dans un `git status`, ou pire, dans un
+    commit d'apprenant.
+    """
+    racine = _depot(tmp_path)
+    lab = _lab_shell(tmp_path)
+    (lab.path / "challenge" / "work").mkdir(parents=True)
+
+    lab_state.enregistrer_depart(racine, lab)
+
+    laisses = [p for p in racine.rglob("*.sha256")]
+    assert not laisses, f"empreintes écrites dans le catalogue : {laisses}"

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.67"
+version = "0.1.68"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
« Où en suis-je ? » n'avait pas de réponse. L'état d'un lab existait, mais
éparpillé : le contexte actif dans un JSON, la note dans une base SQLite, le
répertoire de travail sur le disque, les conteneurs chez Docker. Chaque commande
en reconstituait un morceau à sa façon, donc **aucune ne pouvait répondre**.

```console
$ dsoxlab status
╭─ État du lab — l2-swap-management ─────────────╮
│ en cours                                        │
│ Le travail a commencé dans …/challenge/work     │
╰─────────────────────────────────────────────────╯
```

## Cinq états, un seul endroit qui les calcule

| `state` | Ce qu'il veut dire |
| --- | --- |
| `not_started` | rien n'est préparé |
| `ready` | environnement prêt, rien n'y a été touché |
| `in_progress` | le travail a commencé |
| `validated` | une note a été obtenue |
| `degraded` | un service déclaré ne tourne plus |

Le **jeton et le libellé sont séparés**, comme pour `doctor` : une intégration
qui filtre sur « validé » ne doit pas dépendre de la langue de qui a lancé la
commande. Vérifié dans les deux langues, `state` ne bouge pas, `label` suit.

## La distinction qui demandait une décision

`ready` et `in_progress` se distinguent par **le travail lui-même**, et non par
le fait d'avoir joué `run` : celui-ci retient une empreinte du répertoire de
travail, et l'état la compare. Ajouter un fichier, en modifier un, en vider un,
tout compte. Les mtimes en sont exclus à dessein — une copie ou un `touch` ne
doivent pas passer pour du travail.

Sur un lab `vm`, ce travail se fait sur la machine, où aucune empreinte locale ne
le verrait. L'état y vaut `in_progress` dès la préparation, et le `detail` **le
dit** plutôt que de laisser croire à une mesure qui n'a pas eu lieu.

## Deux non-dégradations, qui comptent autant que la dégradation

`degraded` prime sur tout, parce que c'est le seul état qui appelle un geste
immédiat. Mais :

- **un service jamais démarré n'est pas une dégradation** : c'est le cas normal
  avant le premier `run`, et confondre `absent` avec `stopped` ferait virer au
  rouge tout lab à service ;
- **Docker absent non plus** : on ne sait simplement rien, et une machine sans
  Docker n'est pas un lab cassé.

Les deux ont leur test.

## Les empreintes ne vont pas dans le catalogue

Un état recalculable n'a rien à faire dans un dépôt versionné : il apparaîtrait
dans un `git status`, ou pire, dans un commit d'apprenant. Elles vivent sous
`XDG_STATE_HOME`, et un test vérifie qu'aucun `.sha256` n'atterrit dans le
catalogue.

## La rupture, et comment elle est amortie

`status` ne vérifie plus la connectivité SSH : **`infra status` s'en charge, à
l'identique**. Le nom qui devait porter « où en suis-je ? » était pris par une
commande d'infrastructure, sans rien à dire sur un catalogue sans bloc `infra:`.

Lancé sans lab actif, `status` nomme la commande qui a déménagé :

```console
$ dsoxlab status
ℹ Aucun lab actif dans ce catalogue. Choisis-en un : dsoxlab run <lab>
ℹ Pour l'état de l'infrastructure, c'est désormais : dsoxlab infra status
```

Le `fullhelp` porte la même mention (« Portait le nom « status » jusqu'en
0.1.67 »), et les quatre tests qui exerçaient l'ancien comportement ont été
repointés sans rien changer à ce qu'ils vérifient.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 62 source files*
- [x] `uv run pytest` : **705 passed** (690 avant, **+15**, un par transition)
- [x] `uv run pytest tests_e2e` : **18 passed**
- [x] Le moteur reste neutre vis-à-vis du domaine
- [x] Aucun chemin personnel ; les emplacements passent par `xdg_state_home()`
- [x] Testé sur **deux dépôts fournisseurs**, transitions réelles à l'appui :
      - `terraform-training` : `not_started` → `ready` après `run` → `in_progress`
        après avoir écrit dans le workdir
      - `ansible-training` (lab `vm`) : `not_started`, et `infra status` rend bien
        l'ancien comportement

### When behavior changes

- [x] CHANGELOG EN **et** FR, dont la section `Changed` qui annonce la rupture
- [x] Version **0.1.68** ; `uv.lock` aligné

### When a command or option is added, removed or changed

- [x] Clés i18n dans **en.py et fr.py**, aides de commande et d'argument
- [x] `fullhelp` **EN et FR** : `status` réécrit, `infra status` ajouté avec la
      mention de son ancien nom
- [x] `docs/commands.*` régénérés ; `docs/machine-output.*` décrit les cinq états
      et leurs transitions, ce que l'issue demandait explicitement
- [x] `docs/files.*` documente l'emplacement des empreintes, et le relevé de
      `generer-doc.py` est étendu pour que le contrôle porte dessus
- [x] Joué sous `DSOXLAB_LANG=en` et `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched — N/A
### When the declarative contract changes — N/A

## Related issues

Closes #80

Débloque partiellement #79, dont le commentaire nomme cette machine d'état comme
l'une des deux conditions. L'autre — des retours d'utilisateurs qui butent
réellement sur l'enchaînement — n'est pas remplie, donc `start` n'est pas écrit
ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
