### PR TITLE
fix(scripts): une version annoncée et jamais publiée se dit enfin

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,29 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Corrigé
+
+- **Rien ne disait qu'une version fusionnée n'avait jamais été taguée.** C'est
+  arrivé deux fois le 2026-08-24 : la 0.1.64, puis la 0.1.68, ont été fusionnées
+  sur main, décrites au CHANGELOG, et jamais taguées. PyPI restait une version
+  en arrière pendant que le dépôt avançait. Les contrôles existants demandent
+  tous si le tag *suivant* peut être posé ; aucun ne demandait si le précédent
+  l'avait été. Une version enjambée ne se rattrape pas : la suivante prend sa
+  place, et ce que la première annonçait ne part jamais chez personne.
+
+  `check-release.py` vérifie désormais que **toute version décrite au CHANGELOG
+  est servie par l'index PyPI**, hormis celle qu'on s'apprête à publier. Il
+  interroge l'index plutôt que les tags git, parce que c'est la question qui
+  compte : la 0.1.26 est installable alors qu'aucun tag ne la porte, ayant été
+  publiée sous celui de la 0.1.25. Cette exemption est nommée et motivée dans le
+  script, comme l'est déjà la liste des chemins absents de `generer-doc.py`.
+
+  Un second test est né du premier : retirer un contrôle de la séquence de
+  `main()` ne faisait rougir aucun test, puisqu'ils appellent tous les fonctions
+  directement. Un contrôle qui existe mais que personne n'appelle ne garde rien
+  — un test vérifie maintenant que les huit sont réellement câblés.
+
+
 ## [0.1.69] - 2026-08-24
 
 ### Modifié

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Nothing said that a merged version had never been tagged.** It happened
+  twice on 2026-08-24: 0.1.64, then 0.1.68, were merged into main, described in
+  the CHANGELOG, and never tagged. PyPI stayed one version behind while the
+  repository had moved on. The existing checks all ask whether the *next* tag
+  can be pushed; none asked whether the previous one ever was. A skipped version
+  does not come back: the next one takes its place, and what the first announced
+  never reaches anyone.
+
+  `check-release.py` now verifies that **every version described in the
+  CHANGELOG is served by the PyPI index**, the current one excepted. It checks
+  the index rather than git tags because that is the question that matters:
+  0.1.26 is installable although no tag carries it, having shipped under the
+  0.1.25 tag. That exemption is named and motivated in the script, as the
+  absent-paths list of `generer-doc.py` already does.
+
+  A second test came out of testing the first: removing a check from `main()`'s
+  sequence made no test fail, since they all call the functions directly. A
+  check that exists but nobody calls guards nothing — one test now asserts the
+  eight of them are actually wired.
+
+
 ## [0.1.69] - 2026-08-24
 
 ### Changed

--- a/scripts/check-release.py
+++ b/scripts/check-release.py
@@ -276,6 +276,86 @@ _SANS_GH = (
 )
 
 
+#: Versions décrites au CHANGELOG qui ne seront jamais sur PyPI, et pourquoi.
+#:
+#: L'exemption est nominative, comme celle des chemins absents de
+#: `generer-doc.py` : une dispense globale rouvrirait la porte que ce contrôle
+#: existe pour fermer, puisque n'importe quelle version enjambée passerait
+#: ensuite inaperçue.
+VERSIONS_JAMAIS_PUBLIEES = {
+    "0.1.25": (
+        "le tag v0.1.25 a été posé sur un commit portant déjà le bump 0.1.26 : "
+        "PyPI n'a jamais reçu de 0.1.25, et tout ce qu'elle annonçait est dans "
+        "la 0.1.26. Voir la note en tête de cette section du CHANGELOG."
+    ),
+}
+
+
+def _verifier_versions_annoncees(r: Rapport, version_courante: str) -> None:
+    """Toute version décrite au CHANGELOG est-elle installable ?
+
+    Le contrôle qui manquait, et le défaut s'est produit deux fois le
+    2026-08-24 : la 0.1.64 puis la 0.1.68 ont été fusionnées sur main, décrites
+    au CHANGELOG, et jamais taguées. Personne ne l'a vu, parce que rien ne
+    regardait en arrière : les autres contrôles disent si le PROCHAIN tag peut
+    être posé, aucun ne demandait si le précédent l'avait été.
+
+    Une version enjambée ne se rattrape pas : la suivante prend sa place, et ce
+    que la première annonçait n'est jamais parti chez personne.
+
+    Le contrôle porte sur l'index PyPI et non sur les tags git, parce que c'est
+    la question qui compte — la 0.1.26 est installable alors qu'aucun tag ne la
+    porte, ayant été publiée sous celui de la 0.1.25.
+    """
+    chemin = RACINE / "CHANGELOG.md"
+    try:
+        contenu = chemin.read_text(encoding="utf-8")
+    except OSError:
+        r.note("CHANGELOG.md illisible", "Contrôle des versions annoncées sauté.")
+        return
+
+    annoncees = re.findall(r"^## \[(\d+\.\d+\.\d+)\]", contenu, re.MULTILINE)
+    if not annoncees:
+        # Garde-fou : une liste vide vaudrait feu vert sans rien avoir mesuré.
+        r.ko(
+            "Aucune version trouvée dans CHANGELOG.md",
+            "Le contrôle des versions annoncées ne mesure plus rien : "
+            "vérifie le format des titres de section.",
+        )
+        return
+
+    index = _index_simple()
+    if index is None:
+        r.note("Index PyPI injoignable",
+               "Contrôle des versions annoncées sauté.")
+        return
+
+    # La version courante est celle qu'on s'apprête à publier : normal qu'elle
+    # manque encore.
+    absentes = [v for v in annoncees
+                if v != version_courante
+                and v not in VERSIONS_JAMAIS_PUBLIEES
+                and f"dsoxlab-{v}" not in index]
+    if absentes:
+        r.ko(
+            f"{len(absentes)} version(s) annoncée(s) mais jamais publiée(s) : "
+            + ", ".join(absentes[:5]),
+            "Elles sont décrites au CHANGELOG et absentes de PyPI. Tague-les "
+            "avant de continuer, ou dis dans le CHANGELOG pourquoi elles ne "
+            "sont jamais parties.",
+        )
+        return
+    revenues = [v for v in VERSIONS_JAMAIS_PUBLIEES if f"dsoxlab-{v}" in index]
+    if revenues:
+        # L'autre bout de l'exemption : le jour où l'une d'elles est publiée,
+        # la dispense devient fausse et doit disparaître.
+        r.note(
+            f"Exemption caduque : {', '.join(revenues)} est sur PyPI",
+            "Retire-la de VERSIONS_JAMAIS_PUBLIEES dans ce script.",
+        )
+    r.ok(f"Les {len(annoncees)} versions annoncées sont publiées")
+
+
 def _verifier_ci(r: Rapport, *, ci_verifiee: bool = False) -> None:
     # RELEASING demande d'attendre une CI verte : le tag construit depuis ce
     # commit, et PyPI ne se rattrape pas.
@@ -495,6 +575,7 @@ def main() -> int:
     _verifier_changelog(r, version)
     _verifier_lock(r, version)
     _verifier_pypi(r, version)
+    _verifier_versions_annoncees(r, version)
     _verifier_ci(r, ci_verifiee=ci_verifiee)
 
     print()

--- a/tests/test_check_release.py
+++ b/tests/test_check_release.py
@@ -226,3 +226,118 @@ def test_une_ci_en_echec_reste_un_echec(
         r = cr.Rapport()
         cr._verifier_ci(r, ci_verifiee=drapeau)
         assert r.echecs, f"une CI rouge doit bloquer (ci_verifiee={drapeau})"
+
+
+# ── Les versions annoncées : celles qu'on a enjambées ───────────────────────
+
+def _index(*versions: str) -> str:
+    """Un index simple de PyPI, réduit à ce que le contrôle y cherche."""
+    return "\n".join(f"dsoxlab-{v}-py3-none-any.whl" for v in versions)
+
+
+def test_une_version_annoncee_et_jamais_publiee_bloque(
+    cr: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Le défaut qui s'est produit DEUX fois le 2026-08-24.
+
+    La 0.1.64 puis la 0.1.68 ont été fusionnées sur main, décrites au CHANGELOG,
+    et jamais taguées. Rien ne le disait : les autres contrôles regardent si le
+    PROCHAIN tag peut être posé, aucun ne demandait si le précédent l'avait été.
+    Une version enjambée ne se rattrape pas, la suivante prenant sa place.
+    """
+    (tmp_path / "CHANGELOG.md").write_text(
+        "## [0.1.69] - x\n## [0.1.68] - x\n## [0.1.67] - x\n", encoding="utf-8")
+    monkeypatch.setattr(cr, "RACINE", tmp_path)
+    monkeypatch.setattr(cr, "_index_simple", lambda: _index("0.1.67"))
+
+    r = cr.Rapport()
+    cr._verifier_versions_annoncees(r, "0.1.69")
+
+    assert r.echecs, "une version annoncée et absente de PyPI doit bloquer"
+
+
+def test_la_version_courante_n_est_pas_reprochee(
+    cr: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Celle qu'on s'apprête à publier manque forcément : c'est le cas normal."""
+    (tmp_path / "CHANGELOG.md").write_text(
+        "## [0.1.69] - x\n## [0.1.68] - x\n", encoding="utf-8")
+    monkeypatch.setattr(cr, "RACINE", tmp_path)
+    monkeypatch.setattr(cr, "_index_simple", lambda: _index("0.1.68"))
+
+    r = cr.Rapport()
+    cr._verifier_versions_annoncees(r, "0.1.69")
+
+    assert not r.echecs
+
+
+def test_une_version_exemptee_ne_bloque_pas(
+    cr: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """0.1.25 n'ira jamais sur PyPI, et le CHANGELOG dit pourquoi."""
+    (tmp_path / "CHANGELOG.md").write_text(
+        "## [0.1.26] - x\n## [0.1.25] - x\n", encoding="utf-8")
+    monkeypatch.setattr(cr, "RACINE", tmp_path)
+    monkeypatch.setattr(cr, "_index_simple", lambda: _index("0.1.26"))
+
+    r = cr.Rapport()
+    cr._verifier_versions_annoncees(r, "0.1.27")
+
+    assert not r.echecs
+    assert "0.1.25" in cr.VERSIONS_JAMAIS_PUBLIEES
+
+
+def test_un_changelog_sans_version_est_un_echec(
+    cr: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Le garde-fou du garde-fou : une liste vide vaudrait feu vert à vide."""
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\nrien\n", encoding="utf-8")
+    monkeypatch.setattr(cr, "RACINE", tmp_path)
+    monkeypatch.setattr(cr, "_index_simple", lambda: _index("0.1.68"))
+
+    r = cr.Rapport()
+    cr._verifier_versions_annoncees(r, "0.1.69")
+
+    assert r.echecs, "ne rien mesurer ne doit pas valoir « tout est bon »"
+
+
+def test_index_injoignable_ne_bloque_pas(
+    cr: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Hors ligne, on ne sait pas : on le dit, sans reprocher une absence."""
+    (tmp_path / "CHANGELOG.md").write_text("## [0.1.68] - x\n", encoding="utf-8")
+    monkeypatch.setattr(cr, "RACINE", tmp_path)
+    monkeypatch.setattr(cr, "_index_simple", lambda: None)
+
+    r = cr.Rapport()
+    cr._verifier_versions_annoncees(r, "0.1.69")
+
+    assert not r.echecs
+
+
+def test_les_controles_sont_bien_cables(cr: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Un contrôle qui existe mais que personne n'appelle ne garde rien.
+
+    Constaté en éprouvant le précédent : retirer `_verifier_versions_annoncees`
+    de la séquence de `main()` ne faisait rougir aucun test, puisque tous
+    l'appellent directement. Le contrôle aurait cessé de tourner sans un mot.
+    """
+    joues: list[str] = []
+
+    for nom in ("_verifier_arbre", "_verifier_branche", "_verifier_tag",
+                "_verifier_changelog", "_verifier_lock", "_verifier_pypi",
+                "_verifier_versions_annoncees", "_verifier_ci"):
+        monkeypatch.setattr(
+            cr, nom,
+            (lambda n: lambda *a, **k: joues.append(n))(nom),
+        )
+    monkeypatch.setattr(cr, "version_empaquetee", lambda: "0.1.99")
+    monkeypatch.setattr(cr.sys, "argv", ["check-release.py"])
+
+    cr.main()
+
+    manquants = [n for n in ("_verifier_arbre", "_verifier_branche", "_verifier_tag",
+                             "_verifier_changelog", "_verifier_lock", "_verifier_pypi",
+                             "_verifier_versions_annoncees", "_verifier_ci")
+                 if n not in joues]
+    assert not manquants, f"contrôles définis mais jamais appelés : {manquants}"


### PR DESCRIPTION
C'est arrivé **deux fois le même jour**. La 0.1.64, puis la 0.1.68, ont été
fusionnées sur main, décrites au CHANGELOG, et jamais taguées. PyPI restait une
version en arrière pendant que le dépôt avançait, et rien ne le disait.

```console
$ git show origin/main:pyproject.toml | grep version
version = "0.1.68"
$ curl -s https://pypi.org/simple/dsoxlab/ | grep -o 'dsoxlab-0\.1\.6[0-9]' | sort -u | tail -1
dsoxlab-0.1.67
```

Les contrôles existants demandent tous si le tag **suivant** peut être posé.
Aucun ne demandait si le précédent l'avait été. Or **une version enjambée ne se
rattrape pas** : la suivante prend sa place, et ce que la première annonçait ne
part jamais chez personne.

## Le contrôle

Toute version décrite au CHANGELOG doit être servie par l'index PyPI, hormis
celle qu'on s'apprête à publier.

```console
$ python3 scripts/check-release.py
  ✔ Les 67 versions annoncées sont publiées
```

**Il interroge l'index, pas les tags git**, parce que c'est la question qui
compte. La 0.1.26 est installable alors qu'aucun tag ne la porte : elle est
partie sous le tag `v0.1.25`, posé sur un commit qui portait déjà le bump
suivant. Un contrôle sur les tags l'aurait déclarée manquante à tort, et un
contrôle sur PyPI dit vrai.

## Une exemption, nominative et motivée

La 0.1.25, elle, n'ira jamais sur PyPI — son contenu est dans la 0.1.26. Elle
est exemptée **par son nom**, avec sa raison, comme la liste des chemins absents
de `generer-doc.py` :

```python
VERSIONS_JAMAIS_PUBLIEES = {
    "0.1.25": (
        "le tag v0.1.25 a été posé sur un commit portant déjà le bump 0.1.26 : "
        "PyPI n'a jamais reçu de 0.1.25, et tout ce qu'elle annonçait est dans "
        "la 0.1.26. Voir la note en tête de cette section du CHANGELOG."
    ),
}
```

Une dispense globale rouvrirait la porte que le contrôle existe pour fermer.
L'autre bout est tenu aussi : le jour où une version exemptée apparaît sur PyPI,
la dispense devient fausse et le script le dit.

## Un second test, né en éprouvant le premier

En neutralisant le contrôle pour vérifier qu'un test rougissait, j'ai découvert
que **le retirer de la séquence de `main()` ne faisait rougir personne** : tous
les tests appellent les fonctions directement. Le contrôle aurait donc cessé de
tourner sans un mot — exactement le défaut qu'il vient corriger, un cran plus
haut.

Un test vérifie désormais que les **huit** contrôles sont réellement câblés, et
il attrape bien un décâblage, vérifié en le provoquant.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 78 source files*
- [x] `uv run pytest` : **711 passed** (705 avant, +6)
- [x] Les hooks `pre-commit` passent
- [x] **Chaque test éprouvé par son échec**, y compris celui du câblage
- [x] Joué en conditions réelles sur le dépôt : 67 versions, aucune manquante
- [x] `src/dsoxlab/` n'est pas touché
- [ ] Test manuel sur deux dépôts fournisseurs : **N/A**, `scripts/` ne lit aucun
      catalogue

### When behavior changes — pas de bump

- [x] CHANGELOG EN **et** FR, section `Unreleased`
- [ ] Bump : **volontairement absent**, `scripts/` n'est pas dans la roue publiée

### When a command or option is added, removed or changed — N/A
### When `.github/workflows/` is touched — N/A
### When the declarative contract changes — N/A

## Note

C'est la quatrième correction de ce script aujourd'hui, et la seule dont le
défaut s'était produit **deux fois** avant d'être vu. Le script n'avait aucun
test ce matin ; il en a seize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
