### PR TITLE
fix(doctor): un correctif typé, sans shell, et qui dit ce qu'il engage (0.1.70)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,33 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.70] - 2026-08-24
+
+### Modifié
+
+- **`doctor --fix` ne joue plus de chaînes shell : un correctif typé et
+  catégorisé.** (#89) La commande la plus intrusive de l'outil, souvent sous
+  sudo, était aussi la seule à exécuter des chaînes interprétées par un shell
+  (`subprocess.run(..., shell=True)`, l'unique occurrence de `src/dsoxlab/`).
+  Les remédiations sont désormais un `Fix` typé : une séquence d'argv jouée
+  **dans l'ordre, token par token, sans aucun shell**, par le wrapper central
+  `run_command`. Un argument qui porte une espace arrive entier à la commande,
+  exactement ce qu'une chaîne shell aurait redécoupé ; un nouveau test le
+  prouve.
+
+  Chaque correctif porte aussi une catégorie, et c'est elle qui pilote le
+  message : `automatic` (exécuté, effet immédiat), `manual` (**jamais**
+  exécuté : `--fix` nomme le geste, l'humain le pose), `needs_relogin` et
+  `needs_reboot` (exécutés, puis `doctor` dit que la ligne restera rouge
+  jusqu'à la reconnexion ou au redémarrage : un effet différé, pas un échec).
+  Avant cela, un `usermod -aG` réussi ressemblait trait pour trait à un
+  `usermod` raté : l'utilisateur relançait `doctor`, revoyait le même rouge,
+  et concluait que le correctif avait échoué.
+
+  `doctor --json` expose désormais `fix_kind` sur chaque contrôle, et `fix`
+  devient la forme lisible des commandes typées (documenté dans
+  `docs/machine-output.fr.md`).
+
 ### Corrigé
 
 - **Rien ne disait qu'une version fusionnée n'avait jamais été taguée.** C'est

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.70] - 2026-08-24
+
+### Changed
+
+- **`doctor --fix` no longer runs shell strings: a typed, categorized fix.**
+  (#89) The most intrusive command of the tool — often under sudo — was also
+  the only one executing strings through a shell (`subprocess.run(...,
+  shell=True)`, the single occurrence in `src/dsoxlab/`). Remediations are now
+  a typed `Fix`: a sequence of argv played **in order, token by token, without
+  any shell**, through the central `run_command` wrapper. An argument carrying
+  a space reaches the command whole, which is precisely what a shell string
+  would have split — and what a new test proves.
+
+  Each fix also carries a category, and the category drives the message:
+  `automatic` (run, effect immediate), `manual` (**never** run: `--fix` names
+  the step, the human takes it), `needs_relogin` and `needs_reboot` (run, then
+  `doctor` says the line will stay red until the session or the machine
+  restarts — a delayed effect, not a failure). Before that, a successful
+  `usermod -aG` looked exactly like a failed one: the user re-ran `doctor`,
+  saw the same red line, and concluded the fix had not worked.
+
+  `doctor --json` now exposes `fix_kind` on each check, and `fix` becomes the
+  readable form of the typed commands (documented in `docs/machine-output.md`).
+
 ### Fixed
 
 - **Nothing said that a merged version had never been tagged.** It happened

--- a/docs/machine-output.fr.md
+++ b/docs/machine-output.fr.md
@@ -330,6 +330,7 @@ Un catalogue sans bloc `infra:` est un cas normal, pas une erreur : il rend
       "label": "pytest",
       "detail": "embarqué avec dsoxlab (celui qu'utilise « check »)",
       "fix": null,
+      "fix_kind": null,
       "hint": null
     }
   ],
@@ -341,6 +342,7 @@ Un catalogue sans bloc `infra:` est un cas normal, pas une erreur : il rend
       "label": "virsh/KVM",
       "detail": "virsh introuvable",
       "fix": "sudo apt install libvirt-clients libvirt-daemon-system qemu-kvm",
+      "fix_kind": "automatic",
       "hint": null
     }
   ],
@@ -364,7 +366,8 @@ Chaque contrôle :
 | `ok` | booléen | la même chose que `state == "ok"`, gardé pour une lecture vert/rouge immédiate |
 | `label` | chaîne | le nom du composant, traduit : pour l'affichage seulement |
 | `detail` | chaîne | ce qui a été mesuré : une version, une ligne d'erreur, un compte |
-| `fix` | chaîne ou null | une commande shell que `dsoxlab doctor --fix` joue telle quelle |
+| `fix` | chaîne ou null | la remédiation sous sa forme lisible ; `dsoxlab doctor --fix` joue les mêmes commandes token par token, sans shell |
+| `fix_kind` | chaîne ou null | la catégorie de la remédiation : `automatic`, `manual` (affichée, jamais exécutée), `needs_relogin` ou `needs_reboot` (exécutée, mais le contrôle reste rouge jusqu'à la reconnexion ou au redémarrage) |
 | `hint` | chaîne ou null | un geste que seul un humain doit poser : une page d'installation, une décision |
 
 `state: choice_required` existe parce qu'une décision n'est pas une panne : un
@@ -378,6 +381,12 @@ n'utilisera jamais n'a pas à peindre en rouge une machine qui va très bien.
 `fix` et `hint` restent séparés à dessein : l'un est une commande, l'autre une
 phrase. Les fondre ferait exécuter une URL de documentation par une
 automatisation.
+
+`fix_kind` est ce qu'une automatisation doit lire avant d'agir sur `fix` :
+une remédiation `manual` n'est jamais exécutée par `--fix`, et une
+`needs_relogin` ou `needs_reboot` réussit alors que son contrôle continue de
+rapporter `failed` jusqu'à la reconnexion ou au redémarrage. C'est un effet
+différé, pas un échec.
 
 ## `validate-structure`
 

--- a/docs/machine-output.md
+++ b/docs/machine-output.md
@@ -328,6 +328,7 @@ A catalog with no `infra:` block is a normal case, not an error: it yields
       "label": "pytest",
       "detail": "bundled with dsoxlab (the one `check` uses)",
       "fix": null,
+      "fix_kind": null,
       "hint": null
     }
   ],
@@ -339,6 +340,7 @@ A catalog with no `infra:` block is a normal case, not an error: it yields
       "label": "virsh/KVM",
       "detail": "virsh not found",
       "fix": "sudo apt install libvirt-clients libvirt-daemon-system qemu-kvm",
+      "fix_kind": "automatic",
       "hint": null
     }
   ],
@@ -362,7 +364,8 @@ Each check:
 | `ok` | bool | the same thing as `state == "ok"`, kept for a plain green/red reading |
 | `label` | string | the component's name, translated — for display only |
 | `detail` | string | what was measured: a version, an error line, a count |
-| `fix` | string or null | a shell command that `dsoxlab doctor --fix` runs as is |
+| `fix` | string or null | the remediation in its readable form; `dsoxlab doctor --fix` plays the same commands token by token, without a shell |
+| `fix_kind` | string or null | the remediation category: `automatic`, `manual` (shown, never run), `needs_relogin` or `needs_reboot` (run, but the check stays red until the session or the machine restarts) |
 | `hint` | string or null | a step only a human should take — an install page, a decision |
 
 `state: choice_required` exists because a decision is not a failure: a catalog
@@ -374,6 +377,11 @@ use must not turn a perfectly healthy machine red.
 
 `fix` and `hint` are kept apart on purpose: one is a command, the other is a
 sentence. Merging them would have an automation run a documentation URL.
+
+`fix_kind` is what an automation must read before acting on `fix`: a `manual`
+remediation is never run by `--fix`, and a `needs_relogin` or `needs_reboot`
+one succeeds while its check keeps reporting `failed` until the session or
+the machine restarts — that is a delayed effect, not a failure.
 
 ## `validate-structure`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.69"
+version = "0.1.70"
 description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli/diagnostic.py
+++ b/src/dsoxlab/cli/diagnostic.py
@@ -42,8 +42,11 @@ from ..reporting import (
     warn,
 )
 from ..services import (
+    Fix,
+    FixKind,
     collect_checks,
 )
+from ..utils.shell import CommandError, run_command
 from ._commun import (
     LabHomeOption,
     _read_repo,
@@ -220,16 +223,35 @@ def doctor(
     print_doctor(report)
 
     if fix:
-        failing = [(c.label, c.fix) for c in report.fixable() if c.fix]
-        if not failing:
+        correctifs = [
+            (c.label, c.fix) for c in report.fixable() if c.fix is not None
+        ]
+        if not correctifs:
             info(_("fix_nothing"))
             return
 
-        # Pr\u00e9-conditions sudo : si au moins un fix d\u00e9marre par "sudo", on
-        # v\u00e9rifie que l'env est compatible avant d'attaquer (TTY pour
-        # taper le password, sudo dispo, et id\u00e9alement on cache le
+        # Un correctif MANUAL n'est JAMAIS exécuté : le geste appartient à
+        # l'humain, `--fix` se contente de le nommer. Tout le reste s'exécute,
+        # y compris les catégories à effet différé : c'est le message d'après
+        # qui change, pas la décision de jouer la commande.
+        manuels = [
+            (label, correctif) for label, correctif in correctifs
+            if correctif.kind is FixKind.MANUAL
+        ]
+        executables = [
+            (label, correctif) for label, correctif in correctifs
+            if correctif.kind is not FixKind.MANUAL
+        ]
+        for label, correctif in manuels:
+            info(_("fix_manual", label=label, command=correctif.display))
+        if not executables:
+            return
+
+        # Pré-conditions sudo : si au moins un correctif passe par sudo, on
+        # vérifie que l'env est compatible avant d'attaquer (TTY pour
+        # taper le password, sudo dispo, et idéalement on cache le
         # password une seule fois pour toute la cascade).
-        sudo_fixes = [c for _, c in failing if c.strip().startswith("sudo ")]
+        sudo_fixes = [c for _label, c in executables if c.requires_sudo]
         if sudo_fixes:
             if not sys.stdin.isatty():
                 error(_("fix_needs_tty"))
@@ -238,10 +260,10 @@ def doctor(
                 error(_("fix_no_sudo"))
                 raise typer.Exit(1)
 
-            # Pr\u00e9-cache les credentials sudo : un seul prompt password
+            # Pré-cache les credentials sudo : un seul prompt password
             # pour toute la cascade. Sans ce sudo -v, l'apprenant
-            # pourrait avoir \u00e0 retaper son password \u00e0 chaque commande
-            # (si sudo timestamp_timeout=0 ou si la cascade d\u00e9passe 5min).
+            # pourrait avoir à retaper son password à chaque commande
+            # (si sudo timestamp_timeout=0 ou si la cascade dépasse 5min).
             info(_("fix_sudo_preauth", count=len(sudo_fixes)))
             # check=False : un mot de passe refusé ou un Ctrl-C sur le prompt
             # sudo est une réponse de l'utilisateur, pas une panne. On la
@@ -251,18 +273,53 @@ def doctor(
                 error(_("fix_sudo_failed"))
                 raise typer.Exit(1)
 
-        info(_("fix_count", count=len(failing)))
-        for label, fix_cmd in failing:
-            info(f"[bold]{label}[/bold] \u2192 {fix_cmd}")
-            # check=False : `--fix` joue une CASCADE. Un correctif en \u00e9chec
-            # doit \u00eatre signal\u00e9 puis laisser tourner les suivants ; lever ici
-            # abandonnerait les r\u00e9parations restantes sur la premi\u00e8re qui rate.
-            result = subprocess.run(fix_cmd, shell=True, text=True, check=False)  # noqa: S602
-            if result.returncode == 0:
+        info(_("fix_count", count=len(executables)))
+        for label, correctif in executables:
+            info(f"[bold]{label}[/bold] → {correctif.display}")
+            code = _executer_correctif(correctif)
+            if code == 0:
                 success(_("fix_success", label=label))
+                # Dire l'effet différé au moment du succès, sans quoi le
+                # prochain `doctor` remontre la même ligne rouge et
+                # l'utilisateur conclut, à tort, que le correctif a échoué.
+                if correctif.kind is FixKind.NEEDS_RELOGIN:
+                    warn(_("fix_needs_relogin", label=label))
+                elif correctif.kind is FixKind.NEEDS_REBOOT:
+                    warn(_("fix_needs_reboot", label=label))
             else:
-                error(_("fix_failure", label=label, code=result.returncode))
+                error(_("fix_failure", label=label, code=code))
         info(_("fix_rerun"))
+
+
+def _executer_correctif(correctif: Fix) -> int:
+    """Joue les commandes d'un correctif, dans l'ordre, sans shell.
+
+    Chaque argv part tel quel à ``run_command`` : aucun token n'est redécoupé
+    en route, un argument portant une espace arrive entier à la commande. La
+    séquence s'arrête au premier échec, dont le code est rendu. ``check=False``
+    parce que `--fix` joue une CASCADE : un correctif en échec doit être
+    signalé puis laisser tourner les suivants ; lever ici abandonnerait les
+    réparations restantes sur la première qui rate.
+
+    La sortie capturée est rejouée sur les flux d'origine : l'utilisateur
+    voit ce qu'apt ou systemctl ont dit, en particulier quand ça a raté.
+    """
+    for commande in correctif.commands:
+        try:
+            resultat = run_command(list(commande), check=False, timeout=900)
+        except CommandError as exc:
+            # Commande introuvable ou délai dépassé : le wrapper l'a déjà
+            # journalisé, on rend un échec franc avec ce qu'on sait.
+            if exc.result.stderr:
+                sys.stderr.write(exc.result.stderr + "\n")
+            return 1
+        if resultat.stdout:
+            sys.stdout.write(resultat.stdout)
+        if resultat.stderr:
+            sys.stderr.write(resultat.stderr)
+        if resultat.returncode != 0:
+            return resultat.returncode
+    return 0
 
 
 # ── provision / destroy / ssh / status ────────────────────────────────────────

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -903,6 +903,14 @@ silent.
         "below (a single prompt for the whole run):",
     "fix_sudo_failed": "sudo pre-authentication failed: remediations aborted.",
     "fix_success": "{label}: remediation successful.",
+    "fix_manual":
+        "{label}: manual step, shown but never run automatically → {command}",
+    "fix_needs_relogin":
+        "{label}: fixed, but the change only takes effect after you log out "
+        "and back in. This line will stay red until then; it is not a failure.",
+    "fix_needs_reboot":
+        "{label}: fixed, but the change only takes effect after a reboot. "
+        "This line will stay red until then; it is not a failure.",
     "fix_failure": "{label}: remediation failed (code {code}).",
     "fix_rerun":   "Run [bold]dsoxlab doctor[/bold] again to verify.",
 

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -913,6 +913,17 @@ hors ligne, elle se tait.
         "Pré-authentification ci-dessous (un seul prompt pour toute la cascade) :",
     "fix_sudo_failed": "Pré-authentification sudo échouée : remédiations abandonnées.",
     "fix_success": "{label} : remédiation réussie.",
+    "fix_manual":
+        "{label} : geste manuel, affiché mais jamais exécuté automatiquement "
+        "→ {command}",
+    "fix_needs_relogin":
+        "{label} : corrigé, mais le changement ne prend effet qu'après une "
+        "déconnexion puis une reconnexion. Cette ligne restera rouge d'ici "
+        "là ; ce n'est pas un échec.",
+    "fix_needs_reboot":
+        "{label} : corrigé, mais le changement ne prend effet qu'après un "
+        "redémarrage. Cette ligne restera rouge d'ici là ; ce n'est pas un "
+        "échec.",
     "fix_failure": "{label} : échec de la remédiation (code {code}).",
     "fix_rerun":   "Relancez [bold]dsoxlab doctor[/bold] pour vérifier.",
 

--- a/src/dsoxlab/reporting/machine.py
+++ b/src/dsoxlab/reporting/machine.py
@@ -106,10 +106,14 @@ def check_dict(check: Check) -> dict[str, Any]:
         "ok": check.ok,
         "label": check.label,
         "detail": check.detail,
-        # Deux remédiations, deux natures : ``fix`` est une commande que
-        # ``--fix`` exécute telle quelle, ``hint`` une consigne que seul un
-        # humain pose. Les fondre en un champ ferait exécuter une URL.
-        "fix": check.fix,
+        # Deux remédiations, deux natures : ``fix`` est un correctif que
+        # ``--fix`` sait jouer (token par token, sans shell), ``hint`` une
+        # consigne que seul un humain pose. Les fondre en un champ ferait
+        # exécuter une URL. Le correctif est rendu sous sa forme lisible,
+        # accompagnée de sa catégorie : c'est elle qui dit à un appelant si
+        # le geste est automatisable, manuel, ou à effet différé.
+        "fix": None if check.fix is None else check.fix.display,
+        "fix_kind": None if check.fix is None else check.fix.kind.value,
         "hint": check.hint,
     }
 

--- a/src/dsoxlab/services/__init__.py
+++ b/src/dsoxlab/services/__init__.py
@@ -1,6 +1,6 @@
 """Package services."""
 
-from .doctor import Check, DoctorReport, collect_checks, uses_vm
+from .doctor import Check, DoctorReport, Fix, FixKind, collect_checks, uses_vm
 from .guide_service import guide_url
 from .lab_service import (
     CheckResult,
@@ -34,6 +34,8 @@ __all__ = [
     "Check",
     "CheckResult",
     "DoctorReport",
+    "Fix",
+    "FixKind",
     "ScoreResult",
     "build_progress",
     "check_lab",

--- a/src/dsoxlab/services/doctor.py
+++ b/src/dsoxlab/services/doctor.py
@@ -25,12 +25,16 @@ Le module reste agnostique du domaine : il ne connaît que le contrat
 
 from __future__ import annotations
 
+import getpass
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 
 from ..discovery.scanner import compter_fichiers_labs
@@ -59,14 +63,76 @@ STATE_FAILED = "failed"
 STATE_CHOICE_REQUIRED = "choice_required"
 
 
+class FixKind(StrEnum):
+    """Ce qu'un correctif engage, au-delà de son exécution.
+
+    La catégorie pilote deux décisions de ``--fix`` : exécuter ou seulement
+    afficher (``MANUAL``), et surtout **ce qu'on dit après**. Un ``usermod
+    -aG`` réussi laisse la ligne rouge jusqu'à la reconnexion : sans le dire,
+    l'utilisateur relance ``doctor``, revoit le même rouge, et conclut que le
+    correctif a échoué.
+    """
+
+    AUTOMATIC = "automatic"
+    """Exécuté par ``--fix``, effet immédiat : relancer ``doctor`` suffit."""
+
+    MANUAL = "manual"
+    """Jamais exécuté : ``--fix`` l'affiche, le geste appartient à l'humain."""
+
+    NEEDS_RELOGIN = "needs_relogin"
+    """Exécuté, mais l'effet attend une déconnexion puis une reconnexion."""
+
+    NEEDS_REBOOT = "needs_reboot"
+    """Exécuté, mais l'effet attend un redémarrage de la machine."""
+
+
+@dataclass(frozen=True)
+class Fix:
+    """Un correctif typé : des tokens, jamais une chaîne interprétée.
+
+    ``commands`` est une séquence d'argv joués **dans l'ordre** et **sans
+    shell**, la suite s'arrêtant au premier échec. C'est une séquence et non
+    une commande unique parce que deux correctifs réels sont des chaînes
+    (créer un pool libvirt prend quatre ``virsh``), et qu'une seule liste ne
+    les porterait qu'en réintroduisant un ``&&``, donc un shell.
+
+    ``requires_sudo`` se déduit des tokens plutôt que d'être déclaré : un
+    champ séparé pourrait contredire la commande qu'il décrit.
+    """
+
+    commands: tuple[tuple[str, ...], ...]
+    kind: FixKind = FixKind.AUTOMATIC
+
+    @property
+    def requires_sudo(self) -> bool:
+        """Au moins une des commandes s'exécute par ``sudo``."""
+        return any(cmd and cmd[0] == "sudo" for cmd in self.commands)
+
+    @property
+    def display(self) -> str:
+        """La forme lisible du correctif, pour l'affichage seulement.
+
+        ``shlex.join`` requote ce qui doit l'être : un argument portant une
+        espace se relit tel qu'il s'exécute. Le ``&&`` est une convention de
+        lecture, pas une promesse d'exécution par un shell.
+        """
+        return " && ".join(shlex.join(cmd) for cmd in self.commands)
+
+
+def _fix(*commands: Sequence[str], kind: FixKind = FixKind.AUTOMATIC) -> Fix:
+    """Un correctif, écrit en listes de tokens sans cérémonie de tuples."""
+    return Fix(commands=tuple(tuple(cmd) for cmd in commands), kind=kind)
+
+
 @dataclass(frozen=True)
 class Check:
     """Un composant diagnostiqué.
 
-    ``fix`` est une commande shell que ``--fix`` peut exécuter telle quelle.
-    ``hint`` est une consigne affichée mais **jamais** exécutée : réinstaller
-    l'outil ou choisir un provider sont des gestes que l'apprenant doit
-    poser lui-même.
+    ``fix`` est un correctif typé (:class:`Fix`) que ``--fix`` sait jouer,
+    token par token et sans shell ; sa catégorie dit s'il s'exécute et ce
+    qu'il faut annoncer ensuite. ``hint`` est une consigne affichée mais
+    **jamais** exécutée : une URL d'installation ou un choix de provider
+    sont des gestes que l'apprenant doit poser lui-même.
     """
 
     key: str
@@ -79,7 +145,7 @@ class Check:
     label: str
     ok: bool
     detail: str
-    fix: str | None = None
+    fix: Fix | None = None
     hint: str | None = None
     forced_state: str | None = None
     """État imposé, quand « en échec » serait faux. Un provider qui reste
@@ -94,7 +160,9 @@ class Check:
     @property
     def remediation(self) -> str:
         """Ce qu'affiche la colonne « Remédiation »."""
-        return self.fix or self.hint or ""
+        if self.fix is not None:
+            return self.fix.display
+        return self.hint or ""
 
 
 def _check(
@@ -102,7 +170,7 @@ def _check(
     ok: bool,
     detail: str,
     *,
-    fix: str | None = None,
+    fix: Fix | None = None,
     hint: str | None = None,
     forced_state: str | None = None,
 ) -> Check:
@@ -195,6 +263,16 @@ def _sonder(
         return None
 
 
+def _current_user() -> str:
+    """L'utilisateur à qui s'adresse un correctif de groupe.
+
+    ``$USER`` d'abord, comme le faisait la chaîne shell d'avant ; à défaut,
+    ``getpass.getuser()`` lit la table des comptes. L'ancien repli littéral
+    ``$USER`` n'a plus de sens sans shell pour l'expanser.
+    """
+    return os.environ.get("USER") or getpass.getuser()
+
+
 def _check_incus() -> Check:
     """Binaire + daemon + permissions user + init storage/network.
 
@@ -205,7 +283,7 @@ def _check_incus() -> Check:
     if not shutil.which("incus"):
         return _check(
             "incus", False, _("detail_incus_missing"),
-            fix="sudo apt install incus",
+            fix=_fix(["sudo", "apt", "install", "incus"]),
         )
 
     # Le numéro de version n'est qu'un ornement du diagnostic. Le verdict vient
@@ -219,7 +297,7 @@ def _check_incus() -> Check:
     if probe is None:
         return _check(
             "incus", False, _("detail_incus_daemon_down", version=version),
-            fix="sudo systemctl enable --now incus.service",
+            fix=_fix(["sudo", "systemctl", "enable", "--now", "incus.service"]),
         )
     if probe.returncode == 0:
         return _check("incus", True, _("detail_incus_ok", version=version))
@@ -235,18 +313,24 @@ def _check_incus() -> Check:
             return _check(
                 "incus", False,
                 _("detail_incus_daemon_down", version=version),
-                fix="sudo systemctl enable --now incus.service",
+                fix=_fix(["sudo", "systemctl", "enable", "--now", "incus.service"]),
             )
+        # NEEDS_RELOGIN : l'appartenance à un groupe ne prend effet qu'à la
+        # session suivante. Sans cette catégorie, l'utilisateur relançait
+        # `doctor`, revoyait le rouge, et croyait le correctif en échec.
         return _check(
             "incus", False,
             _("detail_incus_no_group", version=version),
-            fix=f"sudo usermod -aG incus,incus-admin {os.environ.get('USER', '$USER')}",
+            fix=_fix(
+                ["sudo", "usermod", "-aG", "incus,incus-admin", _current_user()],
+                kind=FixKind.NEEDS_RELOGIN,
+            ),
         )
     if "no storage pools" in err or "init" in err:
         return _check(
             "incus", False,
             _("detail_incus_no_init", version=version),
-            fix="sudo incus admin init --auto",
+            fix=_fix(["sudo", "incus", "admin", "init", "--auto"]),
         )
 
     tail = (probe.stderr or probe.stdout).strip().splitlines()
@@ -257,7 +341,10 @@ def _check_kvm() -> Check:
     if not shutil.which("virsh"):
         return _check(
             "kvm", False, _("detail_kvm_missing"),
-            fix="sudo apt install libvirt-clients libvirt-daemon-system qemu-kvm",
+            fix=_fix([
+                "sudo", "apt", "install",
+                "libvirt-clients", "libvirt-daemon-system", "qemu-kvm",
+            ]),
         )
     # Un virsh qui sort en erreur est justement ce que ce contrôle cherche à
     # rapporter ; un virsh qui ne répond pas dit la même chose plus fort.
@@ -265,7 +352,7 @@ def _check_kvm() -> Check:
     if result is None or result.returncode != 0:
         return _check(
             "kvm", False, _("detail_kvm_daemon_err"),
-            fix="sudo systemctl start libvirtd",
+            fix=_fix(["sudo", "systemctl", "start", "libvirtd"]),
         )
     first_line = result.stdout.splitlines()[0] if result.stdout else "ok"
     return _check("kvm", True, first_line)
@@ -318,27 +405,42 @@ def _check_ansible() -> Check:
     if not ansible_infra.has_ansible_playbook():
         return _check(
             "ansible", False, _("detail_ansible_missing"),
-            fix="uv tool install ansible-core",
+            fix=_fix(["uv", "tool", "install", "ansible-core"]),
         )
     return _check("ansible", True, _("detail_ansible_ok"))
 
 
-def creer_pool_command(pool: str) -> str:
-    """La commande qui crée un pool libvirt de bout en bout.
+def creer_pool_fix(pool: str) -> Fix:
+    """Le correctif qui crée un pool libvirt de bout en bout.
 
     Les quatre étapes comptent : ``pool-define-as`` seul laisse un pool défini
     mais **inactif**, dans lequel Terraform ne peut rien écrire.
     """
-    return (
-        f"sudo virsh pool-define-as {pool} dir --target "
-        f"/var/lib/libvirt/images && sudo virsh pool-build {pool} && "
-        f"sudo virsh pool-start {pool} && sudo virsh pool-autostart {pool}"
+    return _fix(
+        ["sudo", "virsh", "pool-define-as", pool, "dir",
+         "--target", "/var/lib/libvirt/images"],
+        ["sudo", "virsh", "pool-build", pool],
+        ["sudo", "virsh", "pool-start", pool],
+        ["sudo", "virsh", "pool-autostart", pool],
     )
 
 
+def demarrer_pool_fix(pool: str) -> Fix:
+    """Le correctif qui démarre un pool déjà défini, et le rend permanent."""
+    return _fix(
+        ["sudo", "virsh", "pool-start", pool],
+        ["sudo", "virsh", "pool-autostart", pool],
+    )
+
+
+def creer_pool_command(pool: str) -> str:
+    """La création du pool, en une ligne à copier après un échec de provision."""
+    return creer_pool_fix(pool).display
+
+
 def demarrer_pool_command(pool: str) -> str:
-    """La commande qui démarre un pool déjà défini, et le rend permanent."""
-    return f"sudo virsh pool-start {pool} && sudo virsh pool-autostart {pool}"
+    """Le démarrage du pool, en une ligne à copier après un échec de provision."""
+    return demarrer_pool_fix(pool).display
 
 
 def _pools_libvirt(*, definis: bool) -> list[str] | None:
@@ -387,11 +489,11 @@ def _check_libvirt_pool(pool: str) -> Check:
     if definis is not None and pool in definis:
         return _check(
             "libvirt_pool", False, _("detail_pool_inactive", pool=pool),
-            fix=demarrer_pool_command(pool),
+            fix=demarrer_pool_fix(pool),
         )
     return _check(
         "libvirt_pool", False, _("detail_pool_missing", pool=pool),
-        fix=creer_pool_command(pool),
+        fix=creer_pool_fix(pool),
     )
 
 
@@ -530,7 +632,7 @@ def _check_iso_tool() -> Check:
             return _check("iso_tool", True, outil)
     return _check(
         "iso_tool", False, _("detail_iso_tool_missing"),
-        fix="sudo apt install genisoimage",
+        fix=_fix(["sudo", "apt", "install", "genisoimage"]),
     )
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -68,7 +68,10 @@ def stub_hypervisors(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         doctor, "_hypervisor_checks",
         lambda: {
-            "kvm": doctor._check("kvm", False, "not found", fix="apt install"),
+            "kvm": doctor._check(
+                "kvm", False, "not found",
+                fix=doctor.Fix((("apt", "install"),)),
+            ),
             "incus": doctor._check("incus", True, "daemon ok"),
         },
     )

--- a/tests/test_doctor_fix.py
+++ b/tests/test_doctor_fix.py
@@ -1,0 +1,191 @@
+"""`doctor --fix` : un correctif typé, joué sans shell, catégorisé.
+
+Ce que ce module prouve, catégorie par catégorie :
+
+- AUTOMATIC s'exécute par le wrapper centralisé, token par token : un argument
+  qui porte une espace arrive **entier** à la commande, ce qu'une chaîne
+  passée à un shell aurait redécoupé en deux mots ;
+- MANUAL n'est **jamais** exécuté : il est affiché, le geste appartient à
+  l'humain ;
+- NEEDS_RELOGIN et NEEDS_REBOOT s'exécutent, puis disent que la ligne restera
+  rouge jusqu'à la reconnexion ou au redémarrage : sans ce message,
+  l'utilisateur relançait `doctor`, revoyait le rouge, et croyait le correctif
+  en échec ;
+- une séquence de commandes s'arrête au premier échec, et le dit.
+
+Et la preuve de fond : plus aucun ``shell=True`` dans ``src/dsoxlab/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dsoxlab.cli import app, diagnostic
+from dsoxlab.services import doctor as service_doctor
+from dsoxlab.services.doctor import DoctorReport, Fix, FixKind
+from dsoxlab.utils.shell import CommandResult
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def environnement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Un dépôt vide suffit : le rapport est injecté, pas découvert."""
+    monkeypatch.setenv("LAB_HOME", str(tmp_path))
+    monkeypatch.setenv("DSOXLAB_LANG", "en")
+    for variable in ("XDG_STATE_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME"):
+        monkeypatch.setenv(variable, str(tmp_path / variable.lower()))
+
+
+def _rapport(*correctifs: Fix) -> DoctorReport:
+    """Un diagnostic où chaque correctif porte un contrôle en échec."""
+    report = DoctorReport()
+    for index, correctif in enumerate(correctifs):
+        report.required.append(
+            service_doctor.Check(
+                key=f"composant_{index}",
+                label=f"Component {index}",
+                ok=False,
+                detail="broken",
+                fix=correctif,
+            )
+        )
+    return report
+
+
+def _doctor_fix(
+    monkeypatch: pytest.MonkeyPatch, *correctifs: Fix
+) -> tuple[list[list[str]], object]:
+    """Joue `doctor --fix` sur un rapport injecté, en espionnant run_command.
+
+    Rend les argv **exacts** reçus par le wrapper, et le résultat CLI. Aucun
+    shell ne tourne : ce que l'espion enregistre est ce que la commande
+    recevrait.
+    """
+    appels: list[list[str]] = []
+
+    def faux_run_command(cmd: list[str], **kwargs: object) -> CommandResult:
+        appels.append(list(cmd))
+        return CommandResult(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(diagnostic, "run_command", faux_run_command)
+    monkeypatch.setattr(
+        diagnostic, "collect_checks", lambda root, meta: _rapport(*correctifs)
+    )
+    resultat = runner.invoke(app, ["doctor", "--fix"])
+    return appels, resultat
+
+
+def test_un_argument_avec_espace_reste_un_seul_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AUTOMATIC : la commande part en argv, jamais dans un shell.
+
+    C'est LE test qui prouve le gain : « two words » passé à
+    ``subprocess.run(..., shell=True)`` aurait été redécoupé en deux
+    arguments par le shell. En tokens, il arrive entier.
+    """
+    correctif = Fix((("install-tool", "--label", "two words"),))
+
+    appels, resultat = _doctor_fix(monkeypatch, correctif)
+
+    assert resultat.exit_code == 0
+    assert appels == [["install-tool", "--label", "two words"]]
+    assert "remediation successful" in resultat.stdout
+
+
+def test_manuel_affiche_et_jamais_execute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MANUAL : `--fix` nomme le geste, et ne lance rien du tout."""
+    correctif = Fix((("rm", "-rf", "/something"),), kind=FixKind.MANUAL)
+
+    appels, resultat = _doctor_fix(monkeypatch, correctif)
+
+    assert resultat.exit_code == 0
+    assert appels == [], "un correctif manuel ne doit jamais être exécuté"
+    assert "never run automatically" in resultat.stdout
+    assert "rm -rf /something" in resultat.stdout
+
+
+def test_reconnexion_le_rouge_persistant_est_annonce(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NEEDS_RELOGIN : exécuté, puis le message dit que le rouge va rester.
+
+    Un `usermod -aG` réussi laisse la ligne rouge jusqu'à la session
+    suivante : sans cette phrase, le prochain `doctor` ressemble à un échec.
+    """
+    correctif = Fix(
+        (("usermod", "-aG", "incus", "student"),), kind=FixKind.NEEDS_RELOGIN
+    )
+
+    appels, resultat = _doctor_fix(monkeypatch, correctif)
+
+    assert appels == [["usermod", "-aG", "incus", "student"]]
+    assert "remediation successful" in resultat.stdout
+    assert "log out" in resultat.stdout
+    assert "stay red" in resultat.stdout
+
+
+def test_redemarrage_le_rouge_persistant_est_annonce(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NEEDS_REBOOT : exécuté, puis le message annonce l'effet différé."""
+    correctif = Fix((("modprobe", "kvm"),), kind=FixKind.NEEDS_REBOOT)
+
+    appels, resultat = _doctor_fix(monkeypatch, correctif)
+
+    assert appels == [["modprobe", "kvm"]]
+    assert "remediation successful" in resultat.stdout
+    assert "after a reboot" in resultat.stdout
+    assert "stay red" in resultat.stdout
+
+
+def test_une_sequence_s_arrete_au_premier_echec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Un correctif en plusieurs commandes ne poursuit pas après un échec.
+
+    C'est l'équivalent typé du ``&&`` d'hier : `pool-build` sur un
+    `pool-define-as` raté n'a aucun sens, et le code d'échec doit remonter.
+    """
+    appels: list[list[str]] = []
+
+    def run_qui_echoue(cmd: list[str], **kwargs: object) -> CommandResult:
+        appels.append(list(cmd))
+        return CommandResult(returncode=3, stdout="", stderr="boom")
+
+    correctif = Fix((("premiere", "etape"), ("seconde", "etape")))
+    monkeypatch.setattr(diagnostic, "run_command", run_qui_echoue)
+    monkeypatch.setattr(
+        diagnostic, "collect_checks", lambda root, meta: _rapport(correctif)
+    )
+
+    resultat = runner.invoke(app, ["doctor", "--fix"])
+
+    assert appels == [["premiere", "etape"]], "la seconde étape ne doit pas partir"
+    assert "remediation failed (code 3)" in resultat.stderr
+
+
+def test_le_display_requote_ce_qui_doit_l_etre() -> None:
+    """La forme affichée se relit telle qu'elle s'exécute, espaces comprises."""
+    correctif = Fix((("echo", "deux mots"), ("touch", "fichier")))
+
+    assert correctif.display == "echo 'deux mots' && touch fichier"
+    assert not correctif.requires_sudo
+    assert Fix((("sudo", "apt", "install", "x"),)).requires_sudo
+
+
+def test_plus_aucun_shell_true_dans_les_sources() -> None:
+    """Le contrat de l'issue #89 : zéro ``shell=True`` dans ``src/dsoxlab/``."""
+    racine = Path(__file__).resolve().parent.parent / "src" / "dsoxlab"
+    coupables = [
+        chemin
+        for chemin in racine.rglob("*.py")
+        if "shell=True" in chemin.read_text(encoding="utf-8")
+    ]
+    assert coupables == []

--- a/tests/test_doctor_installation.py
+++ b/tests/test_doctor_installation.py
@@ -209,7 +209,10 @@ def test_ansible_est_reparable_automatiquement(
     report = doctor.collect_checks(tmp_path, _repo(provider="kvm"))
 
     par_label = {c.label: c for c in report.required}
-    assert par_label[_("check_ansible")].fix == "uv tool install ansible-core"
+    correctif = par_label[_("check_ansible")].fix
+    assert correctif is not None
+    assert correctif.display == "uv tool install ansible-core"
+    assert correctif.kind is doctor.FixKind.AUTOMATIC
     assert par_label[_("check_terraform")].fix is None
     assert "terraform" in (par_label[_("check_terraform")].hint or "")
 
@@ -455,7 +458,9 @@ def test_un_pool_absent_fait_proposer_sa_creation(
     assert check.detail == _("detail_pool_missing", pool="default")
     assert check.fix is not None
     for etape in ("pool-define-as", "pool-build", "pool-start", "pool-autostart"):
-        assert etape in check.fix, f"« {etape} » manque à la création du pool"
+        assert etape in check.fix.display, (
+            f"« {etape} » manque à la création du pool"
+        )
 
 
 def test_un_pool_defini_mais_arrete_est_dit_tel_quel(
@@ -477,9 +482,9 @@ def test_un_pool_defini_mais_arrete_est_dit_tel_quel(
     assert not check.ok
     assert check.detail == _("detail_pool_inactive", pool="default")
     assert check.fix is not None
-    assert "pool-start" in check.fix
-    assert "pool-autostart" in check.fix
-    assert "pool-define-as" not in check.fix, (
+    assert "pool-start" in check.fix.display
+    assert "pool-autostart" in check.fix.display
+    assert "pool-define-as" not in check.fix.display, (
         "définir un pool qui existe déjà échoue : la remédiation mentirait"
     )
 
@@ -497,8 +502,8 @@ def test_le_pool_du_depot_est_celui_qui_est_sonde(
     assert not check.ok
     assert "labs-pool" in check.detail
     assert check.fix is not None
-    assert "labs-pool" in check.fix
-    assert "default" not in check.fix
+    assert "labs-pool" in check.fix.display
+    assert "default" not in check.fix.display
 
 
 def test_un_virsh_muet_ne_conclut_pas_a_l_absence(

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -217,7 +217,10 @@ def sans_hyperviseur(monkeypatch: pytest.MonkeyPatch) -> None:
         service_doctor,
         "_hypervisor_checks",
         lambda: {
-            "kvm": service_doctor._check("kvm", False, "absent", fix="apt install"),
+            "kvm": service_doctor._check(
+                "kvm", False, "absent",
+                fix=service_doctor.Fix((("apt", "install"),)),
+            ),
             "incus": service_doctor._check("incus", True, "ok"),
         },
     )
@@ -316,6 +319,26 @@ def test_doctor_rend_des_cles_stables(catalogue: Path, sans_hyperviseur: None) -
     # Un catalogue 100 % shell : les hyperviseurs sont informatifs, et le kvm
     # en échec ne doit donc pas peindre le verdict en rouge.
     assert [c["key"] for c in document["informational"]] == ["kvm", "incus"]
+
+
+def test_un_correctif_expose_sa_categorie(
+    catalogue: Path, sans_hyperviseur: None
+) -> None:
+    """`fix` est la forme lisible, `fix_kind` ce qu'une automatisation lit.
+
+    Une remédiation `manual` ne doit jamais être lancée par un appelant, et une
+    `needs_relogin` réussie laisse le contrôle rouge : sans la catégorie, le
+    document ne permet de décider ni l'un ni l'autre.
+    """
+    document = _document("doctor")
+
+    kvm = next(c for c in document["informational"] if c["key"] == "kvm")
+    assert kvm["fix"] == "apt install"
+    assert kvm["fix_kind"] == "automatic"
+    # Un contrôle sans correctif n'invente pas de catégorie.
+    python_check = next(c for c in document["required"] if c["key"] == "python")
+    assert python_check["fix"] is None
+    assert python_check["fix_kind"] is None
 
 
 def test_un_verdict_se_lit_sans_traduire(

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.69"
+version = "0.1.70"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
`doctor --fix` est la commande la plus intrusive de l'outil, souvent avec `sudo`,
et c'était **la seule qui exécutait des chaînes interprétées par un shell** :

```python
result = subprocess.run(fix_cmd, shell=True, text=True)  # noqa: S602
```

L'unique `shell=True` de tout `src/dsoxlab/`. Il ne reste rien, et le `noqa` a
disparu avec lui :

```console
$ grep -rc 'shell=True' src/dsoxlab/ | grep -v ':0'
$ grep -rc 'noqa: S602' src/dsoxlab/ | grep -v ':0'
```

## Une séquence d'argv, et pourquoi pas une commande unique

C'est le seul écart à la forme que l'issue suggérait, et il se défend.
`Fix.commands` est une **séquence** d'argv, jouée dans l'ordre, sans shell,
qui s'arrête au premier échec. Une commande unique n'aurait pas suffi : deux
correctifs réels sont des chaînes — créer un pool libvirt prend **quatre**
`virsh` — et une seule liste ne les porterait qu'en réintroduisant un `&&`,
donc un shell par la porte de derrière.

`requires_sudo` se déduit des tokens plutôt que d'être déclaré : un champ séparé
pourrait contredire la commande qu'il décrit.

`display` (via `shlex.join`) donne la forme lisible pour la colonne
Remédiation et le JSON. Le `&&` y est une convention de lecture, pas une
promesse d'exécution.

## Quatre catégories, et celle qui compte

| `kind` | Ce qu'elle engage |
|---|---|
| `automatic` | exécuté, effet immédiat |
| `manual` | **jamais exécuté** : `--fix` nomme le geste |
| `needs_relogin` | exécuté, mais l'effet attend une reconnexion |
| `needs_reboot` | exécuté, mais l'effet attend un redémarrage |

La plus utile est `needs_relogin`. Un `usermod -aG` réussi laisse la ligne
rouge jusqu'à la reconnexion : sans le dire, l'utilisateur relance `doctor`,
revoit le même rouge, et conclut que le correctif a échoué. C'est exactement le
défaut que l'issue décrit.

## Le test qui prouve le gain

```python
correctif = Fix((("install-tool", "--label", "two words"),))
...
assert appels == [["install-tool", "--label", "two words"]]
```

« two words » passé à `shell=True` aurait été redécoupé en deux arguments. En
tokens, il arrive entier. Saboté par un redécoupage façon shell, ce test rougit.

Un second garde-fou scanne `src/dsoxlab/` et refuse tout retour de `shell=True`,
pour que la correction ne se défasse pas en silence.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 78 source files*
- [x] `uv run pytest` : **719 passed** (711 avant, **+8**)
- [x] `uv run pytest tests_e2e` : **18 passed**
- [x] `grep -rn 'shell=True' src/dsoxlab/` : **zéro occurrence**
- [x] **Chaque test éprouvé par son échec** : sabotage puis restauration
- [x] Le moteur reste neutre vis-à-vis du domaine
- [x] Aucun chemin personnel

### When behavior changes

- [x] CHANGELOG EN **et** FR ; version **0.1.70** ; `uv.lock` aligné

### When a command or option is added, removed or changed

- [x] Clés i18n `fix_manual`, `fix_needs_relogin`, `fix_needs_reboot` dans
      **en.py et fr.py**, rendu vérifié sous les deux langues
- [x] `doctor --json` gagne `fix_kind`, documenté dans `docs/machine-output.md`
      **et** `.fr.md`
- [ ] Aide CLI et `fullhelp` : **N/A**, aucune commande ni option ne change

### When `.github/workflows/` is touched — N/A
### When the declarative contract changes — N/A

## Related issues

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
