### PR TITLE
feat(new): un squelette de catalogue et de lab déjà conforme (0.1.71)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,43 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.71] - 2026-08-24
+
+### Ajouté
+
+- **`dsoxlab new catalog` et `dsoxlab new lab` : un squelette déjà conforme au
+  contrat** (issue #88). Écrire un catalogue supposait de connaître le contrat
+  par cœur, ou de copier un dépôt existant. Les deux chemins produisent les
+  mêmes erreurs — un fichier obligatoire oublié, un nom de fichier de test qui
+  ne correspond pas à celui qu'attend le validator, une fixture livrée mais non
+  déclarée — et la sanction est muette : un `lab.yaml` qui lève au parsing n'est
+  jamais examiné par `validate-structure`, si bien qu'un débutant obtient un
+  catalogue qui « passe la validation » et n'affiche aucun lab.
+
+  ```console
+  $ dsoxlab new catalog mon-catalogue
+  $ cd mon-catalogue && dsoxlab new lab premier-lab --runtime shell
+  $ dsoxlab list-labs && dsoxlab validate-structure
+  ```
+
+  Le squelette diffère selon le runtime, comme le contrat l'exige : un lab
+  `shell` déclare son `workdir`, un lab `vm` ses `targets` et ses deux
+  playbooks.
+
+  **Le test généré échoue**, il n'est pas sauté. Un squelette vert d'emblée
+  apprendrait la mauvaise habitude, celle de noter sans rien vérifier ; et un
+  test sauté ne dit ni que le travail reste à faire, ni qu'il est fait. Un test
+  rouge dit la première chose, qui est celle dont son auteur a besoin.
+
+  Le squelette produit est éprouvé contre les **schémas publiés**, et pas
+  seulement contre `validate-structure` : le contrat est gelé et ses schémas
+  sont publiés, donc les ignorer laisserait le générateur diverger vers une
+  variante sans que rien ne le dise. Ce contrôle a attrapé la première version
+  de ce générateur, qui écrivait un `:` non quoté dans une description — du YAML
+  d'apparence valide qui ne se chargeait pas, et un lab qui disparaissait en
+  silence.
+
+
 ### Corrigé
 
 - **Rien ne disait qu'une version fusionnée n'avait jamais été taguée.** C'est

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.71] - 2026-08-24
+
+### Added
+
+- **`dsoxlab new catalog` and `dsoxlab new lab`: a skeleton that already matches
+  the contract** (issue #88). Writing a catalog meant knowing the contract by
+  heart, or copying an existing repository. Both paths produce the same
+  mistakes — a missing required file, a test file whose name is not the one the
+  validator expects, a fixture shipped but never declared — and the penalty is
+  silent: a `lab.yaml` that raises while parsing is never examined by
+  `validate-structure`, so a beginner ends up with a catalog that "passes
+  validation" and shows no lab at all.
+
+  ```console
+  $ dsoxlab new catalog my-catalog
+  $ cd my-catalog && dsoxlab new lab first-lab --runtime shell
+  $ dsoxlab list-labs && dsoxlab validate-structure
+  ```
+
+  The skeleton differs by runtime, as the contract demands: a `shell` lab
+  declares its `workdir`, a `vm` lab its `targets` and both playbooks.
+
+  **The generated test fails**, and is not skipped. A skeleton green from the
+  start would teach the wrong habit — grading without checking anything — and a
+  skipped test says neither that the work remains nor that it is done. A failing
+  test says the first, which is what its author needs.
+
+  The generated skeleton is checked against the **published schemas**, not only
+  against `validate-structure`: the contract is frozen and its schemas are
+  published, so ignoring them would let the generator drift into a variant
+  without anything saying so. That check caught the first version of this
+  generator, which wrote an unquoted `:` inside a description — valid-looking
+  YAML that would not load, and a lab that vanished in silence.
+
+
 ### Fixed
 
 - **Nothing said that a merged version had never been tagged.** It happened

--- a/docs/commands.fr.md
+++ b/docs/commands.fr.md
@@ -39,6 +39,8 @@ complet de la plateforme dans le terminal, `dsoxlab fullhelp`.
 | `dsoxlab install` | Déprécié : utilise « dsoxlab completion install ». Installe l'auto-complétion. |
 | `dsoxlab instructor bootstrap` | Génère la clé SSH du lab (si absente) et vérifie que terraform/ansible-runner sont installés. |
 | `dsoxlab list-labs` | Liste tous les labs disponibles (filtrés par contexte actif si défini). |
+| `dsoxlab new catalog` | Crée un catalogue vide : meta.yml, labs/, .gitignore, ssh/. |
+| `dsoxlab new lab` | Crée un lab conforme, découvert dès le prochain list-labs. |
 | `dsoxlab next` | Recommande le prochain lab ou challenge à compléter dans le contexte actif. |
 | `dsoxlab progress` | Affiche la progression par bloc (labs complétés, score moyen, challenges et capstones). |
 | `dsoxlab provision` | Provisionne l'infrastructure du lab (terraform apply sur le provider courant). |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,6 +38,8 @@ guide in the terminal, `dsoxlab fullhelp`.
 | `dsoxlab install` | Deprecated: use `dsoxlab completion install`. Installs shell completion. |
 | `dsoxlab instructor bootstrap` | Generate the lab SSH key (if missing) and check that terraform/ansible-runner are installed. |
 | `dsoxlab list-labs` | List all available labs (filtered by active context if set). |
+| `dsoxlab new catalog` | Scaffold an empty catalog: meta.yml, labs/, .gitignore, ssh/. |
+| `dsoxlab new lab` | Scaffold a lab, discovered by the next list-labs. |
 | `dsoxlab next` | Recommend the next lab or challenge to complete in the active context. |
 | `dsoxlab progress` | Show progression by bloc (labs completed, average score, challenges and capstones). |
 | `dsoxlab provision` | Provision the lab infrastructure (terraform apply on the current provider). |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.69"
+version = "0.1.71"
 description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli/_socle.py
+++ b/src/dsoxlab/cli/_socle.py
@@ -148,3 +148,14 @@ infra_app = typer.Typer(
     cls=_I18nGroup,
 )
 app.add_typer(infra_app, name="infra")
+
+# ── Sous-application 'new' ────────────────────────────────────────────────────
+
+new_app = typer.Typer(
+    name="new",
+    help=_("cmd_new_help"),
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+    cls=_I18nGroup,
+)
+app.add_typer(new_app, name="new")

--- a/src/dsoxlab/cli/auteur.py
+++ b/src/dsoxlab/cli/auteur.py
@@ -44,7 +44,7 @@ from ._commun import (
     LabHomeOption,
     _root,
 )
-from ._socle import app
+from ._socle import app, new_app
 from ._validation import _compter
 
 logger = logging.getLogger(__name__)
@@ -259,3 +259,54 @@ def validate_structure_cmd(
 
 
 # ── doctor ────────────────────────────────────────────────────────────────────
+
+
+# ── new : créer un squelette conforme au contrat ──────────────────────────────
+
+@new_app.command("catalog", help=_("cmd_new_catalog_help"))
+def new_catalog(
+    identifiant: Annotated[str, typer.Argument(help=_("arg_new_id"))],
+    dans: Annotated[
+        Path | None, typer.Option("--in", help=_("opt_new_dans"))
+    ] = None,
+) -> None:
+    """Crée un catalogue vide mais conforme."""
+    from ..services.scaffold import ScaffoldError, creer_catalogue
+
+    try:
+        creation = creer_catalogue(identifiant, dans or Path.cwd())
+    except ScaffoldError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from None
+    except OSError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from None
+
+    success(_("scaffold_catalogue_cree", name=identifiant, path=str(creation.racine)))
+    info(_("scaffold_catalogue_suite", path=str(creation.racine)))
+
+
+@new_app.command("lab", help=_("cmd_new_lab_help"))
+def new_lab(
+    identifiant: Annotated[str, typer.Argument(help=_("arg_new_id"))],
+    runtime: Annotated[
+        str, typer.Option("--runtime", help=_("opt_new_runtime"))
+    ] = "shell",
+    lab_home: LabHomeOption = None,
+) -> None:
+    """Crée un lab conforme, découvert dès le prochain `list-labs`."""
+    from ..services.scaffold import ScaffoldError, creer_lab
+
+    root = _root(lab_home)
+    try:
+        creation = creer_lab(identifiant, root, runtime=runtime)
+    except ScaffoldError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from None
+    except OSError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from None
+
+    success(_("scaffold_lab_cree", name=identifiant,
+              path=str(creation.racine), runtime=runtime))
+    info(_("scaffold_lab_suite"))

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -139,6 +139,42 @@ STRINGS: dict[str, str] = {
     "status_titre": "Lab state",
     "cmd_infra_help": "Infrastructure commands for the catalog.",
 
+    # ── new: scaffold a contract-compliant skeleton ─────────────────────────
+    "cmd_new_help":
+        "Scaffold a catalog or a lab that matches the contract, ready to fill.",
+    "cmd_new_catalog_help":
+        "Scaffold an empty catalog: meta.yml, labs/, .gitignore, ssh/.",
+    "cmd_new_lab_help":
+        "Scaffold a lab, discovered by the next list-labs.",
+    "arg_new_id": "Id, lowercase, no spaces.",
+    "opt_new_dans": "Directory to create the catalog in. Defaults to the current one.",
+    "opt_new_runtime":
+        "Lab runtime: shell (local workshop) or vm (dedicated machine).",
+    "scaffold_catalogue_cree": "Catalog '{name}' created in {path}",
+    "scaffold_catalogue_suite":
+        "To get started:\n"
+        "  cd {path}\n"
+        "  dsoxlab new lab <id>\n"
+        "  dsoxlab validate-structure",
+    "scaffold_lab_cree": "Lab '{name}' created in {path} ({runtime})",
+    "scaffold_lab_suite":
+        "It already matches the contract, and its tests fail until they are "
+        "written:\n"
+        "  dsoxlab list-labs\n"
+        "  dsoxlab validate-structure\n"
+        "Then fill scenario.md, and challenge/tests/test_functional.py.",
+    "scaffold_id_invalide":
+        "'{name}' cannot be used as an id: lowercase letters, digits, dot, "
+        "dash and underscore only.",
+    "scaffold_existe_deja":
+        "{path} already exists. Pick another id, or remove that directory: "
+        "a skeleton never overwrites work.",
+    "scaffold_runtime_inconnu":
+        "Unknown runtime '{name}'. Possible values: {connus}.",
+    "scaffold_hors_catalogue":
+        "{path} is not a catalog: no meta.yml at its root. Move into a "
+        "catalog, or create one: dsoxlab new catalog <id>",
+
     "cmd_catalog_help":
         "Discover, install and update lab catalogues.",
     "cmd_catalog_list_help":
@@ -476,6 +512,16 @@ Each lab declares:
   [cyan]demo[/cyan]                 Install a demonstration catalog and a first lab you can
                        play right away, with nothing to clone or provision.
     [dim]--force[/dim]              Reinstall over it (loses progress).
+
+  [cyan]new catalog <id>[/cyan]     Scaffolds an empty but compliant catalog: meta.yml,
+                       labs/, .gitignore, ssh/. It passes [cyan]validate-structure[/cyan]
+                       with no edit.
+    [dim]--in <dir>[/dim]           Where to create it. Defaults to the current directory.
+  [cyan]new lab <id>[/cyan]         Scaffolds a compliant lab, discovered by the next
+                       [cyan]list-labs[/cyan]. Its test [bold]fails[/bold] until it is written: a
+                       skeleton green from the start would teach grading
+                       without checking anything.
+    [dim]--runtime <type>[/dim]     [bold]shell[/bold] (local workshop) or [bold]vm[/bold] (dedicated machine).
 
   [cyan]catalog list[/cyan]         Known catalogues, and the ones installed.
     [dim]--json[/dim]               Machine document instead of tables.

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -140,6 +140,42 @@ STRINGS: dict[str, str] = {
     "status_titre": "État du lab",
     "cmd_infra_help": "Commandes d'infrastructure du catalogue.",
 
+    # ── new : créer un squelette conforme au contrat ────────────────────────
+    "cmd_new_help":
+        "Crée un catalogue ou un lab conforme au contrat, prêt à remplir.",
+    "cmd_new_catalog_help":
+        "Crée un catalogue vide : meta.yml, labs/, .gitignore, ssh/.",
+    "cmd_new_lab_help":
+        "Crée un lab conforme, découvert dès le prochain list-labs.",
+    "arg_new_id": "Identifiant, en minuscules, sans espace.",
+    "opt_new_dans": "Répertoire où créer le catalogue. Défaut : le répertoire courant.",
+    "opt_new_runtime":
+        "Runtime du lab : shell (atelier local) ou vm (machine dédiée).",
+    "scaffold_catalogue_cree": "Catalogue « {name} » créé dans {path}",
+    "scaffold_catalogue_suite":
+        "Pour commencer :\n"
+        "  cd {path}\n"
+        "  dsoxlab new lab <id>\n"
+        "  dsoxlab validate-structure",
+    "scaffold_lab_cree": "Lab « {name} » créé dans {path} ({runtime})",
+    "scaffold_lab_suite":
+        "Il est déjà conforme, et ses tests échouent tant qu'ils ne sont pas "
+        "écrits :\n"
+        "  dsoxlab list-labs\n"
+        "  dsoxlab validate-structure\n"
+        "Remplis ensuite scenario.md, puis challenge/tests/test_functional.py.",
+    "scaffold_id_invalide":
+        "« {name} » ne peut pas servir d'identifiant : minuscules, chiffres, "
+        "point, tiret et souligné seulement.",
+    "scaffold_existe_deja":
+        "{path} existe déjà. Choisis un autre identifiant, ou retire ce "
+        "répertoire : un squelette n'écrase jamais du travail.",
+    "scaffold_runtime_inconnu":
+        "Runtime « {name} » inconnu. Valeurs possibles : {connus}.",
+    "scaffold_hors_catalogue":
+        "{path} n'est pas un catalogue : aucun meta.yml à sa racine. "
+        "Place-toi dans un catalogue, ou crées-en un : dsoxlab new catalog <id>",
+
     "cmd_catalog_help":
         "Découvre, installe et met à jour les catalogues de labs.",
     "cmd_catalog_list_help":
@@ -479,6 +515,16 @@ Chaque lab déclare :
   [cyan]demo[/cyan]                 Installe un catalogue de démonstration et un premier lab
                        jouable immédiatement, sans rien cloner ni provisionner.
     [dim]--force[/dim]              Réinstalle par-dessus (perd la progression).
+
+  [cyan]new catalog <id>[/cyan]     Crée un catalogue vide mais conforme : meta.yml,
+                       labs/, .gitignore, ssh/. Il passe [cyan]validate-structure[/cyan]
+                       sans retouche.
+    [dim]--in <dir>[/dim]           Où le créer. Défaut : le répertoire courant.
+  [cyan]new lab <id>[/cyan]         Crée un lab conforme, découvert dès le prochain
+                       [cyan]list-labs[/cyan]. Son test [bold]échoue[/bold] tant qu'il n'est pas
+                       écrit : un squelette vert d'emblée apprendrait à noter
+                       sans rien vérifier.
+    [dim]--runtime <type>[/dim]     [bold]shell[/bold] (atelier local) ou [bold]vm[/bold] (machine dédiée).
 
   [cyan]catalog list[/cyan]         Les catalogues connus, et ceux qui sont installés.
     [dim]--json[/dim]               Document machine plutôt que tableaux.

--- a/src/dsoxlab/services/scaffold.py
+++ b/src/dsoxlab/services/scaffold.py
@@ -1,0 +1,279 @@
+"""Créer un catalogue ou un lab conforme au contrat, sans le connaître par cœur.
+
+Écrire un catalogue supposait jusqu'ici de retenir le contrat, ou de copier un
+dépôt existant. Les deux chemins produisent les mêmes erreurs : un fichier
+obligatoire oublié, un nom de fichier de test qui ne correspond pas à celui
+qu'attend le validator, une fixture livrée mais non déclarée. Et la sanction est
+muette — le lab disparaît du catalogue sans un mot, parce qu'un `lab.yaml` qui
+lève au parsing n'est jamais examiné par `validate-structure`.
+
+**Les gabarits sont des chaînes de ce module, pas des fichiers packagés.** Le
+dépôt s'interdit d'embarquer des templates de labs, et un répertoire
+`templates/scaffold/` ressemblerait à s'y méprendre à ce qu'il proscrit. Ici, ce
+qui est produit est une **structure vide** : des emplacements à remplir, aucun
+contenu pédagogique, aucun nom de domaine.
+
+Le squelette produit doit passer `validate-structure` **sans retouche**, et le
+test généré doit **échouer** tant que l'exercice n'est pas résolu : un squelette
+vert d'emblée apprendrait la mauvaise habitude, celle d'un lab qui note sans
+rien vérifier.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..i18n import _
+
+#: Un identifiant sert de nom de répertoire et de clé CLI : on le borne pour
+#: qu'il ne puisse ni remonter l'arborescence, ni porter d'espace.
+_ID_VALIDE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+RUNTIMES = ("shell", "vm")
+
+
+class ScaffoldError(RuntimeError):
+    """La création a échoué, avec un message déjà traduit."""
+
+
+@dataclass(frozen=True)
+class Creation:
+    """Ce qui a été écrit, pour que la CLI le raconte sans le deviner."""
+
+    racine: Path
+    fichiers: tuple[Path, ...]
+
+
+_META = """\
+# Catalogue {id}, décrit par le contrat v1 de dsoxlab.
+#
+# `repo.id` sert de clé pour l'état local de ce catalogue : le changer
+# déplace ces emplacements.
+schema_version: 1
+
+repo:
+  id: {id}
+  category: {id}
+  title: {id}
+  description: |
+    À remplir : ce que ce catalogue apprend, et à qui.
+
+# Un catalogue sans lab `vm` n'a pas besoin de bloc `infra:`. Décommente-le le
+# jour où un lab déclare `runtime.type: vm`.
+#
+# infra:
+#   provider: kvm
+#   network: {id}-net
+#   cidr: 10.10.10.0/24
+#   hosts:
+#     - name: hote.lab
+#       distro: alma10
+
+sections:
+  - id: premiers-pas
+    title: Premiers pas
+    description: À remplir.
+    labs: []
+"""
+
+_GITIGNORE = """\
+# Progression et contexte : locaux à chaque machine, jamais versionnés.
+.dsoxlab.db
+.dsoxlab-context.json
+
+# Clé privée d'automatisation, posée par `dsoxlab instructor bootstrap`.
+ssh/id_ed25519
+
+# Répertoires de travail des labs `shell` : ce que l'apprenant y écrit lui
+# appartient, et le catalogue les recrée à chaque `run`.
+labs/**/challenge/work/
+"""
+
+_LAB_COMMUN = """\
+# Lab {id}. Les champs marqués REQUIS sont exigés par le validator : sans eux,
+# le lab est refusé, ou pire, disparaît du catalogue sans un mot.
+id: {id}                      # REQUIS
+title: "À remplir"            # REQUIS
+level: l1                     # REQUIS
+description: "À remplir : ce que l'apprenant saura faire à la fin."
+skills:                       # REQUIS, non vide
+  - a-remplir
+distros:                      # REQUIS, non vide
+  - any
+doc_url: https://example.org/a-remplir   # REQUIS, http(s)
+lab_type: lab
+estimated_time: 30m
+"""
+
+_LAB_SHELL = """\
+runtime:
+  type: shell
+  workdir: challenge/work
+  # Une fixture NON déclarée ici n'est PAS copiée, même présente dans
+  # fixtures/ : le répertoire de travail serait vide et l'apprenant sans rien
+  # à faire.
+  fixtures: []
+validation:
+  functional: true
+"""
+
+_LAB_VM = """\
+runtime:
+  type: vm
+  targets:                    # REQUIS pour vm, non vide
+    - name: cible
+      host: hote.lab          # doit exister dans meta.yml: infra.hosts[]
+  default: cible
+validation:
+  functional: true
+  persistence_after_reboot: false
+"""
+
+_README = """\
+# {id}
+
+**Public :** l'apprenant.
+
+À remplir : ce que ce lab apprend, en une phrase.
+
+## Ce que vous saurez faire
+
+- À remplir.
+"""
+
+_SCENARIO = """\
+# Scénario
+
+À remplir : la situation, telle que l'apprenant la rencontrerait.
+
+Un scénario dit **où on est et ce qui ne va pas**, pas la marche à suivre :
+c'est le travail de l'apprenant de la trouver.
+
+## Mission
+
+À remplir.
+"""
+
+#: Le test généré ÉCHOUE, il n'est pas `skip`. Un test sauté ne dit rien : ni
+#: que le travail reste à faire, ni qu'il est fait. Un test rouge dit la
+#: première chose, et c'est celle qui compte pour qui vient d'écrire un
+#: squelette.
+_TEST = '''\
+"""Tests fonctionnels du lab {id} — SQUELETTE, à écrire.
+
+Ce fichier échoue volontairement. Il ne s'agit pas d'une erreur : tant que les
+tests ne sont pas écrits, `dsoxlab check` doit rendre un échec plutôt qu'un
+succès qui ne prouve rien.
+
+Ce qu'un test de lab vérifie, c'est **l'état du système**, jamais qu'une
+commande a été tapée : un apprenant qui atteint le bon état par un autre chemin
+a réussi. Quand le sujet le justifie, vérifiez aussi que l'état survit à un
+redémarrage.
+"""
+
+from __future__ import annotations
+
+
+def test_a_ecrire() -> None:
+    """Remplacez-moi par ce que le lab doit prouver."""
+    raise AssertionError(
+        "Les tests de ce lab restent à écrire. Vérifiez l'état du système "
+        "produit par la mission, pas les commandes tapées pour y arriver."
+    )
+'''
+
+_SETUP = """\
+---
+# Joué par `dsoxlab run` avant d'ouvrir la session : il pose la situation que
+# le scénario décrit.
+- name: Préparer le lab {id}
+  hosts: lab_target
+  become: true
+  tasks:
+    - name: À remplir
+      ansible.builtin.debug:
+        msg: "Remplacez cette tâche par la mise en situation."
+"""
+
+_CLEANUP = """\
+---
+# Joué par `dsoxlab clean` et `dsoxlab reset` : il défait ce que setup.yaml a
+# posé, pour que le lab se rejoue à l'identique.
+- name: Défaire le lab {id}
+  hosts: lab_target
+  become: true
+  tasks:
+    - name: À remplir
+      ansible.builtin.debug:
+        msg: "Remplacez cette tâche par le retour à l'état initial."
+"""
+
+
+def _valider_identifiant(identifiant: str) -> None:
+    if not _ID_VALIDE.match(identifiant):
+        raise ScaffoldError(_("scaffold_id_invalide", name=identifiant))
+
+
+def _ecrire(chemin: Path, contenu: str) -> Path:
+    chemin.parent.mkdir(parents=True, exist_ok=True)
+    chemin.write_text(contenu, encoding="utf-8")
+    return chemin
+
+
+def creer_catalogue(identifiant: str, destination: Path) -> Creation:
+    """Écrit un catalogue vide mais conforme, prêt à recevoir des labs."""
+    _valider_identifiant(identifiant)
+    racine = destination / identifiant
+    if racine.exists():
+        # Ne jamais écrire par-dessus : ce répertoire porte peut-être déjà du
+        # travail, et un squelette l'écraserait sans retour possible.
+        raise ScaffoldError(_("scaffold_existe_deja", path=str(racine)))
+
+    fichiers = [
+        _ecrire(racine / "meta.yml", _META.format(id=identifiant)),
+        _ecrire(racine / ".gitignore", _GITIGNORE),
+    ]
+    (racine / "labs").mkdir(parents=True, exist_ok=True)
+    (racine / "ssh").mkdir(parents=True, exist_ok=True)
+    return Creation(racine=racine, fichiers=tuple(fichiers))
+
+
+def creer_lab(identifiant: str, racine_catalogue: Path, *, runtime: str) -> Creation:
+    """Écrit un lab conforme au contrat, découvert dès le prochain `list-labs`.
+
+    Le squelette diffère selon le runtime, parce que le contrat l'exige : un lab
+    `shell` déclare son `workdir`, un lab `vm` ses `targets` et ses deux
+    playbooks.
+    """
+    _valider_identifiant(identifiant)
+    if runtime not in RUNTIMES:
+        raise ScaffoldError(_("scaffold_runtime_inconnu", name=runtime,
+                              connus=", ".join(RUNTIMES)))
+    if not (racine_catalogue / "meta.yml").is_file():
+        raise ScaffoldError(_("scaffold_hors_catalogue", path=str(racine_catalogue)))
+
+    base = racine_catalogue / "labs" / identifiant
+    if base.exists():
+        raise ScaffoldError(_("scaffold_existe_deja", path=str(base)))
+
+    corps = _LAB_SHELL if runtime == "shell" else _LAB_VM
+    fichiers = [
+        _ecrire(base / "lab.yaml", _LAB_COMMUN.format(id=identifiant) + corps),
+        _ecrire(base / "README.md", _README.format(id=identifiant)),
+        _ecrire(base / "scenario.md", _SCENARIO),
+        _ecrire(base / "challenge" / "tests" / "test_functional.py",
+                _TEST.format(id=identifiant)),
+    ]
+    if runtime == "vm":
+        fichiers += [
+            _ecrire(base / "setup.yaml", _SETUP.format(id=identifiant)),
+            _ecrire(base / "cleanup.yaml", _CLEANUP.format(id=identifiant)),
+        ]
+    else:
+        # Le répertoire de travail existe dès la création : sans lui, le lab
+        # est conforme mais `run` n'a rien à préparer.
+        (base / "challenge" / "work").mkdir(parents=True, exist_ok=True)
+        (base / "fixtures").mkdir(parents=True, exist_ok=True)
+    return Creation(racine=base, fichiers=tuple(fichiers))

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,0 +1,230 @@
+"""Créer un squelette conforme au contrat (issue #88).
+
+Écrire un catalogue supposait de retenir le contrat, ou de copier un dépôt
+existant. Les deux chemins produisent les mêmes erreurs, et la sanction est
+muette : un `lab.yaml` qui lève au parsing n'est jamais examiné par
+`validate-structure`, si bien qu'un débutant obtient un catalogue qui « passe la
+validation » et n'affiche aucun lab.
+
+Ce module éprouve donc les deux bouts, et pas seulement la présence des
+fichiers :
+
+- le squelette est **découvert** (donc son YAML se charge vraiment) ;
+- il passe `validate-structure` **sans retouche** ;
+- il est conforme aux **schémas publiés**, ce qui garantit qu'il produit du v1
+  et non une variante ;
+- et son test **échoue**, parce qu'un squelette vert d'emblée apprendrait la
+  mauvaise habitude.
+
+Le premier point n'est pas théorique : la première version de ce générateur
+écrivait `description: À remplir : ce que…`, dont le second deux-points casse le
+YAML. Le lab disparaissait, et `validate-structure` annonçait pourtant « tous
+les labs sont valides ».
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dsoxlab.discovery.scanner import discover_labs
+from dsoxlab.services import scaffold
+from dsoxlab.validators.structure import validate_structure
+
+RACINE = Path(__file__).resolve().parent.parent
+
+
+def _catalogue(tmp_path: Path, identifiant: str = "essai") -> Path:
+    return scaffold.creer_catalogue(identifiant, tmp_path).racine
+
+
+# ── Le catalogue ────────────────────────────────────────────────────────────
+
+def test_un_catalogue_neuf_porte_ce_que_le_contrat_exige(tmp_path: Path) -> None:
+    racine = _catalogue(tmp_path)
+
+    assert (racine / "meta.yml").is_file()
+    assert (racine / "labs").is_dir()
+    assert (racine / ".gitignore").is_file()
+    # `instructor bootstrap` y pose la clé : le répertoire doit exister.
+    assert (racine / "ssh").is_dir()
+
+
+def test_le_meta_produit_se_charge_vraiment(tmp_path: Path) -> None:
+    """Un meta.yml qui ne se charge pas rend le catalogue muet."""
+    racine = _catalogue(tmp_path, "mon-domaine")
+    document = yaml.safe_load((racine / "meta.yml").read_text(encoding="utf-8"))
+
+    assert document["repo"]["id"] == "mon-domaine"
+    assert document["repo"]["category"] == "mon-domaine"
+
+
+def test_un_catalogue_n_ecrase_jamais_un_repertoire(tmp_path: Path) -> None:
+    """Ce répertoire porte peut-être du travail : on ne passe pas dessus."""
+    _catalogue(tmp_path)
+
+    with pytest.raises(scaffold.ScaffoldError) as exc:
+        _catalogue(tmp_path)
+    assert "essai" in str(exc.value)
+
+
+# ── Le lab ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("runtime", ["shell", "vm"])
+def test_un_lab_neuf_est_decouvert(tmp_path: Path, runtime: str) -> None:
+    """Le critère qui compte : découvert, donc son YAML se charge.
+
+    Vérifier la présence des fichiers ne suffirait pas — c'est exactement ce
+    qui laissait passer un `lab.yaml` cassé.
+    """
+    racine = _catalogue(tmp_path)
+    scaffold.creer_lab("mon-lab", racine, runtime=runtime)
+
+    labs = discover_labs(racine)
+
+    assert [lab.id for lab in labs] == ["mon-lab"]
+    assert labs[0].runtime.type.value == runtime
+
+
+@pytest.mark.parametrize("runtime", ["shell", "vm"])
+def test_un_lab_neuf_passe_la_validation_sans_retouche(
+    tmp_path: Path, runtime: str,
+) -> None:
+    racine = _catalogue(tmp_path)
+    scaffold.creer_lab("mon-lab", racine, runtime=runtime)
+
+    rapport = validate_structure(discover_labs(racine)[0])
+
+    assert not rapport.issues, [i.key for i in rapport.issues]
+
+
+def test_le_squelette_shell_declare_son_workdir(tmp_path: Path) -> None:
+    racine = _catalogue(tmp_path)
+    scaffold.creer_lab("mon-lab", racine, runtime="shell")
+
+    lab = discover_labs(racine)[0]
+
+    assert lab.runtime.workdir
+    assert (lab.path / lab.runtime.workdir).is_dir()
+
+
+def test_le_squelette_vm_livre_ses_deux_playbooks(tmp_path: Path) -> None:
+    """Le contrat les exige, et leur absence refuse le lab."""
+    racine = _catalogue(tmp_path)
+    creation = scaffold.creer_lab("mon-lab", racine, runtime="vm")
+
+    assert (creation.racine / "setup.yaml").is_file()
+    assert (creation.racine / "cleanup.yaml").is_file()
+    assert discover_labs(racine)[0].runtime.targets
+
+
+def test_les_playbooks_produits_se_chargent(tmp_path: Path) -> None:
+    """Un playbook au YAML cassé n'échouerait qu'au premier `run`."""
+    racine = _catalogue(tmp_path)
+    creation = scaffold.creer_lab("mon-lab", racine, runtime="vm")
+
+    for nom in ("setup.yaml", "cleanup.yaml"):
+        document = yaml.safe_load((creation.racine / nom).read_text(encoding="utf-8"))
+        assert isinstance(document, list) and document[0]["hosts"] == "lab_target"
+
+
+# ── Le test généré : il doit échouer ────────────────────────────────────────
+
+def test_le_test_genere_echoue_tant_qu_il_n_est_pas_ecrit(tmp_path: Path) -> None:
+    """Un squelette vert d'emblée apprendrait la mauvaise habitude.
+
+    Et un test `skip` ne vaut pas mieux : il ne dit ni que le travail reste à
+    faire, ni qu'il est fait. Un test rouge dit la première chose, qui est
+    celle dont l'auteur a besoin.
+    """
+    racine = _catalogue(tmp_path)
+    creation = scaffold.creer_lab("mon-lab", racine, runtime="shell")
+    tests = creation.racine / "challenge" / "tests"
+
+    resultat = subprocess.run(
+        [sys.executable, "-m", "pytest", str(tests), "-q"],
+        capture_output=True, text=True, check=False, timeout=120,
+    )
+
+    assert resultat.returncode != 0, "le test généré doit échouer, pas passer"
+    assert "skip" not in resultat.stdout.lower(), (
+        "un test sauté ne dit pas que le travail reste à faire"
+    )
+
+
+# ── Conformité aux schémas publiés ──────────────────────────────────────────
+
+@pytest.mark.parametrize("runtime", ["shell", "vm"])
+def test_le_squelette_est_conforme_au_schema_publie(
+    tmp_path: Path, runtime: str,
+) -> None:
+    """Le générateur doit produire du v1, pas une variante.
+
+    Le contrat est gelé et ses schémas sont publiés : les ignorer laisserait le
+    générateur diverger sans que rien ne le dise.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+
+    racine = _catalogue(tmp_path)
+    creation = scaffold.creer_lab("mon-lab", racine, runtime=runtime)
+
+    for chemin, schema in ((racine / "meta.yml", "meta"),
+                           (creation.racine / "lab.yaml", "lab")):
+        document = yaml.safe_load(chemin.read_text(encoding="utf-8"))
+        definition = json.loads(
+            (RACINE / "schemas" / f"{schema}.schema.json").read_text(encoding="utf-8")
+        )
+        jsonschema.validate(document, definition)
+
+
+# ── Les refus ───────────────────────────────────────────────────────────────
+
+def test_un_lab_hors_catalogue_est_refuse(tmp_path: Path) -> None:
+    """Sans meta.yml, ce n'est pas un catalogue : le lab n'y serait jamais vu."""
+    with pytest.raises(scaffold.ScaffoldError) as exc:
+        scaffold.creer_lab("mon-lab", tmp_path, runtime="shell")
+    assert "meta.yml" in str(exc.value)
+
+
+def test_un_runtime_inconnu_est_refuse(tmp_path: Path) -> None:
+    racine = _catalogue(tmp_path)
+    with pytest.raises(scaffold.ScaffoldError) as exc:
+        scaffold.creer_lab("mon-lab", racine, runtime="podman")
+    assert "podman" in str(exc.value)
+
+
+@pytest.mark.parametrize("mauvais", ["../evade", "/absolu", "Avec Majuscule", ""])
+def test_un_identifiant_ne_peut_pas_sortir_du_repertoire(
+    tmp_path: Path, mauvais: str,
+) -> None:
+    """Un identifiant sert de nom de répertoire : il ne remonte rien."""
+    with pytest.raises(scaffold.ScaffoldError):
+        scaffold.creer_catalogue(mauvais, tmp_path)
+
+
+def test_le_generateur_ne_cite_aucun_nom_de_domaine() -> None:
+    """L'invariant du projet : le squelette est une structure, pas un contenu.
+
+    `ansible` en est exclu, et la distinction n'est pas une facilité : le
+    contrat **impose** que `setup.yaml` et `cleanup.yaml` soient des playbooks
+    Ansible, joués par `ansible-runner`. C'est le format du contrat, au même
+    titre que YAML, pas un domaine enseigné. Ce qui est proscrit, c'est la
+    connaissance d'un domaine — un `if category == "linux"`, un scénario tout
+    fait, une compétence pré-remplie.
+    """
+    source = Path(scaffold.__file__).read_text(encoding="utf-8").lower()
+    for domaine in ("linux", "kubernetes", "terraform", "docker", "rhcsa"):
+        assert domaine not in source, f"« {domaine} » est cité dans scaffold.py"
+
+    # Et pour Ansible : il n'apparaît que comme module de playbook, jamais
+    # comme sujet.
+    for ligne in source.splitlines():
+        if "ansible" in ligne:
+            assert "ansible.builtin" in ligne, (
+                f"« ansible » cité hors d'un module de playbook : {ligne.strip()}"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.69"
+version = "0.1.71"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Écrire un catalogue supposait de connaître le contrat par cœur, ou de copier un
dépôt existant. Les deux chemins produisent les mêmes erreurs — un fichier
obligatoire oublié, un nom de fichier de test qui ne correspond pas à celui
qu'attend le validator, une fixture livrée mais non déclarée — et **la sanction
est muette** : un `lab.yaml` qui lève au parsing n'est jamais examiné par
`validate-structure`, si bien qu'un débutant obtient un catalogue qui « passe la
validation » et n'affiche aucun lab.

```console
$ dsoxlab new catalog mon-catalogue
✔ Catalogue « mon-catalogue » créé

$ cd mon-catalogue && dsoxlab new lab premier-lab --runtime shell
✔ Lab « premier-lab » créé (shell)
ℹ Il est déjà conforme, et ses tests échouent tant qu'ils ne sont pas écrits

$ dsoxlab list-labs && dsoxlab validate-structure
├── ✔ premier-lab
✔ Tous les labs sont valides.
```

Le squelette diffère selon le runtime, comme le contrat l'exige : un lab `shell`
déclare son `workdir`, un lab `vm` ses `targets` et ses deux playbooks.

## Le test généré échoue, il n'est pas sauté

Un squelette vert d'emblée apprendrait la mauvaise habitude — noter sans rien
vérifier. Mais **un test sauté ne vaut pas mieux** : il ne dit ni que le travail
reste à faire, ni qu'il est fait. Un test rouge dit la première chose, qui est
celle dont son auteur a besoin.

C'est un écart assumé avec le squelette existant de `terraform-training`, qui
utilise `pytest.mark.skip`. Le critère de l'issue tranche dans ce sens, et le
test généré porte la raison dans son propre docstring.

## Éprouvé contre les schémas publiés, et pas seulement contre le validator

Le contrat est gelé et ses schémas sont publiés : les ignorer laisserait le
générateur produire une **variante** sans que rien ne le dise. Chaque squelette
est donc validé contre `schemas/lab.schema.json` et `schemas/meta.schema.json`.

**Ce contrôle a servi immédiatement.** La première version de ce générateur
écrivait :

```yaml
description: À remplir : ce que l'apprenant saura faire à la fin.
```

Le second deux-points casse le YAML. Le lab disparaissait, et
`validate-structure` annonçait pourtant « ✔ Tous les labs sont valides » —
exactement le défaut que l'issue décrit en contexte, reproduit par le générateur
censé l'éviter. Vérifier la présence des fichiers ne l'aurait pas vu ; vérifier
la **découverte** l'a vu.

## Les gabarits sont des chaînes, pas des fichiers packagés

Le dépôt s'interdit d'embarquer des templates de labs, et un
`templates/scaffold/` ressemblerait à s'y méprendre à ce qu'il proscrit. Ce qui
est produit est une **structure vide** : des emplacements à remplir, aucun
contenu pédagogique.

Un test le vérifie, et il **exempte nommément `ansible`** là où le mot désigne
un module de playbook : `setup.yaml` et `cleanup.yaml` *sont* des playbooks par
contrat, joués par `ansible-runner`. C'est le format, pas un sujet enseigné — la
même distinction que `terraform` dans `doctor.py`, qui est un exécutable sondé.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 79 source files*
- [x] `uv run pytest` : **731 passed** (711 avant, **+20**)
- [x] `uv run pytest tests_e2e` : **18 passed**
- [x] Le moteur reste neutre vis-à-vis du domaine, **vérifié par un test**
- [x] Aucun chemin personnel
- [x] Parcours complet joué pour **les deux runtimes** : création, découverte,
      `validate-structure`, échec du test généré, conformité aux schémas
- [ ] Test manuel sur deux dépôts fournisseurs : **N/A**, cette commande *crée*
      un catalogue au lieu d'en lire un ; elle a été jouée sur des catalogues
      neufs, `shell` et `vm`

### When behavior changes

- [x] CHANGELOG EN **et** FR ; version **0.1.71** ; `uv.lock` aligné

### When a command or option is added, removed or changed

- [x] Clés i18n dans **en.py et fr.py**, aides de commande et d'arguments
- [x] `fullhelp` **EN et FR** : le groupe `new` et ses deux sous-commandes
- [x] `docs/commands.*` régénérés par le générateur de doc
- [x] Joué sous `DSOXLAB_LANG=en` et `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched — N/A

### When the declarative contract changes — N/A

Aucun champ nouveau : le générateur *écrit* du contrat v1, il ne l'étend pas.

## Note de version

**0.1.71 et non 0.1.70**, ce numéro appartenant à la PR #166 (`doctor --fix`
typé), ouverte et verte. Si #166 part la première, l'enchaînement est cohérent.

## Related issues

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
