### PR TITLE
fix(check): ne pas noter ce qu'on n'a pas pu mesurer (0.1.72)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,30 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.72] - 2026-08-24
+
+### Corrigé
+
+- **Une exécution qui n'avait rien mesuré était notée 0/100, et le lab devenait
+  « validé »** (issue #168). Quand pytest ne peut pas collecter — un
+  `conftest.py` qui lève à l'import, une machine injoignable, une dépendance
+  absente — le résultat porte `total == 0`. `compute_score` refusait déjà de
+  deviner un score dans ce cas, mais ce refus n'allait pas jusqu'à la base.
+
+  C'est la cascade qui faisait le dégât, et chaque maillon était correct pris
+  isolément : `get_best_scores` voyait le lab puisqu'il avait une ligne,
+  `status` le disait `validated` puisqu'une note existait, et `next` le sautait
+  puisqu'« un lab noté, même 0, n'est plus l'étape suivante ». L'apprenant
+  croyait avoir raté un exercice **qu'il n'avait jamais pu jouer**, et son
+  parcours avançait sans lui.
+
+  Plus rien n'est enregistré quand rien n'a été mesuré, `check` le dit au lieu
+  d'afficher un 0, et `check --json` porte `recorded` pour qu'une intégration
+  distingue un vrai échec d'un environnement qui n'a jamais tourné. Le prédicat
+  vit à **un seul endroit**, lu par celui qui enregistre comme par la sortie
+  machine, pour qu'il ne puisse pas diverger.
+
+
 ## [0.1.71] - 2026-08-24
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.72] - 2026-08-24
+
+### Fixed
+
+- **An execution that measured nothing was recorded as 0/100, and the lab turned
+  "validated"** (issue #168). When pytest cannot collect — a `conftest.py` that
+  raises on import, an unreachable machine, a missing dependency — the result
+  carries `total == 0`. `compute_score` already refused to guess a score there,
+  but that refusal stopped short of the database.
+
+  The cascade did the damage, and every link was correct on its own:
+  `get_best_scores` saw the lab because it had a row; `status` reported
+  `validated` because a score existed; `next` skipped it because "a graded lab,
+  even at 0, is no longer the next step". The learner believed they had failed
+  an exercise **they never got to play**, and the path moved on without them.
+
+  Nothing is recorded now when nothing was measured, `check` says so instead of
+  showing a 0, and `check --json` carries `recorded` so an integration can tell a
+  real failure from an environment that never ran. The predicate lives in **one
+  place**, read by both the recorder and the machine output, so it cannot drift.
+
+
 ## [0.1.71] - 2026-08-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.71"
+version = "0.1.72"
 description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli/_validation.py
+++ b/src/dsoxlab/cli/_validation.py
@@ -217,6 +217,12 @@ def _valider(
         console.print(result.output)
 
     evaluation = evaluate_lab(root, lab, result)
+    if not evaluation.enregistre and not quiet:
+        # Rien n'a été mesuré : le dire, plutôt que d'afficher un 0 que
+        # l'apprenant lirait comme un exercice raté.
+        error(_("check_rien_mesure"))
+        info(_("check_rien_mesure_suite"))
+        return result, evaluation.score, evaluation.max_score
     if quiet:
         # Mode machine : le tableau Rich et le message de confirmation
         # pollueraient le document JSON. Le résultat est tout de même

--- a/src/dsoxlab/cli/progression.py
+++ b/src/dsoxlab/cli/progression.py
@@ -49,6 +49,7 @@ from ..services import (
     next_pending_lab,
     reset_lab,
 )
+from ..services.lab_service import a_mesure
 from ..sessions.store import (
     get_best_scores,
     get_results,
@@ -103,6 +104,11 @@ def check(
                 "total": result.total,
                 "score": score,
                 "max_score": max_score,
+                # `recorded` dit si la note vaut quelque chose : une exécution
+                # qui n'a rien collecté rend 0 sans être inscrite, et un
+                # tableau de bord qui l'ignorerait afficherait un lab « raté »
+                # là où rien n'a pu être joué.
+                "recorded": a_mesure(result),
                 "output": result.output,
             },
         })

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -140,6 +140,13 @@ STRINGS: dict[str, str] = {
     "cmd_infra_help": "Infrastructure commands for the catalog.",
 
     # ── new: scaffold a contract-compliant skeleton ─────────────────────────
+    "check_rien_mesure":
+        "No test could be collected: nothing was measured, and nothing is "
+        "recorded.",
+    "check_rien_mesure_suite":
+        "Look at the output above: a conftest.py that raises, an unreachable "
+        "machine or a missing dependency stops pytest from starting. This is "
+        "not a failed exercise.",
     "cmd_new_help":
         "Scaffold a catalog or a lab that matches the contract, ready to fill.",
     "cmd_new_catalog_help":

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -141,6 +141,13 @@ STRINGS: dict[str, str] = {
     "cmd_infra_help": "Commandes d'infrastructure du catalogue.",
 
     # ── new : créer un squelette conforme au contrat ────────────────────────
+    "check_rien_mesure":
+        "Aucun test n'a pu être collecté : rien n'a été mesuré, et rien n'est "
+        "enregistré.",
+    "check_rien_mesure_suite":
+        "Regarde la sortie ci-dessus : un conftest.py qui lève, une machine "
+        "injoignable ou une dépendance absente empêchent pytest de démarrer. "
+        "Ce n'est pas un exercice raté.",
     "cmd_new_help":
         "Crée un catalogue ou un lab conforme au contrat, prêt à remplir.",
     "cmd_new_catalog_help":

--- a/src/dsoxlab/services/lab_service.py
+++ b/src/dsoxlab/services/lab_service.py
@@ -53,6 +53,14 @@ class ScoreResult:
     hints_used: int
     hints_cost: int
 
+    enregistre: bool = True
+    """L'exécution a-t-elle été inscrite dans l'historique ?
+
+    Faux quand rien n'a pu être mesuré : voir ``evaluate_lab``. L'appelant doit
+    alors dire qu'aucun test n'a été collecté, et surtout ne pas présenter le
+    0 comme une note.
+    """
+
 
 def _parse_counts(output: str) -> tuple[int, int]:
     """Extrait (passed, total) depuis la sortie de pytest.
@@ -111,6 +119,17 @@ def compute_score(passed: int, total: int, max_score: int, hints_cost: int) -> i
     return round((passed / total) * base)
 
 
+def a_mesure(result: CheckResult) -> bool:
+    """L'exécution a-t-elle mesuré quelque chose ?
+
+    Un seul endroit décide, parce que deux lecteurs en dépendent :
+    ``evaluate_lab`` pour savoir s'il enregistre, et la sortie machine pour
+    dire à un programme si la note vaut quelque chose. Dupliquer la règle la
+    ferait diverger le jour où elle change.
+    """
+    return result.total > 0
+
+
 def evaluate_lab(root: Path, lab: LabDefinition, result: CheckResult) -> ScoreResult:
     """Note un ``CheckResult`` et l'enregistre dans l'historique de l'apprenant.
 
@@ -124,6 +143,24 @@ def evaluate_lab(root: Path, lab: LabDefinition, result: CheckResult) -> ScoreRe
     hints_cost = hints_cost_total(root, lab.id)
     used = hints_used_count(root, lab.id)
     score = compute_score(result.passed, result.total, max_score, hints_cost)
+
+    if not a_mesure(result):
+        # Rien n'a été mesuré : pytest n'a pas pu collecter, faute d'un
+        # conftest qui lève, d'une machine injoignable ou d'une dépendance
+        # absente. Inscrire ce 0 le rendrait indiscernable d'un lab tenté et
+        # raté, et la suite en dépend : `status` afficherait « validé », et
+        # `next` sauterait un lab que l'apprenant n'a jamais pu jouer.
+        #
+        # `compute_score` refusait déjà de deviner un score ; ce refus n'allait
+        # pas jusqu'à la base.
+        return ScoreResult(
+            check=result,
+            score=score,
+            max_score=max_score,
+            hints_used=used,
+            hints_cost=hints_cost,
+            enregistre=False,
+        )
 
     record_result(
         root,

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -113,7 +113,8 @@ def test_a_failing_check_still_prints_only_json(monkeypatch, capsys, tmp_path) -
 
     echec = CheckResult(ok=False, output="=== test session starts ===\nFAILED", passed=1, total=3)
     monkeypatch.setattr(cli._validation, "_run_check_with_progress", lambda *a, **k: echec)
-    monkeypatch.setattr(cli._validation, "evaluate_lab", lambda *a, **k: type("E", (), {"score": 30, "max_score": 100})())
+    monkeypatch.setattr(cli._validation, "evaluate_lab", lambda *a, **k: type("E", (), {"score": 30, "max_score": 100, "hints_used": 0,
+                                              "hints_cost": 0, "enregistre": True})())
 
     cli._run_check(Path("/repo"), _lab(), None, quiet=True)
 

--- a/tests/test_note_sans_mesure.py
+++ b/tests/test_note_sans_mesure.py
@@ -1,0 +1,144 @@
+"""Une exécution qui n'a rien mesuré ne devient pas une note (issue #168).
+
+Quand pytest ne peut pas collecter — un `conftest.py` qui lève à l'import, une
+machine injoignable, une dépendance absente — le résultat porte `total == 0`.
+`compute_score` refusait déjà de deviner un score dans ce cas, mais ce refus
+n'allait pas jusqu'à la base : le 0 était enregistré comme une note.
+
+La suite en dépendait, et chaque maillon était correct pris isolément :
+
+- `get_best_scores` voyait le lab, puisqu'il avait une ligne ;
+- `lab_state.calculer` le rendait `validated`, puisqu'une note existait ;
+- `next` le sautait, puisqu'« un lab noté, même 0, n'est plus l'étape suivante ».
+
+L'apprenant croyait donc avoir raté un exercice qu'il n'avait jamais pu jouer, et
+son parcours avançait sans lui. Ce module éprouve la correction **et la cascade
+entière**, parce que c'est elle qui faisait le dégât.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dsoxlab.models.lab import LabDefinition
+from dsoxlab.services import lab_state
+from dsoxlab.services.lab_service import CheckResult, a_mesure, evaluate_lab
+from dsoxlab.services.progress_service import next_pending_lab
+from dsoxlab.sessions import store
+
+_BASE = """\
+id: l1-demo
+title: Demo lab
+level: beginner
+skills: [demo]
+distros: [any]
+doc_url: https://example.org/docs/demo/
+runtime:
+  type: shell
+  workdir: challenge/work
+"""
+
+
+@pytest.fixture(autouse=True)
+def xdg_jetable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+
+def _depot(tmp_path: Path) -> Path:
+    racine = tmp_path / "catalogue"
+    (racine / "labs").mkdir(parents=True, exist_ok=True)
+    (racine / "meta.yml").write_text(
+        "repo:\n  id: essai\n  category: essai\n", encoding="utf-8")
+    return racine
+
+
+def _lab(tmp_path: Path) -> LabDefinition:
+    base = _depot(tmp_path) / "labs" / "l1-demo"
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "lab.yaml").write_text(_BASE, encoding="utf-8")
+    return LabDefinition.from_yaml(base / "lab.yaml")
+
+
+def _rien_mesure() -> CheckResult:
+    """Ce que pytest rend quand il n'a pas pu collecter."""
+    return CheckResult(ok=False, output="ERROR collecting …", passed=0, total=0)
+
+
+def _echec_reel() -> CheckResult:
+    """Un vrai échec : des tests ont tourné, et ils ont échoué."""
+    return CheckResult(ok=False, output="2 failed, 1 passed", passed=1, total=3)
+
+
+# ── Le prédicat, à un seul endroit ──────────────────────────────────────────
+
+def test_le_predicat_distingue_les_deux_situations() -> None:
+    assert not a_mesure(_rien_mesure())
+    assert a_mesure(_echec_reel())
+
+
+# ── L'enregistrement ────────────────────────────────────────────────────────
+
+def test_une_execution_sans_mesure_n_est_pas_enregistree(tmp_path: Path) -> None:
+    racine = _depot(tmp_path)
+    lab = _lab(tmp_path)
+
+    evaluation = evaluate_lab(racine, lab, _rien_mesure())
+
+    assert evaluation.enregistre is False
+    assert store.get_best_scores(racine, [lab.id]) == {}, (
+        "rien ne doit entrer en base : c'est cette ligne qui contaminait la suite"
+    )
+
+
+def test_un_echec_reel_reste_enregistre(tmp_path: Path) -> None:
+    """Le garde-fou du garde-fou : on ne cesse pas d'enregistrer les vrais échecs.
+
+    Un apprenant qui tente et rate doit voir sa tentative comptée ; c'est
+    précisément ce qui distingue son cas de celui d'un environnement cassé.
+    """
+    racine = _depot(tmp_path)
+    lab = _lab(tmp_path)
+
+    evaluation = evaluate_lab(racine, lab, _echec_reel())
+
+    assert evaluation.enregistre is True
+    assert lab.id in store.get_best_scores(racine, [lab.id])
+
+
+# ── La cascade, maillon par maillon ─────────────────────────────────────────
+
+def test_le_lab_n_est_pas_declare_valide(tmp_path: Path) -> None:
+    """`status` annonçait « validé » sur un lab jamais joué."""
+    racine = _depot(tmp_path)
+    lab = _lab(tmp_path)
+    evaluate_lab(racine, lab, _rien_mesure())
+
+    etat = lab_state.calculer(racine, lab, "essai")
+
+    assert etat.state != lab_state.VALIDATED
+
+
+def test_le_lab_reste_l_etape_suivante(tmp_path: Path) -> None:
+    """`next` sautait le lab, et le parcours avançait sans l'apprenant."""
+    racine = _depot(tmp_path)
+    lab = _lab(tmp_path)
+    evaluate_lab(racine, lab, _rien_mesure())
+
+    suivant = next_pending_lab([lab], store.get_best_scores(racine, [lab.id]))
+
+    assert suivant is not None, "un lab qu'aucune exécution n'a mesuré reste à faire"
+    assert suivant.id == lab.id
+
+
+def test_un_lab_reellement_rate_n_est_plus_l_etape_suivante(tmp_path: Path) -> None:
+    """L'autre bout : le comportement d'origine ne doit pas se perdre."""
+    racine = _depot(tmp_path)
+    lab = _lab(tmp_path)
+    evaluate_lab(racine, lab, _echec_reel())
+
+    suivant = next_pending_lab([lab], store.get_best_scores(racine, [lab.id]))
+
+    assert suivant is None, "un lab tenté et raté n'est plus l'étape suivante"

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.71"
+version = "0.1.72"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Quand pytest ne peut pas collecter — un `conftest.py` qui lève à l'import, une
machine injoignable, une dépendance absente — le résultat porte `total == 0`.
`compute_score` refusait déjà de deviner un score dans ce cas, avec le
commentaire qui va bien :

```python
# ``total`` à zéro (pytest n'a pas pu collecter) rend 0 : on ne devine pas un
# score depuis une exécution qui n'a rien mesuré.
```

**Mais ce refus ne descendait pas jusqu'à la base.** `evaluate_lab` appelait
`record_result` inconditionnellement, et le 0 devenait une note.

## La cascade faisait le dégât, et chaque maillon était correct

| Étape | Ce qu'elle faisait, à raison |
|---|---|
| `get_best_scores` | voit le lab, puisqu'il a une ligne |
| `status` | annonce `validated`, puisqu'une note existe |
| `next` | saute le lab, puisqu'« un lab noté, même 0, n'est plus l'étape suivante » |

L'apprenant croyait avoir raté un exercice **qu'il n'avait jamais pu jouer**, et
son parcours avançait sans lui. Aucun maillon n'était fautif : c'est leur
enchaînement, à partir d'une donnée fausse, qui produisait le résultat.

## Ce qui change

Rien n'est enregistré quand rien n'a été mesuré. `check` le dit, et distingue
explicitement ce cas d'un exercice raté :

```
✘ Aucun test n'a pu être collecté : rien n'a été mesuré, et rien n'est enregistré.
ℹ Regarde la sortie ci-dessus : un conftest.py qui lève, une machine injoignable
  ou une dépendance absente empêchent pytest de démarrer. Ce n'est pas un
  exercice raté.
```

`check --json` porte désormais **`recorded`**, pour qu'un tableau de bord fasse
la même distinction sans analyser du français.

**Le prédicat vit à un seul endroit** — `a_mesure()` — lu par celui qui
enregistre comme par la sortie machine. Le dupliquer le ferait diverger le jour
où il change, ce qui est exactement le genre de divergence qui a produit ce
défaut.

## Les tests éprouvent la cascade, pas seulement la correction

Six tests, dont **deux qui rejouent le chemin jusqu'à l'apprenant** (`status` et
`next`), parce que c'est lui qui faisait mal. Deux autres tiennent l'autre bout :

- un **échec réel** reste enregistré — on ne cesse pas de compter les tentatives ;
- un lab **tenté puis raté** n'est plus l'étape suivante.

Éprouvé par l'échec : correction neutralisée, **trois rougissent**, dont les deux
de la cascade.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 79 source files*
- [x] `uv run pytest` : **745 passed** (739 avant, +6)
- [x] `uv run pytest tests_e2e` : **18 passed**
- [x] Le moteur reste neutre vis-à-vis du domaine
- [x] Aucun chemin personnel
- [ ] Test manuel sur deux dépôts fournisseurs : **N/A**, le cas se reproduit par
      un `CheckResult` à `total == 0`, ce que les tests font directement ; le
      provoquer sur un vrai catalogue demanderait de casser volontairement un
      `conftest.py`

### When behavior changes

- [x] CHANGELOG EN **et** FR ; version **0.1.72** ; `uv.lock` aligné

### When a command or option is added, removed or changed

- [x] Clés i18n `check_rien_mesure` et `check_rien_mesure_suite` dans **en.py et
      fr.py**, rendu vérifié sous les deux langues
- [x] `check --json` gagne `recorded`
- [ ] Aide CLI et `fullhelp` : **N/A**, aucune commande ni option ne change

### When `.github/workflows/` is touched — N/A
### When the declarative contract changes — N/A

## Un test adapté

`tests/test_json_output.py` mocke `evaluate_lab` par un objet factice, à qui il
manquait le champ neuf. Le stub le porte désormais ; aucune assertion ne bouge.

## Related issues

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
