### PR TITLE
feat(doctor): dire qu'un lab vm ne peut pas tourner ici, avant de le tenter (0.1.73)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,42 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.73] - 2026-08-24
+
+### Ajouté
+
+- **`doctor` vérifie désormais les trois prérequis qui décident si un lab `vm`
+  peut tourner** (issue #169). `virsh version` répond parfaitement sur une
+  machine sans virtualisation matérielle : le diagnostic était entièrement vert
+  pendant que `provision` échouait en langage Terraform (« could not find
+  capabilities for domaintype=kvm »), ou partait en émulation logicielle
+  jusqu'à l'expiration. Trois nouveaux contrôles, chacun avec une clé stable
+  dans `doctor --json` :
+
+  - `hw_virt` lit `/dev/kvm`, là où qemu ira le chercher. Absent, les labs vm
+    ne peuvent pas tourner sur cette machine, et le détail dit où se joue le
+    geste : le BIOS, ou la virtualisation imbriquée de l'hyperviseur hôte,
+    machine éteinte. Présent mais interdit est un autre état, avec un correctif
+    exécutable (`usermod -aG kvm`, `needs_relogin`).
+  - `cpu_arch` confronte `platform.machine()` aux images que le provider actif
+    sait fournir : le template kvm n'embarque que des images x86_64, et sur
+    aarch64 rien ne bootera jamais. L'écart nomme les deux côtés.
+  - `resources` compare `MemAvailable` et l'espace libre du pool libvirt à la
+    somme des `ram_mb` et des `disk_gb` (+ `extra_disk_gb`) que le `meta.yml`
+    du catalogue déclare. Un rapport de terrain donne l'échelle : un
+    provisionnement a déjà expiré sur un hôte à 2 vCPU / 4 Go, prêt à
+    181 secondes pour un délai de 180.
+
+  Les trois ne sont requis que si le catalogue déclare des labs `vm` sur un
+  hyperviseur local : un catalogue 100 % `shell` (terraform-training) n'en
+  affiche aucun, et un provider distant ne mesure rien sur ce poste.
+
+- **Une sonde qui ne peut pas mesurer ne conclut plus rien : `state: unknown`**.
+  Un `/proc/meminfo` illisible ou un pool libvirt muet n'est ni le vert
+  rassurant d'un « ok » non mérité, ni le rouge accusateur d'une panne non
+  prouvée. Le jeton est exposé par `doctor --json` et rendu « ? non mesuré » ;
+  il ne peint jamais le verdict global en rouge.
+
 ## [0.1.72] - 2026-08-24
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.73] - 2026-08-24
+
+### Added
+
+- **`doctor` now checks the three prerequisites that decide whether a `vm` lab
+  can run at all** (issue #169). `virsh version` answers perfectly on a machine
+  with no hardware virtualization: the diagnosis was fully green while
+  `provision` failed in Terraform language ("could not find capabilities for
+  domaintype=kvm"), or crawled off into software emulation until everything
+  timed out. Three new checks, each with a stable key in `doctor --json`:
+
+  - `hw_virt` reads `/dev/kvm` where qemu will look for it. Absent means the vm
+    labs cannot run on this machine, and the detail says where the gesture
+    belongs: the BIOS, or nested virtualization in the host hypervisor, machine
+    powered off. Present but not openable is a different state with an
+    executable fix (`usermod -aG kvm`, `needs_relogin`).
+  - `cpu_arch` confronts `platform.machine()` with the images the active
+    provider can furnish: the kvm template only packages x86_64 images, and on
+    aarch64 nothing will ever boot. The mismatch names both sides.
+  - `resources` compares `MemAvailable` and the libvirt pool's free space to
+    the sum of `ram_mb` and `disk_gb` (+ `extra_disk_gb`) the catalog's
+    `meta.yml` declares. A field report gave the scale: a provisioning already
+    expired on a 2 vCPU / 4 GB host, ready at 181 seconds for a 180 timeout.
+
+  All three are required only when the catalog declares `vm` labs on a local
+  hypervisor: a 100 % `shell` catalog (terraform-training) shows none of them,
+  and a remote provider measures nothing on this machine.
+
+- **A probe that cannot measure no longer concludes anything: `state: unknown`**.
+  An unreadable `/proc/meminfo` or a silent libvirt pool is neither the
+  reassuring green of an unearned "ok" nor the accusing red of an unproven
+  failure. The token is exposed by `doctor --json` and rendered as "? not
+  measured"; it never paints the top-level verdict red.
+
 ## [0.1.72] - 2026-08-24
 
 ### Fixed

--- a/docs/machine-output.fr.md
+++ b/docs/machine-output.fr.md
@@ -361,8 +361,8 @@ Chaque contrôle :
 
 | Champ | Type | Sens |
 | --- | --- | --- |
-| `key` | chaîne | **l'identité stable** : `python`, `pytest`, `shell`, `provider`, `kvm`, `incus`, `terraform`, `ansible`, `libvirt_pool`, `iso_tool`, `labs`, `lab_home` |
-| `state` | chaîne | `ok`, `failed` ou `choice_required` |
+| `key` | chaîne | **l'identité stable** : `python`, `pytest`, `shell`, `provider`, `kvm`, `incus`, `terraform`, `ansible`, `libvirt_pool`, `iso_tool`, `hw_virt`, `cpu_arch`, `resources`, `labs`, `lab_home` |
+| `state` | chaîne | `ok`, `failed`, `choice_required` ou `unknown` |
 | `ok` | booléen | la même chose que `state == "ok"`, gardé pour une lecture vert/rouge immédiate |
 | `label` | chaîne | le nom du composant, traduit : pour l'affichage seulement |
 | `detail` | chaîne | ce qui a été mesuré : une version, une ligne d'erreur, un compte |
@@ -374,6 +374,13 @@ Chaque contrôle :
 catalogue qui déclare plusieurs providers sans qu'aucun soit choisi bloque bien
 le provisionnement, mais rien n'est cassé, et l'afficher en rouge reviendrait à
 traiter un choix comme une avarie.
+
+`state: unknown` existe parce qu'une sonde impossible ne prouve rien, dans
+aucun sens : un contrôle dont la mesure a échoué (un `/proc/meminfo` illisible,
+un pool libvirt qui ne répond pas) n'est ni le vert rassurant d'un `ok` non
+mérité, ni le rouge accusateur d'une panne non prouvée. Son champ `ok` vaut
+`false`, puisque rien n'a été vérifié, mais il ne compte pas dans le verdict
+global.
 
 `ok` ne porte que sur `required`, délibérément. Un hyperviseur que ce catalogue
 n'utilisera jamais n'a pas à peindre en rouge une machine qui va très bien.

--- a/docs/machine-output.md
+++ b/docs/machine-output.md
@@ -359,8 +359,8 @@ Each check:
 
 | Field | Type | Meaning |
 | --- | --- | --- |
-| `key` | string | **the stable identity**: `python`, `pytest`, `shell`, `provider`, `kvm`, `incus`, `terraform`, `ansible`, `libvirt_pool`, `iso_tool`, `labs`, `lab_home` |
-| `state` | string | `ok`, `failed`, or `choice_required` |
+| `key` | string | **the stable identity**: `python`, `pytest`, `shell`, `provider`, `kvm`, `incus`, `terraform`, `ansible`, `libvirt_pool`, `iso_tool`, `hw_virt`, `cpu_arch`, `resources`, `labs`, `lab_home` |
+| `state` | string | `ok`, `failed`, `choice_required`, or `unknown` |
 | `ok` | bool | the same thing as `state == "ok"`, kept for a plain green/red reading |
 | `label` | string | the component's name, translated — for display only |
 | `detail` | string | what was measured: a version, an error line, a count |
@@ -371,6 +371,13 @@ Each check:
 `state: choice_required` exists because a decision is not a failure: a catalog
 that declares several providers and has none selected blocks provisioning, but
 nothing is broken, and painting it red treats a choice like an outage.
+
+`state: unknown` exists because an impossible probe proves nothing, in either
+direction: a check whose measurement failed (an unreadable `/proc/meminfo`, a
+libvirt pool that does not answer) is neither the reassuring green of an
+unearned `ok` nor the accusing red of an unproven failure. Its `ok` field is
+`false` — nothing was verified — but it does not count toward the top-level
+verdict.
 
 `ok` covers `required` only, deliberately. A hypervisor this catalog will never
 use must not turn a perfectly healthy machine red.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.72"
+version = "0.1.73"
 description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -876,6 +876,9 @@ silent.
     "check_iso_tool":     "genisoimage",
     "check_labs":     "Labs detected",
     "check_lab_home": "LAB_HOME",
+    "check_hw_virt":  "Hardware virtualization",
+    "check_cpu_arch": "CPU architecture",
+    "check_resources": "RAM / disk resources",
 
     "detail_shell_always":   "always available",
     "detail_incus_missing":  "not found",
@@ -897,6 +900,29 @@ silent.
         "not found: `run` cannot play a vm lab's setup.yaml "
         "(ansible-runner does not install it)",
     "detail_ansible_ok":     "present",
+    "detail_hw_virt_missing":
+        "{device} is absent: no hardware virtualization, the vm labs cannot "
+        "run on this machine. Enable VT-x/AMD-V in the BIOS, or nested "
+        "virtualization in your hypervisor (machine powered off).",
+    "detail_hw_virt_denied":
+        "{device} exists but this user cannot open it: `provision` cannot "
+        "start any VM (re-login required after joining the kvm group)",
+    "detail_cpu_arch_mismatch":
+        "this machine is {machine}, but the {provider} images packaged with "
+        "dsoxlab only exist in {archs}: the vm labs cannot boot here",
+    "detail_cpu_arch_unknown":
+        "machine architecture could not be determined",
+    "detail_resources_ram":
+        "RAM: {avail} MB available for {need} MB declared",
+    "detail_resources_ram_unknown":
+        "RAM: /proc/meminfo unreadable, nothing measured",
+    "detail_resources_disk":
+        "pool {pool}: {avail} GB available for {need} GB declared",
+    "detail_resources_disk_unknown":
+        "pool {pool}: not answering, disk space not measured",
+    "detail_resources_disk_unprobed":
+        "disk: this tool cannot measure the {provider} storage pool",
+    "detail_resources_join": "; ",
     "detail_pool_missing":
         "the `{pool}` pool does not exist: `provision` will fail with "
         "\"Pool Not Found\"",
@@ -1041,6 +1067,7 @@ silent.
     "status_present":     "[green]installed[/green]",
     "status_absent":      "[dim]— absent[/dim]",
     "status_choose":      "[yellow]to be chosen[/yellow]",
+    "status_unknown":     "[yellow]? not measured[/yellow]",
     "doctor_fix_hint":    "ℹ Use [bold]dsoxlab doctor --fix[/bold] to attempt automatic remediation.",
     "doctor_manual_hint":
         "ℹ [bold]--fix[/bold] cannot repair what is missing: apply the "

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -884,6 +884,9 @@ hors ligne, elle se tait.
     "check_iso_tool":     "genisoimage",
     "check_labs":     "Labs détectés",
     "check_lab_home": "LAB_HOME",
+    "check_hw_virt":  "Virtualisation matérielle",
+    "check_cpu_arch": "Architecture CPU",
+    "check_resources": "Ressources RAM / disque",
 
     "detail_shell_always":   "toujours disponible",
     "detail_incus_missing":  "introuvable",
@@ -905,6 +908,32 @@ hors ligne, elle se tait.
         "introuvable : « run » ne peut pas jouer le setup.yaml d'un lab vm "
         "(ansible-runner ne l'installe pas)",
     "detail_ansible_ok":     "présent",
+    "detail_hw_virt_missing":
+        "{device} est absent : pas de virtualisation matérielle, les labs vm "
+        "ne peuvent pas tourner sur cette machine. Active VT-x/AMD-V dans le "
+        "BIOS, ou la virtualisation imbriquée dans ton hyperviseur (machine "
+        "éteinte).",
+    "detail_hw_virt_denied":
+        "{device} existe mais cet utilisateur ne peut pas l'ouvrir : "
+        "« provision » ne peut démarrer aucune VM (re-login requis après "
+        "l'ajout au groupe kvm)",
+    "detail_cpu_arch_mismatch":
+        "cette machine est en {machine}, or les images {provider} packagées "
+        "avec dsoxlab n'existent qu'en {archs} : les labs vm ne peuvent pas "
+        "démarrer ici",
+    "detail_cpu_arch_unknown":
+        "architecture de la machine indéterminable",
+    "detail_resources_ram":
+        "RAM : {avail} Mo disponibles pour {need} Mo déclarés",
+    "detail_resources_ram_unknown":
+        "RAM : /proc/meminfo illisible, rien de mesuré",
+    "detail_resources_disk":
+        "pool {pool} : {avail} Go disponibles pour {need} Go déclarés",
+    "detail_resources_disk_unknown":
+        "pool {pool} : muet, espace disque non mesuré",
+    "detail_resources_disk_unprobed":
+        "disque : l'outil ne sait pas mesurer le pool de stockage {provider}",
+    "detail_resources_join": " ; ",
     "detail_pool_missing":
         "le pool « {pool} » n'existe pas : « provision » échouera sur "
         "« Pool Not Found »",
@@ -1053,6 +1082,7 @@ hors ligne, elle se tait.
     "status_present":     "[green]installé[/green]",
     "status_absent":      "[dim]— absent[/dim]",
     "status_choose":      "[yellow]à choisir[/yellow]",
+    "status_unknown":     "[yellow]? non mesuré[/yellow]",
     "doctor_fix_hint":    "ℹ Utilisez [bold]dsoxlab doctor --fix[/bold] pour tenter la remédiation automatique.",
     "doctor_manual_hint":
         "ℹ [bold]--fix[/bold] ne sait pas corriger ce qui manque : appliquez "

--- a/src/dsoxlab/reporting/console.py
+++ b/src/dsoxlab/reporting/console.py
@@ -22,7 +22,12 @@ from ..i18n import _
 from ..models.course import CourseManifest, CourseSection
 from ..models.lab import LabDefinition
 from ..services.catalog import CatalogueConnu, CatalogueInstalle
-from ..services.doctor import STATE_CHOICE_REQUIRED, Check, DoctorReport
+from ..services.doctor import (
+    STATE_CHOICE_REQUIRED,
+    STATE_UNKNOWN,
+    Check,
+    DoctorReport,
+)
 from ..services.lab_state import LabState
 from ..services.progress_service import build_progress, exam_verdict
 from ..validators.structure import StructureReport
@@ -291,6 +296,10 @@ def _libelle_statut(check: Check, *, blocking: bool) -> str:
     """
     if check.state == STATE_CHOICE_REQUIRED:
         return _("status_choose")
+    if check.state == STATE_UNKNOWN:
+        # Rien mesuré : ni le vert qui rassure à tort, ni le rouge qui accuse
+        # sans preuve. Le mot le dit dans les deux tableaux.
+        return _("status_unknown")
     if blocking:
         return _("status_ok") if check.ok else _("status_ko")
     return _("status_present") if check.ok else _("status_absent")

--- a/src/dsoxlab/services/doctor.py
+++ b/src/dsoxlab/services/doctor.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import getpass
 import os
+import platform
 import re
 import shlex
 import shutil
@@ -41,6 +42,7 @@ from ..discovery.scanner import compter_fichiers_labs
 from ..i18n import _
 from ..infra import ansible as ansible_infra
 from ..models import LabDefinition, RepoMetadata
+from ..models.repo import InfraDefinition
 from ..models.runtime import RuntimeType
 from .lab_service import get_all_labs, resolve_pytest_cmd
 
@@ -61,6 +63,16 @@ _VM_RUNTIMES = frozenset({RuntimeType.VM, RuntimeType.KVM, RuntimeType.INCUS})
 STATE_OK = "ok"
 STATE_FAILED = "failed"
 STATE_CHOICE_REQUIRED = "choice_required"
+STATE_UNKNOWN = "unknown"
+"""La sonde n'a pas pu mesurer : ni vert, ni rouge.
+
+Ce module combat deux mensonges symétriques. Le premier est le rouge affiché
+devant une commande qui fonctionne ; le second, plus sournois, est le vert
+affiché faute d'avoir mesuré — c'est exactement le défaut du contrôle du pool
+qui rendait « ok » quand virsh ne répondait pas. Un contrôle en ``unknown``
+n'entre pas dans :meth:`DoctorReport.failing` (il ne prouve aucune panne),
+mais son jeton dit à un programme comme à un humain que rien n'est prouvé
+dans l'autre sens non plus."""
 
 
 class FixKind(StrEnum):
@@ -212,7 +224,12 @@ class DoctorReport:
     libellé qui devait dire la vérité, pas le classement."""
 
     def failing(self) -> list[Check]:
-        return [c for c in self.required if not c.ok]
+        # Un contrôle ``unknown`` n'a rien prouvé : il ne peut pas peindre le
+        # verdict en rouge. Son jeton suffit à dire qu'il n'est pas vert.
+        return [
+            c for c in self.required
+            if not c.ok and c.state != STATE_UNKNOWN
+        ]
 
     def fixable(self) -> list[Check]:
         return [c for c in self.required if not c.ok and c.fix]
@@ -242,7 +259,7 @@ def _check_shell() -> Check:
 
 
 def _sonder(
-    commande: list[str], *, delai: float = 5
+    commande: list[str], *, delai: float = 5, env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str] | None:
     """Joue une sonde, ou rend ``None`` si elle ne répond pas.
 
@@ -257,7 +274,8 @@ def _sonder(
     """
     try:
         return subprocess.run(
-            commande, capture_output=True, text=True, timeout=delai, check=False,
+            commande, capture_output=True, text=True, timeout=delai,
+            check=False, env=env,
         )
     except (OSError, subprocess.SubprocessError):
         return None
@@ -408,6 +426,184 @@ def _check_ansible() -> Check:
             fix=_fix(["uv", "tool", "install", "ansible-core"]),
         )
     return _check("ansible", True, _("detail_ansible_ok"))
+
+
+#: Le périphérique par lequel un hyperviseur local accède à la virtualisation
+#: matérielle. Constante de module pour que les tests la déplacent : le point
+#: du contrôle est justement de mesurer une machine où il n'existe pas.
+_KVM_DEVICE = Path("/dev/kvm")
+
+
+def _check_hw_virt() -> Check:
+    """La virtualisation matérielle, lue là où qemu ira la chercher.
+
+    ``virsh version`` répond parfaitement sur une machine sans virtualisation :
+    le daemon tourne, le client cause, et ``provision`` échoue ensuite en
+    langage Terraform (« could not find capabilities for domaintype=kvm »),
+    ou pire, démarre en émulation logicielle et tout expire. Le premier
+    contexte réel où le périphérique manque est une VM sans virtualisation
+    imbriquée, et c'est machine éteinte, dans l'hyperviseur hôte, que ça se
+    règle : aucun correctif exécutable, la consigne vit dans le détail.
+
+    L'inaccessible est un état distinct de l'absent : le périphérique existe,
+    seul le droit manque, et ``usermod -aG kvm`` le rend, à la session
+    suivante seulement, d'où la catégorie.
+    """
+    if not _KVM_DEVICE.exists():
+        return _check(
+            "hw_virt", False, _("detail_hw_virt_missing", device=_KVM_DEVICE),
+        )
+    if not os.access(_KVM_DEVICE, os.R_OK | os.W_OK):
+        return _check(
+            "hw_virt", False, _("detail_hw_virt_denied", device=_KVM_DEVICE),
+            fix=_fix(
+                ["sudo", "usermod", "-aG", "kvm", _current_user()],
+                kind=FixKind.NEEDS_RELOGIN,
+            ),
+        )
+    return _check("hw_virt", True, str(_KVM_DEVICE))
+
+
+#: Architectures des images que chaque provider packagé sait fournir.
+#: ``kvm`` : les URL de ``templates/terraform/kvm/main.tf`` sont toutes des
+#: images x86_64/amd64, avec ``q35``, firmware EFI x86 et ``host-passthrough``.
+#: ``incus`` en est absent volontairement : le registre ``images:`` résout
+#: chaque alias dans l'architecture de l'hôte.
+_PROVIDER_IMAGE_ARCHS: dict[str, frozenset[str]] = {
+    "kvm": frozenset({"x86_64", "amd64"}),
+}
+
+
+def _check_cpu_arch(provider: str) -> Check:
+    """L'architecture du poste, confrontée aux images du provider actif.
+
+    Sur un processeur aarch64, les images amd64 du template kvm ne booteront
+    jamais, et rien ne le disait avant l'échec. Un provider hors du tableau
+    n'impose aucune contrainte : le contrôle rend alors l'architecture
+    mesurée, pas un verdict inventé.
+    """
+    machine = platform.machine().lower()
+    if not machine:
+        # Rien mesuré : ni vert ni rouge, et surtout pas un « ok » par défaut.
+        return _check(
+            "cpu_arch", False, _("detail_cpu_arch_unknown"),
+            forced_state=STATE_UNKNOWN,
+        )
+    archs = _PROVIDER_IMAGE_ARCHS.get(provider)
+    if archs is None or machine in archs:
+        return _check("cpu_arch", True, machine)
+    return _check(
+        "cpu_arch", False,
+        _(
+            "detail_cpu_arch_mismatch",
+            machine=machine, provider=provider,
+            archs="/".join(sorted(archs, reverse=True)),
+        ),
+    )
+
+
+def _mem_available_mb() -> int | None:
+    """``MemAvailable`` de ``/proc/meminfo``, en MiB, ou ``None`` si illisible.
+
+    ``MemAvailable`` plutôt que ``MemFree`` : c'est l'estimation du noyau de
+    ce qu'une nouvelle charge peut réellement obtenir, cache compris.
+    """
+    try:
+        contenu = Path("/proc/meminfo").read_text(encoding="ascii")
+    except OSError:
+        return None
+    for ligne in contenu.splitlines():
+        if ligne.startswith("MemAvailable:"):
+            champs = ligne.split()
+            if len(champs) >= 2 and champs[1].isdigit():
+                return int(champs[1]) // 1024
+    return None
+
+
+def _pool_available_gb(pool: str) -> int | None:
+    """L'espace disponible du pool libvirt visé, en GiB, ou ``None`` si non mesuré.
+
+    ``pool-info --bytes`` rend la place telle que libvirt la voit, c'est-à-dire
+    celle du répertoire cible réel du pool, où qu'il soit monté. ``LC_ALL=C``
+    n'est pas décoratif : virsh traduit ses libellés, et « Available: » devient
+    « Disponible : » sous une locale française.
+    """
+    probe = _sonder(
+        ["virsh", "-c", "qemu:///system", "pool-info", pool, "--bytes"],
+        env={**os.environ, "LC_ALL": "C"},
+    )
+    if probe is None or probe.returncode != 0:
+        return None
+    for ligne in probe.stdout.splitlines():
+        if ligne.startswith("Available:"):
+            champs = ligne.split()
+            if len(champs) >= 2 and champs[1].isdigit():
+                return int(champs[1]) // 2**30
+    return None
+
+
+def _check_resources(infra: InfraDefinition, provider: str) -> Check:
+    """Ce que le poste offre, face à ce que le ``meta.yml`` déclare.
+
+    Un provisionnement a déjà expiré sur un hôte à 2 vCPU / 4 Go (hôte prêt à
+    181 secondes pour un délai de 180) sans que rien ne l'annonce. La somme
+    des ``ram_mb`` et des ``disk_gb`` (+ ``extra_disk_gb``) du catalogue est la
+    demande ; ``MemAvailable`` et le pool libvirt sont l'offre.
+
+    Une sonde impossible ne vaut jamais « ok » : la portion non mesurée est
+    nommée, et le contrôle sort en ``unknown``, sauf si une portion mesurée
+    manque déjà, auquel cas le manque prouvé l'emporte.
+    """
+    besoin_ram = sum(h.ram_mb for h in infra.hosts)
+    besoin_disk = sum(h.disk_gb + h.extra_disk_gb for h in infra.hosts)
+
+    manque = False
+    inconnu = False
+    portions: list[str] = []
+
+    dispo_ram = _mem_available_mb()
+    if dispo_ram is None:
+        inconnu = True
+        portions.append(_("detail_resources_ram_unknown"))
+    else:
+        manque = manque or dispo_ram < besoin_ram
+        portions.append(
+            _("detail_resources_ram", avail=dispo_ram, need=besoin_ram)
+        )
+
+    if provider == "kvm":
+        pool = str(infra.provider_config("kvm").get("storage_pool") or "default")
+        dispo_disk = _pool_available_gb(pool)
+        if dispo_disk is None:
+            # Pool absent, inactif ou virsh muet : le contrôle du pool porte
+            # déjà ce rouge-là, le redire ici empilerait deux échecs pour une
+            # seule cause. Mais rien n'est mesuré, donc rien n'est vert.
+            inconnu = True
+            portions.append(_("detail_resources_disk_unknown", pool=pool))
+        else:
+            manque = manque or dispo_disk < besoin_disk
+            portions.append(
+                _(
+                    "detail_resources_disk",
+                    pool=pool, avail=dispo_disk, need=besoin_disk,
+                )
+            )
+    else:
+        # L'outil ne sait pas mesurer le stockage de ce provider : le dire
+        # vaut mieux qu'un vert conclu sur la seule RAM.
+        inconnu = True
+        portions.append(_("detail_resources_disk_unprobed", provider=provider))
+
+    # Le joint se traduit : la typographie française met une espace avant le
+    # point-virgule, l'anglaise non.
+    detail = _("detail_resources_join").join(portions)
+    if manque:
+        return _check("resources", False, detail)
+    if inconnu:
+        return _check(
+            "resources", False, detail, forced_state=STATE_UNKNOWN,
+        )
+    return _check("resources", True, detail)
 
 
 def creer_pool_fix(pool: str) -> Fix:
@@ -738,6 +934,19 @@ def collect_checks(root: Path, repo_meta: RepoMetadata | None) -> DoctorReport:
     if needs_vm:
         report.required.append(_check_terraform())
         report.required.append(_check_ansible())
+        # Prérequis matériels d'un hyperviseur local : virtualisation,
+        # architecture, ressources. Ils ne dépendent d'aucun binaire installé
+        # (/dev/kvm et /proc/meminfo se lisent sans virsh), donc ils parlent
+        # même quand l'hyperviseur manque : c'est une cause DIFFÉRENTE, pas le
+        # même rouge répété. Un provider distant (outscale…) provisionne
+        # ailleurs : rien de tout cela ne concerne alors ce poste.
+        if active in _LOCAL_HYPERVISORS:
+            report.required.append(_check_hw_virt())
+            report.required.append(_check_cpu_arch(active))
+            if repo_meta is not None and repo_meta.infra.hosts:
+                report.required.append(
+                    _check_resources(repo_meta.infra, active)
+                )
         # Contrôles propres à un hyperviseur : ils n'ont de sens qu'une fois le
         # provider choisi, sinon ils affichent du rouge pour un backend que ce
         # poste n'utilisera peut-être jamais.

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -95,6 +95,22 @@ def _outillage_present(monkeypatch: pytest.MonkeyPatch) -> None:
         doctor, "_check_ansible",
         lambda: doctor._check("ansible", True, "ok"),
     )
+    # Même raison pour les prérequis matériels : /dev/kvm, platform.machine()
+    # et /proc/meminfo mesurent la machine qui joue la suite, pas le classement
+    # que ce module vérifie. Leur comportement propre vit dans
+    # `test_doctor_prerequis_vm.py`.
+    monkeypatch.setattr(
+        doctor, "_check_hw_virt",
+        lambda: doctor._check("hw_virt", True, "/dev/kvm"),
+    )
+    monkeypatch.setattr(
+        doctor, "_check_cpu_arch",
+        lambda provider: doctor._check("cpu_arch", True, "x86_64"),
+    )
+    monkeypatch.setattr(
+        doctor, "_check_resources",
+        lambda infra, provider: doctor._check("resources", True, "ok"),
+    )
 
 
 def _labs(monkeypatch: pytest.MonkeyPatch, labs: list[LabDefinition]) -> None:

--- a/tests/test_doctor_installation.py
+++ b/tests/test_doctor_installation.py
@@ -64,6 +64,29 @@ def _labels(checks: list[doctor.Check]) -> set[str]:
     return {c.label for c in checks}
 
 
+@pytest.fixture(autouse=True)
+def _prerequis_materiels_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Les prérequis matériels (virtualisation, archi, ressources) au vert.
+
+    /dev/kvm, platform.machine() et /proc/meminfo mesurent la machine qui joue
+    la suite : sans stub, ces tests de classement changeraient de verdict d'un
+    poste à l'autre. Le comportement propre de ces contrôles est couvert par
+    `test_doctor_prerequis_vm.py`.
+    """
+    monkeypatch.setattr(
+        doctor, "_check_hw_virt",
+        lambda: doctor._check("hw_virt", True, "/dev/kvm"),
+    )
+    monkeypatch.setattr(
+        doctor, "_check_cpu_arch",
+        lambda provider: doctor._check("cpu_arch", True, "x86_64"),
+    )
+    monkeypatch.setattr(
+        doctor, "_check_resources",
+        lambda infra, provider: doctor._check("resources", True, "ok"),
+    )
+
+
 @pytest.fixture
 def hyperviseur_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     """Les deux hyperviseurs installés et fonctionnels.

--- a/tests/test_doctor_prerequis_vm.py
+++ b/tests/test_doctor_prerequis_vm.py
@@ -1,0 +1,348 @@
+"""Tests des prérequis matériels d'un lab ``vm`` : ce que `doctor` ignorait.
+
+Trois prérequis décident si un lab ``vm`` peut tourner, et aucun n'était
+vérifié : la virtualisation matérielle (`/dev/kvm`), l'architecture du
+processeur face aux images packagées, et les ressources disponibles face à ce
+que le ``meta.yml`` déclare. Sur une VM sans virtualisation imbriquée,
+`doctor` était entièrement vert pendant que `provision` échouait en langage
+Terraform (« could not find capabilities for domaintype=kvm »).
+
+Deux règles héritées du module s'appliquent aussi ici :
+
+- un catalogue 100 % ``shell`` ne doit jamais voir ces contrôles en rouge ;
+- une sonde impossible ne vaut jamais « ok » : elle sort en ``unknown``,
+  un jeton qui n'est ni le vert qui rassure à tort, ni le rouge qui accuse
+  sans preuve.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dsoxlab.models.lab import LabDefinition, ValidationConfig
+from dsoxlab.models.repo import HostDefinition, InfraDefinition, RepoMetadata
+from dsoxlab.models.runtime import RuntimeConfig, RuntimeType, Target
+from dsoxlab.reporting import machine
+from dsoxlab.services import doctor
+
+
+def _lab(lab_id: str, runtime_type: RuntimeType) -> LabDefinition:
+    targets = (
+        []
+        if runtime_type is RuntimeType.SHELL
+        else [Target(name="rhel", host="node1.lab")]
+    )
+    return LabDefinition(
+        id=lab_id,
+        title=lab_id,
+        level="l1",
+        skills=["s"],
+        runtime=RuntimeConfig(type=runtime_type, targets=targets),
+        distros=["alma10"],
+        doc_url="https://example.test/doc",
+        validation=ValidationConfig(),
+    )
+
+
+def _infra(provider: str = "kvm") -> InfraDefinition:
+    """Deux hôtes déclarés : 3072 Mo de RAM, 25 Go de disque en tout."""
+    return InfraDefinition(
+        provider=provider,
+        hosts=[
+            HostDefinition(name="a.lab", ram_mb=2048, disk_gb=10, extra_disk_gb=5),
+            HostDefinition(name="b.lab", ram_mb=1024, disk_gb=10),
+        ],
+    )
+
+
+def _repo(provider: str, infra: InfraDefinition | None = None) -> RepoMetadata:
+    return RepoMetadata(
+        id="demo",
+        category="demo",
+        infra=infra or InfraDefinition(provider=provider),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _environnement_stable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralise tout ce qui mesure la machine, sauf le contrôle sous test.
+
+    Chaque test réactive la sonde qu'il vérifie en la pilotant lui-même.
+    """
+    monkeypatch.setattr(
+        doctor, "_hypervisor_checks",
+        lambda: {
+            "kvm": doctor._check("kvm", True, "libvirt 10.0.0"),
+            "incus": doctor._check("incus", True, "daemon ok"),
+        },
+    )
+    monkeypatch.setattr(
+        doctor, "_check_terraform",
+        lambda: doctor._check("terraform", True, "Terraform v1.0.0"),
+    )
+    monkeypatch.setattr(
+        doctor, "_check_ansible",
+        lambda: doctor._check("ansible", True, "ok"),
+    )
+    monkeypatch.setattr(
+        doctor, "_check_libvirt_pool",
+        lambda pool: doctor._check("libvirt_pool", True, pool),
+    )
+
+
+# ── /dev/kvm : la virtualisation matérielle ───────────────────────────────────
+
+def test_dev_kvm_absent_est_un_echec_qui_le_dit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sans /dev/kvm, les labs vm ne peuvent pas tourner ici, et ça se dit.
+
+    `virsh version` répond parfaitement sur une machine sans virtualisation :
+    c'est le périphérique qu'il faut lire, pas le client.
+    """
+    monkeypatch.setattr(doctor, "_KVM_DEVICE", tmp_path / "kvm")
+    check = doctor._check_hw_virt()
+
+    assert check.key == "hw_virt"
+    assert check.state == doctor.STATE_FAILED
+    # Le geste (BIOS, virtualisation imbriquée) appartient à l'humain, machine
+    # éteinte : aucun correctif exécutable ne doit être proposé.
+    assert check.fix is None
+
+
+def test_dev_kvm_inaccessible_est_reparable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Présent mais interdit est un autre état : le groupe kvm le rend.
+
+    L'appartenance à un groupe ne prend effet qu'à la session suivante, d'où
+    la catégorie NEEDS_RELOGIN : sans elle, l'utilisateur relance `doctor`,
+    revoit le rouge et croit le correctif en échec.
+    """
+    device = tmp_path / "kvm"
+    device.touch()
+    monkeypatch.setattr(doctor, "_KVM_DEVICE", device)
+    monkeypatch.setattr(doctor.os, "access", lambda p, mode: False)
+
+    check = doctor._check_hw_virt()
+
+    assert check.state == doctor.STATE_FAILED
+    assert check.fix is not None
+    assert check.fix.kind is doctor.FixKind.NEEDS_RELOGIN
+    assert "usermod" in check.fix.display
+
+
+def test_dev_kvm_accessible_est_vert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    device = tmp_path / "kvm"
+    device.touch()
+    monkeypatch.setattr(doctor, "_KVM_DEVICE", device)
+
+    check = doctor._check_hw_virt()
+
+    assert check.state == doctor.STATE_OK
+    assert check.detail == str(device)
+
+
+# ── l'architecture face aux images packagées ──────────────────────────────────
+
+def test_une_archi_etrangere_aux_images_kvm_echoue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Les images du template kvm sont x86_64 : sur aarch64, rien ne bootera.
+
+    L'écart est nommé des deux côtés, la machine ET les images, pour que
+    l'utilisateur comprenne qu'aucune installation ne le comblera.
+    """
+    monkeypatch.setattr(doctor.platform, "machine", lambda: "aarch64")
+    check = doctor._check_cpu_arch("kvm")
+
+    assert check.key == "cpu_arch"
+    assert check.state == doctor.STATE_FAILED
+    assert "aarch64" in check.detail
+    assert "x86_64" in check.detail
+
+
+def test_x86_64_convient_aux_images_kvm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(doctor.platform, "machine", lambda: "x86_64")
+    check = doctor._check_cpu_arch("kvm")
+
+    assert check.state == doctor.STATE_OK
+    assert check.detail == "x86_64"
+
+
+def test_un_provider_multiarch_ne_contraint_pas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le registre images: d'incus résout l'alias dans l'archi de l'hôte."""
+    monkeypatch.setattr(doctor.platform, "machine", lambda: "aarch64")
+    check = doctor._check_cpu_arch("incus")
+
+    assert check.state == doctor.STATE_OK
+
+
+def test_une_archi_indeterminable_nest_pas_verte(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """platform.machine() vide : rien mesuré, donc ni vert ni rouge."""
+    monkeypatch.setattr(doctor.platform, "machine", lambda: "")
+    check = doctor._check_cpu_arch("kvm")
+
+    assert check.state == doctor.STATE_UNKNOWN
+    assert not check.ok
+
+
+# ── les ressources face au contrat ────────────────────────────────────────────
+
+def test_des_ressources_suffisantes_sont_vertes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(doctor, "_mem_available_mb", lambda: 8192)
+    monkeypatch.setattr(doctor, "_pool_available_gb", lambda pool: 100)
+
+    check = doctor._check_resources(_infra(), "kvm")
+
+    assert check.key == "resources"
+    assert check.state == doctor.STATE_OK
+    # Le détail montre l'offre ET la demande : c'est la comparaison qui parle.
+    assert "3072" in check.detail
+    assert "25" in check.detail
+
+
+def test_une_ram_insuffisante_echoue_en_le_chiffrant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """4 Go de poste pour 3 Go de catalogue, mais 2 Go réellement libres :
+    c'est le cas de terrain, celui du provisionnement expiré à 181 s."""
+    monkeypatch.setattr(doctor, "_mem_available_mb", lambda: 2048)
+    monkeypatch.setattr(doctor, "_pool_available_gb", lambda pool: 100)
+
+    check = doctor._check_resources(_infra(), "kvm")
+
+    assert check.state == doctor.STATE_FAILED
+    assert "2048" in check.detail
+    assert "3072" in check.detail
+
+
+def test_un_disque_insuffisant_echoue_aussi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(doctor, "_mem_available_mb", lambda: 8192)
+    monkeypatch.setattr(doctor, "_pool_available_gb", lambda pool: 8)
+
+    check = doctor._check_resources(_infra(), "kvm")
+
+    assert check.state == doctor.STATE_FAILED
+
+
+def test_une_sonde_impossible_ne_vaut_jamais_vert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pool muet : l'état est `unknown`, ni « ok » menteur ni rouge sans preuve.
+
+    C'est le motif que ce dépôt combat : le contrôle du pool rendait « ok »
+    quand virsh ne répondait pas. Un `unknown` n'entre pas dans failing()
+    (rien n'est prouvé), mais son jeton dit qu'il n'est pas vert, et le
+    document JSON l'expose tel quel.
+    """
+    monkeypatch.setattr(doctor, "_mem_available_mb", lambda: 8192)
+    monkeypatch.setattr(doctor, "_pool_available_gb", lambda pool: None)
+
+    check = doctor._check_resources(_infra(), "kvm")
+
+    assert check.state == doctor.STATE_UNKNOWN
+    assert not check.ok
+
+    report = doctor.DoctorReport(required=[check])
+    assert not report.failing()
+    assert machine.check_dict(check)["state"] == "unknown"
+
+
+def test_un_manque_mesure_l_emporte_sur_l_inconnu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RAM insuffisante ET disque non mesurable : le manque prouvé décide."""
+    monkeypatch.setattr(doctor, "_mem_available_mb", lambda: 1024)
+    monkeypatch.setattr(doctor, "_pool_available_gb", lambda pool: None)
+
+    check = doctor._check_resources(_infra(), "kvm")
+
+    assert check.state == doctor.STATE_FAILED
+
+
+# ── le classement : requis là où ça bloque, absent ailleurs ───────────────────
+
+_NOUVELLES_CLES = {"hw_virt", "cpu_arch", "resources"}
+
+
+def _cles(checks: list[doctor.Check]) -> set[str]:
+    return {c.key for c in checks}
+
+
+def test_requis_sur_un_catalogue_vm_a_provider_local(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(doctor, "get_all_labs", lambda root: [_lab("a", RuntimeType.VM)])
+    monkeypatch.setattr(doctor, "_mem_available_mb", lambda: 8192)
+    monkeypatch.setattr(doctor, "_pool_available_gb", lambda pool: 100)
+    monkeypatch.setattr(doctor.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(doctor, "_KVM_DEVICE", tmp_path / "absent")
+
+    report = doctor.collect_checks(tmp_path, _repo("kvm", _infra()))
+
+    assert _cles(report.required) >= _NOUVELLES_CLES
+    # /dev/kvm absent : le diagnostic doit le porter en échec, pas en silence.
+    assert "hw_virt" in {c.key for c in report.failing()}
+
+
+def test_absents_dun_catalogue_entierement_shell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`terraform-training` : aucun bloc infra, aucun lab vm — aucun rouge.
+
+    Ces contrôles n'ont rien à y mesurer : ils n'apparaissent nulle part,
+    plutôt que d'y peindre en rouge une machine qui va très bien.
+    """
+    monkeypatch.setattr(
+        doctor, "get_all_labs", lambda root: [_lab("a", RuntimeType.SHELL)]
+    )
+    monkeypatch.setattr(doctor, "_KVM_DEVICE", tmp_path / "absent")
+
+    report = doctor.collect_checks(tmp_path, _repo(""))
+
+    assert not _NOUVELLES_CLES & _cles(report.required)
+    assert not _NOUVELLES_CLES & _cles(report.optional)
+    assert not report.failing()
+
+
+def test_absents_quand_le_provider_est_distant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Un provider cloud provisionne ailleurs : rien à mesurer sur ce poste."""
+    monkeypatch.setattr(doctor, "get_all_labs", lambda root: [_lab("a", RuntimeType.VM)])
+    monkeypatch.setattr(doctor, "_KVM_DEVICE", tmp_path / "absent")
+
+    report = doctor.collect_checks(tmp_path, _repo("outscale"))
+
+    assert not _NOUVELLES_CLES & _cles(report.required)
+
+
+def test_sans_hote_declare_les_ressources_se_taisent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Zéro hôte dans le meta.yml : aucune demande, donc rien à comparer."""
+    monkeypatch.setattr(doctor, "get_all_labs", lambda root: [_lab("a", RuntimeType.VM)])
+    monkeypatch.setattr(doctor.platform, "machine", lambda: "x86_64")
+    device = tmp_path / "kvm"
+    device.touch()
+    monkeypatch.setattr(doctor, "_KVM_DEVICE", device)
+
+    report = doctor.collect_checks(tmp_path, _repo("kvm"))
+
+    assert "resources" not in _cles(report.required)
+    assert _cles(report.required) >= {"hw_virt", "cpu_arch"}

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.72"
+version = "0.1.73"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Trois prérequis décident si un lab `runtime: vm` peut tourner, et **aucun
n'était vérifié**. `doctor` était donc entièrement vert sur une machine sans
virtualisation matérielle, pendant que `provision` échouait ensuite en langage
Terraform.

C'est sans conséquence sur les postes Linux où l'outil a été écrit. Cela cesse de
l'être dès qu'on fait tourner des machines KVM **à l'intérieur** d'une VM, ce qui
est précisément le projet d'image prête à l'emploi.

## Les trois contrôles

| `key` | Ce qu'il mesure |
|---|---|
| `hw_virt` | `/dev/kvm`, **là où qemu ira le chercher** — sans passer par `virsh` |
| `cpu_arch` | `platform.machine()` confronté aux architectures que le provider sait fournir |
| `resources` | RAM disponible vs Σ `ram_mb`, espace du pool vs Σ `disk_gb` |

**`hw_virt` absent ne propose aucun correctif**, et c'est délibéré : aucun argv
n'active la virtualisation imbriquée d'un hyperviseur, c'est une case à cocher,
machine éteinte. Le détail le dit plutôt que de faire semblant. En revanche, un
`/dev/kvm` présent mais non ouvrable propose `usermod -aG kvm` en catégorie
**`needs_relogin`** — le groupe ne prend effet qu'à la reconnexion, et la
catégorie livrée en 0.1.70 existe exactement pour ce cas.

**`cpu_arch`** : les images du template kvm sont toutes x86_64. Sur aarch64,
elles ne booteront jamais, et rien ne le disait avant l'échec.

**`resources`** répond au rapport de terrain qui a motivé l'issue — une machine à
2 vCPU / 4 Go où les sommes déclarées ne passaient pas.

## Le point de conception : l'état `unknown`

Ce module combattait déjà un mensonge — le rouge affiché devant une commande qui
fonctionne. Il lui manquait le symétrique, **le vert affiché faute d'avoir
mesuré**, qui est le défaut encore ouvert sur le pool libvirt (#172).

Une sonde impossible rend donc `unknown` : elle **n'entre pas dans `failing()`**,
puisqu'elle ne prouve aucune panne, mais son jeton dit qu'elle ne prouve rien
dans l'autre sens non plus. Un manque **mesuré** l'emporte toujours sur une
portion inconnue.

## Une limite dite franchement

L'espace disque n'est mesuré que pour `kvm`, via `pool-info`. Pour `incus`,
l'outil ne sait pas mesurer le pool de stockage — il le **dit**, plutôt que de
conclure au vert sur la seule RAM.

## Vérifié sur les deux dépôts

**`terraform-training`** — 87 labs `shell`, aucun bloc `infra:` — c'est lui qui
prouve le critère le plus facile à rater :

```json
{ "ok": true, "required": ["python", "pytest", "shell", "labs", "lab_home"] }
```

Les trois contrôles **n'apparaissent même pas**. Aucun rouge.

**`ansible-training`** — 113 labs, provider kvm :

```
hw_virt    ok   /dev/kvm
cpu_arch   ok   x86_64
resources  ok   RAM : 15352 Mo disponibles pour 5632 Mo déclarés ; pool default …
```

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 79 source files*
- [x] `uv run pytest` : **761 passed** (745 avant, **+16**)
- [x] `uv run pytest tests_e2e` : **18 passed**
- [x] **Chaque test éprouvé par son échec**, neutralisation puis restauration
- [x] Le moteur reste neutre vis-à-vis du domaine
- [x] Testé sur **deux dépôts fournisseurs**, dont celui qui attrape les faux rouges

### When behavior changes

- [x] CHANGELOG EN **et** FR ; version **0.1.73** ; `uv.lock` aligné

### When a command or option is added, removed or changed

- [x] Clés i18n dans **en.py et fr.py**
- [x] `doctor --json` : les trois `key` et le jeton `unknown` documentés dans
      `docs/machine-output.md` **et** `.fr.md`
- [ ] Aide CLI et `fullhelp` : **N/A**, aucune commande ni option ne change

### When `.github/workflows/` is touched — N/A
### When the declarative contract changes — N/A

## Note

Le sandbox de développement masque `/dev/kvm` : un `doctor` lancé sous sandbox
montre `hw_virt` en échec. Vérifié des deux côtés par `ls -l /dev/kvm` — c'est le
sandbox, pas le contrôle.

## Related issues

Closes #169

Lève le prérequis principal du projet d'image de VM (#91), qui vivra dans son
propre dépôt : l'image doit pouvoir dire qu'elle ne peut pas faire tourner de
lab `vm`, plutôt que de laisser un `provision` expirer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
