### PR TITLE
fix(provision, check): deux échecs qui ne se disaient pas (0.1.74)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,31 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.74] - 2026-08-24
+
+### Corrigé
+
+- **`provision` annonçait un succès après avoir renoncé à attendre des hôtes qui
+  ne répondaient pas** (issue #170). Un délai dépassé n'était qu'un
+  avertissement ; la commande affichait ensuite « ✔ N hôtes provisionnés » et
+  sortait en 0. L'infrastructure existait mais n'était pas utilisable, et le
+  `run` suivant échouait en « unreachable » sans lien visible avec la cause.
+  Tout script qui teste le code de retour était aveugle — y compris la
+  construction d'une image prête à l'emploi, qui devra s'y fier. Un code de
+  sortie dédié (`8`) le dit désormais, aux côtés de ceux des orphelins.
+
+- **`check --json` était pollué dès qu'un lab déclarait des services** (issue
+  #171). `_valider` ne propageait pas `quiet` à `_ensure_services`, dont les
+  messages de progression partaient sur la sortie standard : `dsoxlab check
+  --json | jq` échouait sur tout lab de ce type. C'était le défaut corrigé en
+  0.1.23, revenu par une porte latérale.
+
+  `quiet` ne fait taire que **le progrès**. Les erreurs continuent de partir sur
+  la sortie d'erreur dans les deux modes : un service qui refuse de démarrer
+  doit rester audible, sans quoi `--json` masquerait la seule information qui
+  compte.
+
+
 ## [0.1.73] - 2026-08-24
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.74] - 2026-08-24
+
+### Fixed
+
+- **`provision` announced success after giving up on hosts that never answered**
+  (issue #170). A timeout was a mere warning; the command then printed
+  "✔ N hosts provisioned" and exited 0. The infrastructure existed but was not
+  usable, and the next `run` failed with "unreachable" without any visible link
+  to the cause. Every script testing the return code was blind — including the
+  build of a ready-made image, which will rely on it. A dedicated exit code
+  (`8`) now says it, alongside the ones for orphans.
+
+- **`check --json` was polluted as soon as a lab declared services** (issue
+  #171). `_valider` did not propagate `quiet` to `_ensure_services`, whose
+  progress messages went to stdout: `dsoxlab check --json | jq` failed on any
+  such lab. This was the defect fixed in 0.1.23, back through a side door.
+
+  `quiet` silences **progress only**. Errors keep going to stderr in both modes:
+  a service refusing to start must still be heard, or `--json` would hide the
+  one thing that matters.
+
+
 ## [0.1.73] - 2026-08-24
 
 ### Added

--- a/docs/commands.fr.md
+++ b/docs/commands.fr.md
@@ -63,6 +63,7 @@ complet de la plateforme dans le terminal, `dsoxlab fullhelp`.
 | --- | --- |
 | `5` | `provision` a trouvé des machines qu'un provisioning en échec a laissées hors du state Terraform. Le message nomme la commande qui les retire |
 | `6` | `destroy` n'a pas pu retirer ces machines |
+| `8` | `provision` a renoncé à attendre des hôtes qui ne répondaient pas : l'infrastructure existe, mais elle n'est pas utilisable en l'état |
 | `7` | Une autre commande dsoxlab tient déjà le verrou d'écriture de ce catalogue. Le message la nomme |
 | `130` | La commande a été interrompue (Ctrl-C), et dit comment reprendre |
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -62,6 +62,7 @@ guide in the terminal, `dsoxlab fullhelp`.
 | --- | --- |
 | `5` | `provision` found machines a failed provisioning left outside the Terraform state. The message names the command that removes them |
 | `6` | `destroy` could not remove those machines |
+| `8` | `provision` gave up waiting for hosts that never answered: the infrastructure exists, but it is not usable as it stands |
 | `7` | Another dsoxlab command already holds this catalog's write lock. The message names it |
 | `130` | The command was interrupted (Ctrl-C), and says how to resume |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.73"
+version = "0.1.74"
 description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli/_commun.py
+++ b/src/dsoxlab/cli/_commun.py
@@ -261,7 +261,7 @@ def _services_repo_id(root: Path) -> str:
     return meta.id if meta else root.name
 
 
-def _ensure_services(lab: LabDefinition, root: Path) -> None:
+def _ensure_services(lab: LabDefinition, root: Path, *, quiet: bool = False) -> None:
     """Démarre les services conteneurisés déclarés par le lab, avant run/check.
 
     Sans service déclaré, ne fait rien. Si Docker est injoignable ou qu'un
@@ -276,7 +276,12 @@ def _ensure_services(lab: LabDefinition, root: Path) -> None:
         raise typer.Exit(2)
     repo_id = _services_repo_id(root)
     for service in lab.runtime.services:
-        info(_("service_starting", name=service.name, image=service.image))
+        if not quiet:
+            # `quiet` ne fait taire que le PROGRÈS. Les erreurs plus bas
+            # partent sur stderr, que le document JSON ne traverse pas :
+            # un service qui refuse de démarrer doit se dire dans les
+            # deux modes.
+            info(_("service_starting", name=service.name, image=service.image))
         # Le démarrage attend les sondes du service, jusqu'à `ready_timeout`
         # secondes : c'est le point d'attente le plus long d'un lab shell, donc
         # celui où le Ctrl-C tombe.
@@ -286,7 +291,8 @@ def _ensure_services(lab: LabDefinition, root: Path) -> None:
             except svc.ServiceError as exc:
                 error(_("service_failed", name=service.name, detail=str(exc)))
                 raise typer.Exit(2) from None
-        success(_("service_ready", name=service.name))
+        if not quiet:
+            success(_("service_ready", name=service.name))
 
 
 def _stop_services(lab: LabDefinition, root: Path) -> None:

--- a/src/dsoxlab/cli/_validation.py
+++ b/src/dsoxlab/cli/_validation.py
@@ -200,7 +200,7 @@ def _valider(
     """Joue les tests et enregistre la note. Appelé sous verrou."""
     # Les services conteneurisés (émulateur cloud, base…) doivent être debout
     # avant que pytest ne s'exécute : les tests pilotent l'API qu'ils exposent.
-    _ensure_services(lab, root)
+    _ensure_services(lab, root, quiet=quiet)
 
     if not quiet:
         info(_("validating", lab_id=lab.id))

--- a/src/dsoxlab/cli/infrastructure.py
+++ b/src/dsoxlab/cli/infrastructure.py
@@ -184,7 +184,13 @@ def provision(
     # Étape 3 : attendre que les VMs soient réellement joignables (sshd +
     # compte student + cloud-init terminé). Sans ça, le premier `dsoxlab run`
     # échoue en « unreachable » car la VM boote encore.
-    from ..infra.inventory import HostReadyTimeout, wait_for_hosts_ready
+    from ..infra.inventory import (
+        EXIT_HOTES_INJOIGNABLES,
+        HostReadyTimeout,
+        wait_for_hosts_ready,
+    )
+
+    attente_depassee = False
 
     ready_hosts = sorted(result.hosts)
     if ready_hosts:
@@ -220,6 +226,12 @@ def provision(
             except HostReadyTimeout as exc:
                 progress.stop()
                 warn(_("provision_ssh_timeout", error=str(exc)))
+                # Retenu pour la fin : le fragment SSH et les autres gestes qui
+                # suivent restent utiles, mais la commande ne doit pas conclure
+                # au succès. Annoncer « ✔ N hôtes provisionnés » puis sortir en
+                # 0 rendait l'échec invisible à tout script — et le `run`
+                # suivant échouait en « unreachable » sans lien avec la cause.
+                attente_depassee = True
             except Interrupted as exc:
                 # L'infrastructure existe déjà : c'est l'attente qui a été
                 # coupée, pas la création. Rejouer `provision` est idempotent
@@ -257,6 +269,11 @@ def provision(
             info(_("ssh_fragment_written", path=fragment))
         else:
             warn(_("ssh_fragment_no_include", path=fragment))
+
+    if attente_depassee:
+        error(_("provision_incomplet"))
+        info(_("provision_incomplet_suite"))
+        raise typer.Exit(EXIT_HOTES_INJOIGNABLES)
 
     success(_("provision_done", count=len(result.hosts)))
     for fqdn, ip in sorted(result.hosts.items()):

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -140,6 +140,13 @@ STRINGS: dict[str, str] = {
     "cmd_infra_help": "Infrastructure commands for the catalog.",
 
     # ── new: scaffold a contract-compliant skeleton ─────────────────────────
+    "provision_incomplet":
+        "Some hosts did not answer within the allotted time: the "
+        "infrastructure exists, but it is not usable as it stands.",
+    "provision_incomplet_suite":
+        "Run dsoxlab provision again: it resumes without recreating anything. "
+        "If the delay is too short for this machine, raise it: "
+        "DSOXLAB_HOST_READY_TIMEOUT=360 dsoxlab provision",
     "check_rien_mesure":
         "No test could be collected: nothing was measured, and nothing is "
         "recorded.",

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -141,6 +141,13 @@ STRINGS: dict[str, str] = {
     "cmd_infra_help": "Commandes d'infrastructure du catalogue.",
 
     # ── new : créer un squelette conforme au contrat ────────────────────────
+    "provision_incomplet":
+        "Des hôtes n'ont pas répondu dans le délai imparti : "
+        "l'infrastructure existe, mais elle n'est pas utilisable en l'état.",
+    "provision_incomplet_suite":
+        "Relance dsoxlab provision : il reprend sans rien recréer. Si le délai "
+        "est trop court pour cette machine, allonge-le : "
+        "DSOXLAB_HOST_READY_TIMEOUT=360 dsoxlab provision",
     "check_rien_mesure":
         "Aucun test n'a pu être collecté : rien n'a été mesuré, et rien n'est "
         "enregistré.",

--- a/src/dsoxlab/infra/inventory.py
+++ b/src/dsoxlab/infra/inventory.py
@@ -362,6 +362,15 @@ class HostReadyTimeout(RuntimeError):
 #: Variable d'environnement qui règle l'attente de disponibilité des hosts.
 HOST_READY_TIMEOUT_ENV = "DSOXLAB_HOST_READY_TIMEOUT"
 
+#: Des hôtes n'ont pas répondu dans le délai imparti.
+#:
+#: `provision` se contentait d'un avertissement, puis annonçait « ✔ N hôtes
+#: provisionnés » et sortait en 0. L'échec était donc invisible à tout script,
+#: et le `run` suivant échouait en « unreachable » sans lien visible avec la
+#: cause. Un code dédié le dit, comme 5 et 6 le font pour les orphelins.
+EXIT_HOTES_INJOIGNABLES = 8
+
+
 #: Défaut, en secondes. Confortable sur un poste dédié, juste sur un hôte
 #: modeste : le boot parallèle de plusieurs VMs y sature le CPU, et un rapport
 #: d'usage a mesuré un host prêt à 181 s, soit une seconde après l'abandon.

--- a/tests/test_provision_et_json_services.py
+++ b/tests/test_provision_et_json_services.py
@@ -1,0 +1,137 @@
+"""Deux échecs qui ne se disaient pas (issues #170 et #171).
+
+Le premier : `provision` traitait un délai d'attente dépassé par un simple
+avertissement, puis annonçait « ✔ N hôtes provisionnés » et sortait en 0.
+L'infrastructure existait, mais elle n'était pas utilisable, et le `run` suivant
+échouait en « unreachable » sans lien visible avec la cause. Tout script qui
+teste le code de retour était aveugle.
+
+Le second : `check --json` sur un lab déclarant des services faisait précéder
+son document de « ℹ Démarrage du service… », si bien que `| jq` échouait. C'est
+le défaut corrigé en 0.1.23, revenu par une porte latérale — `_valider` ne
+propageait pas `quiet` à `_ensure_services`.
+
+Les deux relèvent de la même règle : la sortie standard porte le document, et
+une commande ne conclut pas au succès sur ce qu'elle n'a pas constaté.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+
+from dsoxlab.models.lab import LabDefinition
+
+_BASE = """\
+id: l1-demo
+title: Demo lab
+level: beginner
+skills: [demo]
+distros: [any]
+doc_url: https://example.org/docs/demo/
+"""
+
+
+def _lab_avec_service(tmp_path: Path) -> LabDefinition:
+    chemin = tmp_path / "lab.yaml"
+    chemin.write_text(
+        _BASE
+        + "runtime:\n  type: shell\n  workdir: challenge/work\n"
+        + "  services:\n    - name: db\n      image: postgres:16\n",
+        encoding="utf-8",
+    )
+    return LabDefinition.from_yaml(chemin)
+
+
+# ── #171 : le document, et rien d'autre ─────────────────────────────────────
+
+def test_le_demarrage_des_services_se_tait_en_mode_machine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Le défaut prouvé par exécution : « ℹ Démarrage du service… » précédait le JSON."""
+    from dsoxlab.cli import _commun
+    from dsoxlab.runtimes import services as svc
+
+    lab = _lab_avec_service(tmp_path)
+    # `_ensure_services` importe le module dans son corps : c'est donc le module
+    # source qu'il faut patcher, pas un attribut de l'appelant.
+    monkeypatch.setattr(svc, "docker_available", lambda: True)
+    monkeypatch.setattr(svc, "start", lambda service, repo: "conteneur")
+
+    _commun._ensure_services(lab, tmp_path, quiet=True)
+
+    lu = capsys.readouterr()
+    assert lu.out == "", f"stdout doit rester vide en mode machine : {lu.out!r}"
+
+
+def test_le_demarrage_des_services_se_dit_en_mode_normal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """L'autre bout : sans `--json`, l'apprenant doit voir ce qui démarre.
+
+    Un lab qui met dix secondes à lever ses conteneurs sans rien afficher
+    passerait pour figé.
+    """
+    from dsoxlab.cli import _commun
+    from dsoxlab.runtimes import services as svc
+
+    lab = _lab_avec_service(tmp_path)
+    # `_ensure_services` importe le module dans son corps : c'est donc le module
+    # source qu'il faut patcher, pas un attribut de l'appelant.
+    monkeypatch.setattr(svc, "docker_available", lambda: True)
+    monkeypatch.setattr(svc, "start", lambda service, repo: "conteneur")
+
+    _commun._ensure_services(lab, tmp_path, quiet=False)
+
+    assert "db" in capsys.readouterr().out
+
+
+def test_un_service_en_echec_se_dit_meme_en_mode_machine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`quiet` fait taire le PROGRÈS, jamais les erreurs.
+
+    Elles partent sur stderr, que le document ne traverse pas : un service qui
+    refuse de démarrer doit se dire dans les deux modes, sinon `--json` masque
+    la seule information qui compte.
+    """
+    from dsoxlab.cli import _commun
+    from dsoxlab.runtimes import services as svc
+
+    lab = _lab_avec_service(tmp_path)
+    monkeypatch.setattr(svc, "docker_available", lambda: True)
+
+    def _echoue(service: object, repo: str) -> str:
+        raise svc.ServiceError("le conteneur ne démarre pas")
+
+    monkeypatch.setattr(svc, "start", _echoue)
+
+    # `typer.Exit` n'est pas un `SystemExit` : c'est une exception de click,
+    # convertie en code de sortie par le runner.
+    with pytest.raises(typer.Exit):
+        _commun._ensure_services(lab, tmp_path, quiet=True)
+
+    lu = capsys.readouterr()
+    assert lu.out == "", "le document ne doit pas être pollué"
+    assert "démarre pas" in lu.err or "start" in lu.err.lower(), (
+        "l'échec doit rester visible sur stderr"
+    )
+
+
+# ── #170 : un code de sortie pour un délai dépassé ──────────────────────────
+
+def test_le_code_de_sortie_des_hotes_injoignables_est_distinct() -> None:
+    """Un code dédié, comme 5 et 6 le sont pour les orphelins.
+
+    Sans lui, `provision` sortait en 0 après avoir renoncé à attendre, et aucun
+    script — ni la construction d'une image — ne pouvait s'en apercevoir.
+    """
+    from dsoxlab.infra.inventory import EXIT_HOTES_INJOIGNABLES
+    from dsoxlab.interrupt import EXIT_INTERRUPTED
+    from dsoxlab.locking import EXIT_LOCKED
+
+    assert EXIT_HOTES_INJOIGNABLES not in (0, 1, 5, 6, EXIT_LOCKED, EXIT_INTERRUPTED), (
+        "le code doit se distinguer de ceux déjà attribués"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.73"
+version = "0.1.74"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Deux défauts distincts, une même règle : **une commande ne conclut pas au succès
sur ce qu'elle n'a pas constaté**, et la sortie standard porte le document, rien
d'autre.

## #170 — `provision` annonçait un succès qu'il n'avait pas constaté

Un délai d'attente dépassé n'était qu'un avertissement. La commande affichait
ensuite « ✔ N hôtes provisionnés » et **sortait en 0**.

L'infrastructure existait, mais elle n'était pas utilisable : le `run` suivant
échouait en « unreachable », sans lien visible avec la cause. Tout script qui
teste le code de retour était aveugle — **y compris la construction d'une image
prête à l'emploi**, qui devra justement s'y fier pour savoir si elle a réussi.

Un code de sortie dédié, **`8`**, le dit désormais, aux côtés de ceux des
orphelins (5 et 6). Le message donne le geste :

```
✘ Des hôtes n'ont pas répondu dans le délai imparti : l'infrastructure existe,
  mais elle n'est pas utilisable en l'état.
ℹ Relance dsoxlab provision : il reprend sans rien recréer. Si le délai est trop
  court pour cette machine, allonge-le : DSOXLAB_HOST_READY_TIMEOUT=360 …
```

Le fragment SSH et les autres gestes de fin restent joués : ils sont utiles même
quand tous les hôtes ne répondent pas. Seule la conclusion change.

## #171 — `check --json` était pollué par le démarrage des services

Prouvé par exécution, avant :

```console
$ dsoxlab check aws-provider-aws-first-ec2 --json 2>/dev/null | head -1
ℹ Démarrage du service floci (floci/floci:1.6.0)…
```

Après :

```console
$ dsoxlab check aws-provider-aws-first-ec2 --json 2>/dev/null | jq -r .lab.id
aws-provider-aws-first-ec2
```

`_valider` ne propageait pas `quiet` à `_ensure_services`. C'était le défaut
corrigé en 0.1.23, revenu **par une porte latérale** — celle qu'aucun test ne
gardait, puisque le lab de démonstration ne déclare aucun service.

**`quiet` ne fait taire que le progrès.** Les erreurs continuent de partir sur
stderr dans les deux modes, et un test le fige : un service qui refuse de
démarrer doit rester audible, sans quoi `--json` masquerait la seule information
qui compte. `run`, qui n'a pas de mode machine, reste bavard à raison.

## Contrôles joués

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` : *All checks passed*
- [x] `uv run mypy src/dsoxlab` : *no issues found in 79 source files*
- [x] `uv run pytest` : **765 passed** (761 avant, +4)
- [x] `uv run pytest tests_e2e` : **18 passed**
- [x] **Éprouvé par l'échec** : correction neutralisée, deux tests rougissent
- [x] **Prouvé par exécution** sur un lab à services réel, avant et après
- [x] Le moteur reste neutre vis-à-vis du domaine

### When behavior changes

- [x] CHANGELOG EN **et** FR ; version **0.1.74** ; `uv.lock` aligné
- [x] Le code de sortie `8` est documenté dans `docs/commands.md` **et** `.fr.md`,
      avec les autres

### When a command or option is added, removed or changed

- [x] Clés i18n `provision_incomplet` et `provision_incomplet_suite` dans
      **en.py et fr.py**
- [ ] Aide CLI et `fullhelp` : **N/A**, aucune commande ni option ne change

### When `.github/workflows/` is touched — N/A
### When the declarative contract changes — N/A

## Related issues

Closes #170
Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
