### PR TITLE
fix(libvirt): une sonde qui n'a pas pu regarder ne conclut plus au vert (0.1.75)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -9,6 +9,40 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+## [0.1.75] - 2026-08-24
+
+### Corrigé
+
+- **Le contrôle du pool libvirt concluait « vert » quand il n'avait pas pu
+  regarder** (issue #172). La sonde invoquait `virsh -c qemu:///system` en
+  direct, sans la détection du préfixe `sudo -n` que `infra/libvirt.py` a
+  construite pour ce cas : sur toute machine où l'URI système exige des
+  droits, la sonde échouait à chaque fois, et cet échec était rendu `ok`, un
+  contrôle vert en permanence précisément là où `provision` allait mourir sur
+  « Pool Not Found ». La sonde passe désormais par `run_virsh`, et une sonde
+  qui ne peut pas mesurer rend `state: unknown` (introduit en 0.1.73), qui ne
+  peint le verdict ni en vert ni en rouge. `_check_kvm` interroge aussi
+  explicitement l'**URI système** : un `virsh version` nu peut viser l'URI
+  session selon la distribution, et répondre parfaitement à un utilisateur que
+  l'URI système refuse.
+
+- **Trois `sudo virsh` bruts sans `-n` pouvaient pendre ou échouer en
+  silence** (issue #173). `_ensure_kvm_dhcp_leases` (deux occurrences) et
+  `_reset_kvm_domain` capturaient leur sortie : un prompt de mot de passe sudo
+  n'avait aucun terminal où s'afficher et l'appel restait pendu ; sur une
+  machine configurée par le groupe `libvirt` sans droits sudo, le bail DHCP
+  n'était jamais posé et l'échec partait dans un journal que personne ne lit,
+  l'hôte mourant plus tard en « injoignable » sans cause visible. Les trois
+  appels passent désormais par `run_virsh` (chemin détecté, URI système,
+  jamais de prompt), et un bail refusé s'affiche **à l'écran** pendant
+  `provision`, pas seulement au journal. Un test garde-fou refuse désormais
+  tout `subprocess.run(["sudo", …])` qui capture sa sortie sans `-n` dans
+  `src/dsoxlab/`, sur le modèle du garde-fou anti-`shell=True` de 0.1.70.
+
+- `run_command` convertit désormais tout `OSError` en `CommandError` au lieu
+  de laisser un binaire qui disparaît en cours de route faire planter
+  l'appelant : un diagnostic ne doit pas mourir en diagnostiquant.
+
 ## [0.1.74] - 2026-08-24
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.75] - 2026-08-24
+
+### Fixed
+
+- **The libvirt pool check concluded "green" when it could not look** (issue
+  #172). The probe invoked `virsh -c qemu:///system` directly, without the
+  `sudo -n` prefix detection that `infra/libvirt.py` was built for: on any
+  machine where the system URI requires privileges, the probe failed every
+  time, and that failure was reported as `ok` — a permanently green check
+  right where `provision` was about to die on "Pool Not Found". The probe now
+  goes through `run_virsh`, and a probe that cannot measure yields
+  `state: unknown` (introduced in 0.1.73), which never paints the verdict
+  green nor red. `_check_kvm` also queries the **system URI** explicitly: a
+  bare `virsh version` may target the session URI depending on the
+  distribution, and answer perfectly for a user the system URI refuses.
+
+- **Three raw `sudo virsh` calls without `-n` could hang or fail silently**
+  (issue #173). `_ensure_kvm_dhcp_leases` (twice) and `_reset_kvm_domain`
+  captured their output, so a sudo password prompt had no terminal to show on
+  and the call hung; on a machine configured through the `libvirt` group
+  without sudo rights, the DHCP lease was never planted and the failure went
+  to a log nobody reads, the host later dying as "unreachable" with no visible
+  cause. All three calls now go through `run_virsh` (detected path, system
+  URI, never a prompt), and a refused lease is printed **on screen** by
+  `provision`, not just logged. A guard test now rejects any
+  `subprocess.run(["sudo", …])` that captures its output without `-n` in
+  `src/dsoxlab/`, on the model of the anti-`shell=True` guard from 0.1.70.
+
+- `run_command` now converts every `OSError` into a `CommandError` instead of
+  letting a binary that vanishes mid-run crash the caller — a diagnosis must
+  not die while diagnosing.
+
 ## [0.1.74] - 2026-08-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dsoxlab"
-version = "0.1.74"
+version = "0.1.75"
 description = "Turn declarative exercises into reproducible, runnable and verifiable lab environments"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dsoxlab/cli/infrastructure.py
+++ b/src/dsoxlab/cli/infrastructure.py
@@ -181,6 +181,12 @@ def provision(
             info(f"  {commande}")
         raise typer.Exit(4) from None
 
+    # Un bail DHCP refusé pendant l'apply se dit ici, à l'écran : confiné au
+    # journal, l'hôte échouerait plus tard en « injoignable » sans que rien ne
+    # relie l'échec à sa cause.
+    for message in result.warnings:
+        warn(message)
+
     # Étape 3 : attendre que les VMs soient réellement joignables (sshd +
     # compte student + cloud-init terminé). Sans ça, le premier `dsoxlab run`
     # échoue en « unreachable » car la VM boote encore.

--- a/src/dsoxlab/i18n/strings/en.py
+++ b/src/dsoxlab/i18n/strings/en.py
@@ -287,6 +287,10 @@ STRINGS: dict[str, str] = {
     "provision_no_ssh_key": "Lab SSH key missing: {path}\nWithout it, cloud keypair would be empty and VMs unreachable.\nRun first: dsoxlab instructor bootstrap",
     "provision_done":      "Provisioning complete — {count} host(s) ready.",
     "provision_failed":    "Provisioning failed: {error}",
+    "provision_lease_refused":
+        "DHCP lease refused for {host} ({mac}): {error}\n"
+        "Without it, the host will get no IP and will later show up as "
+        "unreachable.",
     "provision_provider_conflict": "Cannot provision on '{current}': provider '{others}' still has active lab infrastructure.\nincus and KVM share the lab's network name and subnet, so they can't run at the same time.\nFinish or tear down the other one first:\n  DSOXLAB_PROVIDER={other} dsoxlab destroy",
     "provision_waiting_ssh": "Waiting for hosts to become reachable (SSH + cloud-init)…",
     "provision_waiting_ssh_host": "Waiting for {host} (SSH + cloud-init), attempt {attempt}…",
@@ -936,7 +940,8 @@ silent.
     "detail_pool_inactive":
         "the `{pool}` pool is defined but never started: `provision` will fail "
         "with \"storage pool is not active\"",
-    "detail_pool_unknown":   "cannot be checked without virsh",
+    "detail_pool_unknown":
+        "virsh did not answer: not verified — nothing is proven either way",
     "explain_apparmor_denied":
         "Known cause: AppArmor denies the VM disks. virt-aa-helper cannot "
         "resolve a disk declared by pool reference, so none of them enters the "

--- a/src/dsoxlab/i18n/strings/fr.py
+++ b/src/dsoxlab/i18n/strings/fr.py
@@ -288,6 +288,10 @@ STRINGS: dict[str, str] = {
     "provision_no_ssh_key": "Clé SSH du lab manquante : {path}\nSans elle, le keypair cloud serait vide et les VMs inaccessibles.\nLance d'abord : dsoxlab instructor bootstrap",
     "provision_done":      "Provisionnement terminé — {count} hôte(s) prêt(s).",
     "provision_failed":    "Provisionnement échoué : {error}",
+    "provision_lease_refused":
+        "Bail DHCP refusé pour {host} ({mac}) : {error}\n"
+        "Sans lui, l'hôte n'obtiendra pas son IP et paraîtra plus tard "
+        "injoignable.",
     "provision_provider_conflict": "Impossible de provisionner sur « {current} » : le provider « {others} » a encore une infra de lab active.\nincus et KVM partagent le nom de réseau et le subnet du lab, ils ne peuvent pas tourner en même temps.\nTermine ou détruis l'autre d'abord :\n  DSOXLAB_PROVIDER={other} dsoxlab destroy",
     "provision_waiting_ssh": "Attente que les hôtes soient joignables (SSH + cloud-init)…",
     "provision_waiting_ssh_host": "Attente de {host} (SSH + cloud-init), tentative {attempt}…",
@@ -947,7 +951,9 @@ hors ligne, elle se tait.
     "detail_pool_inactive":
         "le pool « {pool} » est défini mais jamais démarré : « provision » "
         "échouera sur « storage pool is not active »",
-    "detail_pool_unknown":   "non vérifiable sans virsh",
+    "detail_pool_unknown":
+        "virsh n'a pas répondu : non vérifié, rien n'est prouvé ni dans un sens "
+        "ni dans l'autre",
     "explain_apparmor_denied":
         "Cause connue : AppArmor refuse les disques des VM. virt-aa-helper ne "
         "sait pas résoudre un disque déclaré par référence de pool, donc aucun "

--- a/src/dsoxlab/infra/inventory.py
+++ b/src/dsoxlab/infra/inventory.py
@@ -32,6 +32,8 @@ from typing import Any
 from ..i18n import _
 from ..models.repo import RepoMetadata
 from ..utils.fichiers import ecrire_atomiquement
+from ..utils.shell import CommandError
+from . import libvirt
 
 logger = logging.getLogger(__name__)
 
@@ -428,12 +430,16 @@ def _reset_kvm_domain(repo_meta: RepoMetadata, fqdn: str) -> bool:
     if infra is None or getattr(infra, "provider", None) != "kvm":
         return False
     # check=False : la fonction rend un booléen « tenté ou non » et son
-    # appelant enchaîne. Un reset refusé (sudo absent, domaine déjà éteint) ne
-    # doit pas casser l'attente : c'est un dépannage opportuniste, pas une étape.
-    res = subprocess.run(
-        ["sudo", "virsh", "reset", fqdn], capture_output=True, text=True, check=False
-    )
-    if res.returncode == 0:
+    # appelant enchaîne. Un reset refusé (droits absents, domaine déjà éteint)
+    # ne doit pas casser l'attente : c'est un dépannage opportuniste, pas une
+    # étape. `run_virsh` porte la détection du préfixe `sudo -n` : un `sudo`
+    # brut pendait sur un prompt sans terminal, et échouait toujours chez qui
+    # joint libvirt par le groupe, sans droits sudo.
+    try:
+        res = libvirt.run_virsh(["reset", fqdn], check=False)
+    except CommandError:
+        return False
+    if res.ok:
         logger.info("reset envoyé à %s (déblocage du premier boot)", fqdn)
         return True
     return False

--- a/src/dsoxlab/infra/libvirt.py
+++ b/src/dsoxlab/infra/libvirt.py
@@ -94,20 +94,20 @@ def _uri() -> str:
     return os.environ.get("LIBVIRT_DEFAULT_URI") or _URI_DEFAUT
 
 
-def _sonder(prefixe: list[str]) -> bool:
+def _sonder(prefixe: list[str], *, timeout: int = _TIMEOUT) -> bool:
     """Ce préfixe permet-il de joindre l'hyperviseur ?"""
     try:
         run_command(
             [*prefixe, "virsh", "--connect", _uri(), "list", "--name"],
             check=True,
-            timeout=_TIMEOUT,
+            timeout=timeout,
         )
     except CommandError:
         return False
     return True
 
 
-def _prefixe() -> list[str]:
+def _prefixe(*, timeout: int = _TIMEOUT) -> list[str]:
     """Rend le préfixe qui joint l'hyperviseur, ``[]`` ou ``["sudo", "-n"]``.
 
     L'ordre n'est pas indifférent. La configuration que recommande libvirt est
@@ -130,7 +130,7 @@ def _prefixe() -> list[str]:
         return _prefixe_retenu
 
     for candidat in ([], ["sudo", "-n"]):
-        if _sonder(candidat):
+        if _sonder(candidat, timeout=timeout):
             logger.debug(
                 "virsh joignable avec le préfixe %r sur %s", candidat, _uri()
             )
@@ -151,9 +151,14 @@ def _oublier_prefixe() -> None:
 def _virsh(
     args: list[str], *, check: bool = True, timeout: int = _TIMEOUT
 ) -> CommandResult:
-    """Invoque ``virsh`` sur l'URI système, sans jamais bloquer sur un mot de passe."""
+    """Invoque ``virsh`` sur l'URI système, sans jamais bloquer sur un mot de passe.
+
+    Le ``timeout`` borne aussi la détection du préfixe : un appelant pressé
+    (``doctor``, qui sonde en quelques secondes) ne doit pas attendre deux
+    fois trente secondes qu'un démon muet refuse de répondre aux sondes.
+    """
     return run_command(
-        [*_prefixe(), "virsh", "--connect", _uri(), *args],
+        [*_prefixe(timeout=min(timeout, _TIMEOUT)), "virsh", "--connect", _uri(), *args],
         check=check,
         timeout=timeout,
     )

--- a/src/dsoxlab/infra/terraform.py
+++ b/src/dsoxlab/infra/terraform.py
@@ -86,6 +86,13 @@ class ProvisionResult:
     hosts: dict[str, str]
     """Map FQDN → IP extraite de l'output ``hosts``."""
 
+    warnings: list[str] = field(default_factory=list)
+    """Messages déjà traduits que l'appelant doit **afficher**.
+
+    Un bail DHCP refusé n'empêche pas l'apply, mais condamne l'hôte à un
+    « injoignable » ultérieur sans cause visible : le dire seulement au
+    journal, c'est ne le dire à personne."""
+
 
 def is_available() -> bool:
     """Retourne True si la CLI ``terraform`` est dans le PATH."""
@@ -442,7 +449,7 @@ def other_active_providers(repo_meta: RepoMetadata) -> list[str]:
 
 def _ensure_kvm_dhcp_leases(
     repo_meta: RepoMetadata, target_hosts: list[str] | None = None
-) -> None:
+) -> list[str]:
     """Pose à chaud les baux DHCP statiques manquants d'un réseau KVM existant.
 
     Le provider ``dmacvicar/libvirt`` ne sait pas mettre à jour un réseau :
@@ -460,34 +467,46 @@ def _ensure_kvm_dhcp_leases(
     présente ou un ``virsh`` qui échoue ne bloque pas le provision (Terraform
     reste la source de vérité pour la création initiale).
 
+    Les appels passent par :func:`~dsoxlab.infra.libvirt.run_virsh` : un
+    ``sudo virsh`` brut sans ``-n`` pendait sur les machines où sudo demande un
+    mot de passe (la sortie est capturée, le prompt n'a aucun terminal), et
+    échouait toujours sur celles configurées par groupe ``libvirt`` sans droits
+    sudo — le bail n'était jamais posé, et l'hôte mourait plus tard en
+    « injoignable » sans cause visible.
+
     Le calcul MAC/IP DOIT rester aligné sur le template kvm
     (``main.tf`` : préfixe MAC ``52:54:<h0>:<h1>:00`` dérivé de
     ``sha256(repo_id)``, dernier octet ``idx+16`` ; ``ip = cidrhost(cidr,
     idx+11)``), idx étant la position dans ``infra.hosts``.
+
+    Returns:
+        Les avertissements **déjà traduits** à afficher à l'utilisateur : un
+        par bail refusé. Best-effort ne veut pas dire muet.
     """
     infra = repo_meta.infra
     if infra is None or getattr(infra, "provider", None) != "kvm" or not infra.network:
-        return
+        return []
     # check=False : « le réseau n'existe pas encore » est un cas NORMAL, et
     # virsh le dit par un code retour. C'est une branche, pas une panne.
-    dump = subprocess.run(
-        ["sudo", "virsh", "net-dumpxml", infra.network],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if dump.returncode != 0:
-        return  # réseau pas encore créé : Terraform le posera avec ses baux
+    try:
+        dump = libvirt.run_virsh(["net-dumpxml", infra.network], check=False)
+    except CommandError:
+        # virsh absent ou muet : rien à poser à chaud, Terraform dira lui-même
+        # ce qui l'empêche de créer le réseau.
+        return []
+    if not dump.ok:
+        return []  # réseau pas encore créé : Terraform le posera avec ses baux
     existing = {m.lower() for m in re.findall(r"mac='([^']+)'", dump.stdout)}
     try:
         network = ipaddress.ip_network(infra.cidr or "10.10.10.0/24", strict=False)
     except ValueError:
-        return
+        return []
     # Même dérivation que le template kvm (locals.mac_prefix) : deux octets du
     # hash du repo.id isolent les MAC entre dépôts. Doit rester synchronisé.
     digest = hashlib.sha256(repo_meta.id.encode("utf-8")).hexdigest()
     mac_prefix = f"52:54:{digest[0:2]}:{digest[2:4]}:00"
     wanted = set(target_hosts) if target_hosts else None
+    avertissements: list[str] = []
     for idx, host in enumerate(infra.hosts):
         if wanted is not None and host.name not in wanted:
             continue
@@ -498,23 +517,30 @@ def _ensure_kvm_dhcp_leases(
         entry = f"<host mac='{mac}' name='{host.name}' ip='{ip}'/>"
         # check=False : best-effort assumé (voir la docstring), Terraform reste
         # la source de vérité pour la création initiale du réseau.
-        res = subprocess.run(
-            ["sudo", "virsh", "net-update", infra.network,
-             "add-last", "ip-dhcp-host", entry, "--live", "--config"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if res.returncode == 0:
+        try:
+            res = libvirt.run_virsh(
+                ["net-update", infra.network,
+                 "add-last", "ip-dhcp-host", entry, "--live", "--config"],
+                check=False,
+            )
+        except CommandError as exc:
+            res = exc.result
+        if res.ok:
             logger.info("bail DHCP ajouté à chaud: %s -> %s (%s)", host.name, ip, mac)
         else:
             # Best-effort ne veut pas dire muet. Sans ce bail, l'hôte n'obtiendra
             # pas son IP et l'attente échouera plus tard sur un « injoignable »
-            # qui ne dira jamais pourquoi. On continue, mais on le dit.
+            # qui ne dira jamais pourquoi. On continue, mais on le dit — à
+            # l'écran, via l'appelant : un logger.warning que personne ne lit
+            # est un silence.
+            erreur = (res.stderr or res.stdout).strip()
             logger.warning(
-                "bail DHCP refusé pour %s (%s) : %s",
-                host.name, mac, (res.stderr or res.stdout).strip(),
+                "bail DHCP refusé pour %s (%s) : %s", host.name, mac, erreur,
             )
+            avertissements.append(
+                _("provision_lease_refused", host=host.name, mac=mac, error=erreur)
+            )
+    return avertissements
 
 
 def apply(
@@ -552,7 +578,7 @@ def apply(
     # DHCP des hosts ajoutés après sa création, à chaud, sinon leur VM ne
     # recevrait pas son IP statique. No-op au premier provision (réseau absent)
     # et hors kvm. Voir _ensure_kvm_dhcp_leases.
-    _ensure_kvm_dhcp_leases(repo_meta, target_hosts)
+    avertissements = _ensure_kvm_dhcp_leases(repo_meta, target_hosts)
 
     # Note : ``init`` n'est PAS appelé automatiquement ici. La CLI
     # ``dsoxlab provision`` l'appelle séparément (avec spinner) pour
@@ -602,7 +628,9 @@ def apply(
             env=_provider_env(repo_meta),
         )
 
-    return _read_outputs(tf_dir, env=_provider_env(repo_meta))
+    result = _read_outputs(tf_dir, env=_provider_env(repo_meta))
+    result.warnings.extend(avertissements)
+    return result
 
 
 #: Délai laissé à Terraform pour mourir sur ``SIGTERM`` avant le ``SIGKILL``.

--- a/src/dsoxlab/services/doctor.py
+++ b/src/dsoxlab/services/doctor.py
@@ -41,9 +41,11 @@ from pathlib import Path
 from ..discovery.scanner import compter_fichiers_labs
 from ..i18n import _
 from ..infra import ansible as ansible_infra
+from ..infra import libvirt as libvirt_infra
 from ..models import LabDefinition, RepoMetadata
 from ..models.repo import InfraDefinition
 from ..models.runtime import RuntimeType
+from ..utils.shell import CommandError, CommandResult
 from .lab_service import get_all_labs, resolve_pytest_cmd
 
 #: Providers packagés qui reposent sur un hyperviseur **local**, donc
@@ -281,6 +283,22 @@ def _sonder(
         return None
 
 
+def _sonde_virsh(args: list[str], *, delai: int = 5) -> CommandResult | None:
+    """Joue une sonde ``virsh`` sur l'URI système, ou rend ``None`` si impossible.
+
+    Le chemin est celui de :func:`~dsoxlab.infra.libvirt.run_virsh` — même URI,
+    même détection du préfixe ``sudo -n`` — parce qu'un diagnostic qui
+    n'emprunte pas le chemin des commandes qu'il couvre mesure autre chose
+    qu'elles. ``check=False`` : un code retour non nul EST une réponse ; seul
+    l'appel qui ne peut pas aboutir (binaire absent, timeout) vaut ``None``.
+    """
+    try:
+        result = libvirt_infra.run_virsh(args, check=False, timeout=delai)
+    except CommandError:
+        return None
+    return result
+
+
 def _current_user() -> str:
     """L'utilisateur à qui s'adresse un correctif de groupe.
 
@@ -366,13 +384,20 @@ def _check_kvm() -> Check:
         )
     # Un virsh qui sort en erreur est justement ce que ce contrôle cherche à
     # rapporter ; un virsh qui ne répond pas dit la même chose plus fort.
-    result = _sonder(["virsh", "version"])
-    if result is None or result.returncode != 0:
+    #
+    # L'interrogation vise **l'URI système**, celle où ``provision`` crée ses
+    # domaines : ``virsh version`` nu peut viser l'URI session selon la
+    # distribution, et répondre parfaitement à un utilisateur que l'URI système
+    # refuse — deux lignes vertes au-dessus d'un provisionnement mort.
+    # ``run_virsh`` porte le ``--connect qemu:///system`` et la détection du
+    # préfixe ``sudo -n``, exactement comme les commandes qu'il couvre.
+    probe = _sonde_virsh(["version"])
+    if probe is None or not probe.ok:
         return _check(
             "kvm", False, _("detail_kvm_daemon_err"),
             fix=_fix(["sudo", "systemctl", "start", "libvirtd"]),
         )
-    first_line = result.stdout.splitlines()[0] if result.stdout else "ok"
+    first_line = probe.stdout.splitlines()[0] if probe.stdout else "ok"
     return _check("kvm", True, first_line)
 
 
@@ -644,14 +669,20 @@ def _pools_libvirt(*, definis: bool) -> list[str] | None:
 
     Rendre ``None`` quand la sonde n'aboutit pas. ``virsh`` absent ou muet est
     l'affaire du contrôle KVM ; le redire ici empilerait deux rouges pour une
-    seule cause.
+    seule cause. Mais ``None`` n'est pas un vert : le contrôle appelant doit le
+    traduire en :data:`STATE_UNKNOWN`, jamais en « tout va bien ».
+
+    La sonde passe par :func:`~dsoxlab.infra.libvirt.run_virsh` : invoquer
+    ``virsh`` en direct échouait systématiquement sur les machines où l'URI
+    système exige ``sudo``, et l'échec permanent de la sonde peignait le
+    contrôle en vert permanent.
     """
-    cmd = ["virsh", "-c", "qemu:///system", "pool-list"]
+    args = ["pool-list"]
     if definis:
-        cmd.append("--all")
-    cmd.append("--name")
-    probe = _sonder(cmd)
-    if probe is None or probe.returncode != 0:
+        args.append("--all")
+    args.append("--name")
+    probe = _sonde_virsh(args)
+    if probe is None or not probe.ok:
         return None
     return probe.stdout.split()
 
@@ -677,12 +708,26 @@ def _check_libvirt_pool(pool: str) -> Check:
     """
     actifs = _pools_libvirt(definis=False)
     if actifs is None:
-        return _check("libvirt_pool", True, _("detail_pool_unknown"))
+        # La sonde n'a pas pu regarder : ni vert, ni rouge. L'ancien code
+        # rendait ``ok=True`` ici — le vert affiché faute d'avoir mesuré,
+        # exactement le mensonge que STATE_UNKNOWN existe pour interdire.
+        return _check(
+            "libvirt_pool", False, _("detail_pool_unknown"),
+            forced_state=STATE_UNKNOWN,
+        )
     if pool in actifs:
         return _check("libvirt_pool", True, pool)
 
     definis = _pools_libvirt(definis=True)
-    if definis is not None and pool in definis:
+    if definis is None:
+        # Le pool n'est pas actif, mais sans la liste des pools définis on ne
+        # sait pas si le geste est « créer » ou « démarrer » : proposer l'un
+        # des deux au hasard ferait échouer la remédiation sur l'autre cas.
+        return _check(
+            "libvirt_pool", False, _("detail_pool_unknown"),
+            forced_state=STATE_UNKNOWN,
+        )
+    if pool in definis:
         return _check(
             "libvirt_pool", False, _("detail_pool_inactive", pool=pool),
             fix=demarrer_pool_fix(pool),

--- a/src/dsoxlab/utils/shell.py
+++ b/src/dsoxlab/utils/shell.py
@@ -79,6 +79,13 @@ def run_command(
         raise CommandError(
             cmd, CommandResult(returncode=-1, stdout="", stderr=f"Commande introuvable: {cmd[0]}")
         ) from exc
+    except OSError as exc:
+        # Un binaire qui disparaît entre deux appels, un exec refusé : l'échec
+        # appartient à la commande, pas à l'appelant. Le laisser remonter en
+        # OSError nu ferait planter un diagnostic en train de diagnostiquer.
+        raise CommandError(
+            cmd, CommandResult(returncode=-1, stdout="", stderr=str(exc))
+        ) from exc
 
     result = CommandResult(
         returncode=proc.returncode,

--- a/tests/test_doctor_installation.py
+++ b/tests/test_doctor_installation.py
@@ -16,10 +16,19 @@ from pathlib import Path
 import pytest
 
 from dsoxlab.i18n import _
+from dsoxlab.infra import libvirt
 from dsoxlab.models.lab import LabDefinition, ValidationConfig
 from dsoxlab.models.repo import InfraDefinition, RepoMetadata
 from dsoxlab.models.runtime import RuntimeConfig, RuntimeType, Target
 from dsoxlab.services import doctor
+
+
+@pytest.fixture(autouse=True)
+def sans_cache_de_prefixe() -> None:
+    """Les sondes du pool passent par ``run_virsh``, dont le chemin détecté
+    est mémorisé par processus : un test ne doit pas hériter de la détection
+    d'un autre."""
+    libvirt._oublier_prefixe()
 
 
 def _lab(lab_id: str, runtime_type: RuntimeType) -> LabDefinition:
@@ -533,7 +542,12 @@ def test_un_virsh_muet_ne_conclut_pas_a_l_absence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Sonder n'est pas deviner : un virsh injoignable ne prouve pas qu'un pool
-    manque, et le rouge appartient alors au contrôle KVM, pas à celui-ci."""
+    manque, et le rouge appartient alors au contrôle KVM, pas à celui-ci.
+
+    Mais ne pas savoir n'est pas savoir que tout va bien : l'ancien contrôle
+    rendait ``ok=True`` ici, le vert affiché faute d'avoir mesuré (issue #172).
+    L'état est désormais ``unknown`` — hors de ``failing()``, et hors du vert.
+    """
 
     def _run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
         raise OSError("virsh a disparu entre deux appels")
@@ -541,8 +555,13 @@ def test_un_virsh_muet_ne_conclut_pas_a_l_absence(
     monkeypatch.setattr(doctor.subprocess, "run", _run)
     check = doctor._check_libvirt_pool("default")
 
-    assert check.ok
+    assert not check.ok
+    assert check.state == doctor.STATE_UNKNOWN
     assert check.detail == _("detail_pool_unknown")
+    assert check.fix is None
+
+    rapport = doctor.DoctorReport(required=[check])
+    assert rapport.failing() == [], "unknown ne prouve aucune panne"
 
 
 # ── la remédiation nomme le pool que Terraform a nommé ────────────────────────

--- a/tests/test_sondes_virsh.py
+++ b/tests/test_sondes_virsh.py
@@ -1,0 +1,446 @@
+"""Issues #172 et #173 : toute sonde ``virsh`` emprunte le chemin détecté.
+
+Deux défauts, une même cause : des appels ``virsh`` qui recomposaient leur
+propre ligne de commande au lieu de passer par ``run_virsh``.
+
+* ``doctor`` sondait le pool par un ``virsh -c qemu:///system`` direct, sans la
+  détection du préfixe ``sudo -n``. Sur une machine où l'URI système exige des
+  droits, la sonde échouait **toujours** — et l'échec rendait ``ok=True`` :
+  le contrôle était vert en permanence, précisément là où ``provision``
+  allait mourir sur « Pool Not Found ». Et ``virsh version`` nu, sans
+  ``--connect``, pouvait viser l'URI session : deux lignes vertes au-dessus
+  d'un provisionnement mort.
+* Trois ``subprocess.run(["sudo", "virsh", …], capture_output=True)`` sans
+  ``-n`` : un prompt sudo sans terminal où s'afficher pend, et sur une machine
+  configurée par groupe ``libvirt`` sans droits sudo, le bail DHCP n'était
+  jamais posé — l'échec partait dans un ``logger.warning`` que personne ne lit.
+
+Comme dans ``test_etat_libvirt.py``, ``virsh`` est simulé au niveau du wrapper
+``run_command`` du module ``libvirt`` : c'est le seul niveau qui prouve que
+l'appel passe bien par la détection de préfixe et par l'URI système.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from dsoxlab import i18n
+from dsoxlab.cli import app
+from dsoxlab.i18n import _
+from dsoxlab.infra import inventory, libvirt, terraform
+from dsoxlab.models.repo import HostDefinition, InfraDefinition, RepoMetadata
+from dsoxlab.services import doctor
+from dsoxlab.utils.shell import CommandError, CommandResult
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def langue_en(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Les assertions portent sur le texte anglais, pas sur la LANG du poste."""
+    monkeypatch.setattr(i18n, "_strings", i18n._load("en"))
+
+
+@pytest.fixture(autouse=True)
+def sans_cache_de_prefixe() -> None:
+    """Le chemin retenu est mémorisé par processus : un test ne doit pas
+    hériter de la détection d'un autre."""
+    libvirt._oublier_prefixe()
+
+
+class VirshScripte:
+    """Un ``run_command`` de substitution, réglé sous-commande par sous-commande.
+
+    Chaque commande reçue est enregistrée **entière**, préfixe compris : c'est
+    sur elle que portent les assertions « par quel chemin » et « vers quelle
+    URI », qui sont tout le sujet de ces deux issues.
+
+    ``reponses`` associe une sous-commande virsh à son :class:`CommandResult`.
+    Une sous-commande absente répond ``rc=0`` sans sortie. ``sudo_requis``
+    simule la machine où l'URI système n'est joignable que par ``sudo -n``.
+    """
+
+    def __init__(
+        self,
+        reponses: dict[str, CommandResult] | None = None,
+        *,
+        sudo_requis: bool = False,
+    ) -> None:
+        self.reponses = reponses or {}
+        self.sudo_requis = sudo_requis
+        self.commandes: list[list[str]] = []
+
+    @staticmethod
+    def _sous_commande(cmd: list[str]) -> str:
+        if "virsh" not in cmd:
+            return ""
+        reste = cmd[cmd.index("virsh") + 1 :]
+        if reste[:1] == ["--connect"]:
+            reste = reste[2:]
+        return reste[0] if reste else ""
+
+    def __call__(self, cmd: list[str], **kwargs: Any) -> CommandResult:
+        self.commandes.append(cmd)
+        if self.sudo_requis and cmd[:2] != ["sudo", "-n"]:
+            return self._rendre(
+                cmd, kwargs,
+                CommandResult(returncode=1, stdout="", stderr="permission denied"),
+            )
+        reponse = self.reponses.get(
+            self._sous_commande(cmd), CommandResult(returncode=0, stdout="", stderr="")
+        )
+        return self._rendre(cmd, kwargs, reponse)
+
+    @staticmethod
+    def _rendre(
+        cmd: list[str], kwargs: dict[str, Any], reponse: CommandResult
+    ) -> CommandResult:
+        if not reponse.ok and kwargs.get("check", True):
+            raise CommandError(cmd, reponse)
+        return reponse
+
+    def celles_de(self, sous_commande: str) -> list[list[str]]:
+        return [c for c in self.commandes if self._sous_commande(c) == sous_commande]
+
+
+def _meta(*hosts: str, provider: str = "kvm") -> RepoMetadata:
+    return RepoMetadata(
+        id="demo",
+        category="demo",
+        infra=InfraDefinition(
+            provider=provider,
+            network="lab-demo",
+            cidr="10.10.30.0/24",
+            hosts=[HostDefinition(name=h) for h in hosts],
+        ),
+    )
+
+
+# ── #172 : la sonde du pool passe par run_virsh ──────────────────────────────
+
+def test_le_pool_present_est_vu_meme_derriere_sudo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le cœur du défaut : la sonde directe échouait toujours sur une machine
+    où l'URI système exige des droits, et l'échec valait « vert ». Par
+    ``run_virsh``, la sonde emprunte ``sudo -n`` et **mesure** enfin."""
+    virsh = VirshScripte(
+        {
+            "list": CommandResult(returncode=0, stdout="", stderr=""),
+            "pool-list": CommandResult(returncode=0, stdout="default\n", stderr=""),
+        },
+        sudo_requis=True,
+    )
+    monkeypatch.setattr(libvirt, "run_command", virsh)
+
+    check = doctor._check_libvirt_pool("default")
+
+    assert check.ok
+    assert check.detail == "default"
+    sondes = virsh.celles_de("pool-list")
+    assert sondes, "aucune sonde pool-list jouée"
+    for cmd in sondes:
+        assert cmd[:2] == ["sudo", "-n"], "la sonde doit emprunter le chemin détecté"
+        assert "--connect" in cmd and "qemu:///system" in cmd
+
+
+def test_le_pool_absent_reste_un_constat_rouge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mesurer et ne rien trouver n'est pas « ne pas pouvoir mesurer » : le
+    pool manquant garde son rouge et sa remédiation de création."""
+    virsh = VirshScripte(
+        {"pool-list": CommandResult(returncode=0, stdout="", stderr="")}
+    )
+    monkeypatch.setattr(libvirt, "run_command", virsh)
+
+    check = doctor._check_libvirt_pool("default")
+
+    assert not check.ok
+    assert check.state == doctor.STATE_FAILED
+    assert check.fix is not None
+    assert "pool-define-as" in check.fix.display
+
+
+def test_la_sonde_impossible_rend_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ne pas savoir n'est ni vert ni rouge. L'ancien contrôle rendait
+    ``ok=True`` ici : le vert affiché faute d'avoir mesuré, l'occurrence la
+    plus littérale du motif que ce dépôt combat (issue #172)."""
+
+    def _echec(cmd: list[str], **kwargs: Any) -> CommandResult:
+        raise CommandError(
+            cmd, CommandResult(returncode=1, stdout="", stderr="daemon muet")
+        )
+
+    monkeypatch.setattr(libvirt, "run_command", _echec)
+
+    check = doctor._check_libvirt_pool("default")
+
+    assert not check.ok
+    assert check.state == doctor.STATE_UNKNOWN
+    assert check.detail == _("detail_pool_unknown")
+    assert check.fix is None
+    assert doctor.DoctorReport(required=[check]).failing() == []
+
+
+def test_check_kvm_interroge_l_uri_systeme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``virsh version`` nu peut viser l'URI session selon la distribution, et
+    répondre parfaitement à un utilisateur que l'URI système refuse : deux
+    lignes vertes au-dessus d'un ``provision`` mort. Le contrôle doit viser
+    l'URI que ``provision`` utilise."""
+    virsh = VirshScripte(
+        {"version": CommandResult(returncode=0, stdout="Compiled against 10.0\n", stderr="")}
+    )
+    monkeypatch.setattr(libvirt, "run_command", virsh)
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    check = doctor._check_kvm()
+
+    assert check.ok
+    versions = virsh.celles_de("version")
+    assert versions, "aucun virsh version joué"
+    for cmd in versions:
+        assert "--connect" in cmd and "qemu:///system" in cmd
+
+
+def test_kvm_rouge_quand_l_uri_systeme_refuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Machine fraîche, utilisateur hors du groupe ``libvirt``, pas de sudo :
+    l'URI système ne répond ni en direct ni par ``sudo -n``. Le contrôle doit
+    le dire, au lieu d'un vert lu sur l'URI session."""
+
+    def _echec(cmd: list[str], **kwargs: Any) -> CommandResult:
+        raise CommandError(
+            cmd,
+            CommandResult(returncode=1, stdout="", stderr="authentication failed"),
+        )
+
+    monkeypatch.setattr(libvirt, "run_command", _echec)
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    check = doctor._check_kvm()
+
+    assert not check.ok
+
+
+# ── #173 : les trois sudo virsh passent par run_virsh ────────────────────────
+
+def test_le_reset_kvm_emprunte_le_chemin_detecte(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le ``sudo virsh reset`` brut pendait sur un prompt sans terminal, et
+    échouait toujours chez qui joint libvirt par le groupe, sans sudo."""
+    virsh = VirshScripte()
+    monkeypatch.setattr(libvirt, "run_command", virsh)
+
+    assert inventory._reset_kvm_domain(_meta("web1.lab"), "web1.lab")
+
+    resets = virsh.celles_de("reset")
+    assert len(resets) == 1
+    assert "sudo" not in resets[0], "le chemin direct répond : pas de sudo"
+    assert "--connect" in resets[0] and "qemu:///system" in resets[0]
+    assert resets[0][-1] == "web1.lab"
+
+
+def test_un_reset_refuse_reste_un_faux_sans_lever(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """C'est un dépannage opportuniste : un hyperviseur injoignable ne doit
+    pas casser la boucle d'attente qui l'entoure."""
+
+    def _echec(cmd: list[str], **kwargs: Any) -> CommandResult:
+        raise CommandError(
+            cmd, CommandResult(returncode=1, stdout="", stderr="unreachable")
+        )
+
+    monkeypatch.setattr(libvirt, "run_command", _echec)
+
+    assert not inventory._reset_kvm_domain(_meta("web1.lab"), "web1.lab")
+
+
+def test_un_bail_refuse_est_rendu_a_l_appelant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Best-effort ne veut pas dire muet : le refus doit remonter jusqu'à
+    l'écran, pas seulement au journal (issue #173)."""
+    virsh = VirshScripte(
+        {
+            "net-dumpxml": CommandResult(
+                returncode=0, stdout="<network><name>lab-demo</name></network>",
+                stderr="",
+            ),
+            "net-update": CommandResult(
+                returncode=1, stdout="", stderr="error: permission denied"
+            ),
+        }
+    )
+    monkeypatch.setattr(libvirt, "run_command", virsh)
+
+    avertissements = terraform._ensure_kvm_dhcp_leases(_meta("web1.lab"))
+
+    assert len(avertissements) == 1
+    assert "web1.lab" in avertissements[0]
+    assert "permission denied" in avertissements[0]
+    updates = virsh.celles_de("net-update")
+    assert updates, "aucun net-update joué"
+    assert "--connect" in updates[0] and "qemu:///system" in updates[0]
+
+
+def test_un_bail_pose_ne_produit_aucun_avertissement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Le contre-cas, sans lequel le précédent passerait sur un code qui
+    avertit toujours."""
+    virsh = VirshScripte(
+        {
+            "net-dumpxml": CommandResult(
+                returncode=0, stdout="<network><name>lab-demo</name></network>",
+                stderr="",
+            ),
+        }
+    )
+    monkeypatch.setattr(libvirt, "run_command", virsh)
+
+    assert terraform._ensure_kvm_dhcp_leases(_meta("web1.lab")) == []
+
+
+def test_apply_porte_les_avertissements_de_bail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """``apply`` est le seul relais entre le refus et l'appelant CLI : s'il
+    jette la liste, l'écran ne saura jamais rien."""
+    monkeypatch.setattr(terraform, "is_available", lambda: True)
+    monkeypatch.setattr(terraform, "workdir", lambda meta: tmp_path)
+    monkeypatch.setattr(terraform, "write_tfvars", lambda meta: None)
+    monkeypatch.setattr(
+        terraform, "_ensure_kvm_dhcp_leases", lambda meta, hosts=None: ["refusé"]
+    )
+    monkeypatch.setattr(
+        terraform, "run_command",
+        lambda *a, **k: CommandResult(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        terraform, "_read_outputs",
+        lambda tf_dir, env=None: terraform.ProvisionResult(outputs={}, hosts={}),
+    )
+
+    result = terraform.apply(_meta("web1.lab"))
+
+    assert result.warnings == ["refusé"]
+
+
+def test_provision_affiche_le_refus_de_bail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Critère de l'issue #173 : l'échec se dit **à l'écran**. Un
+    ``logger.warning`` que personne ne lit est un silence."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.setenv("DSOXLAB_NO_UPDATE_CHECK", "1")
+    monkeypatch.setenv("DSOXLAB_LANG", "en")
+    monkeypatch.delenv("DSOXLAB_PROVIDER", raising=False)
+    (tmp_path / "home" / ".ssh" / "config.d").mkdir(parents=True)
+
+    depot = tmp_path / "repo"
+    (depot / "ssh").mkdir(parents=True)
+    (depot / "ssh" / "id_ed25519").write_text("clé factice", encoding="utf-8")
+    (depot / "meta.yml").write_text(
+        "repo:\n  id: demo\n  category: demo\n"
+        "infra:\n  provider: kvm\n  network: lab-demo\n  cidr: 10.10.30.0/24\n"
+        "  hosts:\n    - name: web1.lab\n",
+        encoding="utf-8",
+    )
+
+    refus = _(
+        "provision_lease_refused",
+        host="web1.lab", mac="52:54:00:00:00:10", error="permission denied",
+    )
+    monkeypatch.setattr(terraform, "other_active_providers", lambda meta: [])
+    monkeypatch.setattr(
+        terraform, "find_orphan_domains", lambda meta: terraform.OrphanScan()
+    )
+    monkeypatch.setattr(terraform, "init", lambda *a, **k: None)
+    monkeypatch.setattr(
+        terraform, "apply",
+        lambda *a, **k: terraform.ProvisionResult(
+            outputs={}, hosts={}, warnings=[refus]
+        ),
+    )
+
+    resultat = runner.invoke(app, ["provision", "--lab-home", str(depot)])
+
+    assert resultat.exit_code == 0, resultat.stdout
+    assert "web1.lab" in resultat.stdout
+    assert "DHCP lease refused" in resultat.stdout
+
+
+# ── le garde-fou : plus un seul sudo capturé sans -n ─────────────────────────
+
+def _appels_sudo_captures_sans_n(texte: str) -> list[int]:
+    """Les lignes où un ``subprocess.run(["sudo", …])`` capture sa sortie
+    sans ``-n``. La capture est le critère : c'est elle qui prive le prompt
+    de terminal et fait pendre l'appel. Un sudo **interactif** délibéré (le
+    ``sudo -v`` de pré-authentification de ``doctor --fix``, gardé par un
+    ``isatty``) laisse le prompt s'afficher, et reste légitime."""
+    lignes: list[int] = []
+    for depart in re.finditer(r"subprocess\.run\(", texte):
+        profondeur, fin = 0, None
+        for i in range(depart.end() - 1, len(texte)):
+            if texte[i] == "(":
+                profondeur += 1
+            elif texte[i] == ")":
+                profondeur -= 1
+                if profondeur == 0:
+                    fin = i
+                    break
+        if fin is None:
+            continue
+        appel = texte[depart.start() : fin + 1]
+        capture = "capture_output" in appel or "stdout=" in appel
+        if capture and re.search(r'\[\s*"sudo"\s*,\s*"(?!-n")', appel):
+            lignes.append(texte.count("\n", 0, depart.start()) + 1)
+    return lignes
+
+
+def test_plus_aucun_sudo_capture_sans_n_en_source() -> None:
+    """Le contrat de l'issue #173, sur le modèle du garde-fou
+    anti-``shell=True`` : la règle que ``libvirt.py`` s'est donnée vaut pour
+    tout ``src/dsoxlab/``, pas pour la moitié des appels."""
+    racine = Path(__file__).resolve().parent.parent / "src" / "dsoxlab"
+    coupables = [
+        f"{chemin}:{ligne}"
+        for chemin in sorted(racine.rglob("*.py"))
+        for ligne in _appels_sudo_captures_sans_n(
+            chemin.read_text(encoding="utf-8")
+        )
+    ]
+    assert coupables == []
+
+
+def test_le_garde_fou_detecte_bien_le_motif() -> None:
+    """Un garde-fou qui ne détecte rien ne garde rien : on le prouve sur le
+    motif exact que l'issue #173 a retiré des sources."""
+    fautif = (
+        'res = subprocess.run(\n'
+        '    ["sudo", "virsh", "reset", fqdn],'
+        ' capture_output=True, text=True, check=False\n'
+        ')\n'
+    )
+    assert _appels_sudo_captures_sans_n(fautif) == [1]
+
+    corrige = 'res = subprocess.run(["sudo", "-n", "virsh", "reset"], capture_output=True)'
+    assert _appels_sudo_captures_sans_n(corrige) == []
+
+    interactif = 'preauth = subprocess.run(["sudo", "-v"], check=False)'
+    assert _appels_sudo_captures_sans_n(interactif) == []

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "dsoxlab"
-version = "0.1.74"
+version = "0.1.75"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
# Summary

Le contrôle du pool libvirt rendait `ok` quand **sa sonde échouait** : ne pas
savoir y valait « tout va bien ». Aggravant, la sonde invoquait `virsh` en
direct, sans la détection de préfixe `sudo -n` que `infra/libvirt.py` a
précisément construite pour ce cas. Sur une machine où l'URI système exige des
droits, elle échouait donc **toujours**, et le contrôle était **toujours** vert.

**L'hypothèse de #172 sur `_check_kvm` est confirmée.** Il sondait
`virsh version` **sans `--connect`**, alors que `libvirt.py` documente déjà que
`virsh` sans `--connect` peut viser l'URI **session** selon la distribution. Un
utilisateur hors du groupe `libvirt` avait donc « KVM ✔ OK » pendant que
`provision`, qui vise l'URI **système**, mourait sur `Pool not found`. Les deux
sondes passent désormais par `run_virsh`, qui porte le `--connect` et la
détection du préfixe.

Une sonde impossible rend maintenant `unknown` — le jeton livré en 0.1.73, dont
la docstring citait déjà ce pool comme le défaut à corriger. Cas ajouté au
passage : **première sonde réussie mais seconde impossible vaut `unknown`
aussi**, parce que proposer « créer » ou « démarrer » au hasard ferait échouer
la remédiation.

Côté #173, les trois `sudo virsh` restants passent par `run_virsh`. Le `-n`
n'est pas un détail de style : la sortie est **capturée**, donc un prompt `sudo`
n'a aucun terminal où s'afficher, et l'appel **pend**. Un bail DHCP refusé
remonte désormais à l'écran (`ProvisionResult.warnings`) au lieu d'un journal
que personne ne lit — c'est ce qui faisait échouer un hôte en « injoignable »
sans cause visible.

**Un écart assumé, et il est motivé.** Le garde-fou vise les `sudo` qui
**capturent leur sortie** sans `-n`, pas tout `sudo` : le `sudo -v` de
pré-authentification de `doctor --fix` est délibérément interactif, sa sortie
n'est pas capturée, et son prompt a bien un terminal. C'est la **capture** sans
`-n` qui produit la pendaison, pas `sudo` lui-même.

Au passage, tout `OSError` de `run_command` devient un `CommandError` : un
binaire qui disparaît entre le `which` et l'appel ne fait plus planter un
diagnostic sur une trace Python.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` passes — « All checks passed! »
- [x] `uv run mypy src/dsoxlab` passes (strict) — no issues found in 79 source files
- [x] `uv run pytest` passes — **778 passed**, dont **13 neufs**, chacun éprouvé par mutation (neutraliser la correction → rouge → restaurer)
- [x] `uv run pytest tests_e2e` passes — **18 passed**
- [x] The engine stays domain-agnostic — les sondes ne connaissent que `virsh`, `run_virsh` et l'URI ; aucun nom de domaine ajouté
- [x] No hardcoded personal path or host; `pathlib.Path` throughout
- [x] Manually tested against **two** lab repositories : `ansible-training` (bloc `infra:`, provider kvm actif → sondes en **requis**) et `terraform-training` (**aucun bloc `infra:`** → `virsh/KVM` reste **informatif**, ce qui est l'invariant que ce dépôt sert à attraper)

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] Version bumped in `pyproject.toml` (0.1.74 → **0.1.75**) and `uv.lock` refreshed

### When a command or option is added, removed or changed

- [x] Keys added to **both** `i18n/strings/en.py` and `i18n/strings/fr.py` (état `unknown` du pool, avertissements de baux DHCP)
- [x] Aucune commande ni option ajoutée, supprimée ou renommée : `fullhelp` est inchangé et reste exact
- [x] Checked with `DSOXLAB_LANG=en` and `DSOXLAB_LANG=fr`

### When `.github/workflows/` is touched

N/A — aucun fichier de `.github/workflows/` n'est touché par cette PR.

### When the declarative contract (`meta.yml` / `lab.yaml`) changes

N/A — le contrat déclaratif est inchangé. Ni champ ajouté, ni sémantique
modifiée : le changement porte sur le **diagnostic** et sur l'**exécution** de
`virsh`, jamais sur ce qu'un dépôt de labs déclare.

## Related issues

Closes #172
Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)