### PR TITLE
chore(changelog): une seule version publiée, 0.1.84, plutôt que douze fantômes

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -11,329 +11,10 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [0.1.84] - 2026-08-24
 
-### Ajouté
-
-- **`doctor` contrôle désormais le pool de stockage Incus**
-  (linux-dsoxlab-training#54). Un utilisateur a signalé que sur un
-  provisionnement Incus raté, « seules les résolutions liées à KVM sont
-  proposées ». Le symptôme avait raison et l'hypothèse la plus évidente avait
-  tort : `_check_incus` **propose bien** `incus admin init` — mais seulement
-  quand `incus list` échoue en le disant. Or `incus list` **réussit** sur une
-  installation jamais initialisée : elle rend simplement une liste vide. Le
-  contrôle passait au vert, et la branche Incus de `doctor` n'ajoutait que
-  l'outil ISO, là où la branche KVM contrôle son pool depuis longtemps. Le
-  template crée le réseau mais écrit `pool = "default"` en dur sans le créer.
-
-## [0.1.83] - 2026-08-24
-
-### Modifié
-
-- **Le journal parle désormais une seule langue, et c'est l'anglais**
-  (issue #140). Il mélangeait le français et l'anglais, ce qui n'est pas une
-  question de goût : c'est le fichier que `dsoxlab support` collecte et qu'un
-  utilisateur colle dans un rapport de bug. Mesuré avant d'être corrigé —
-  **41 messages français contre 4 anglais**.
-
-  Les appels `logger.*` restent **délibérément hors** du garde-fou i18n : un
-  message de journal n'est pas un texte d'interface, il ne passe par `_()` nulle
-  part, et le traduire à l'exécution rendrait deux rapports de bug incomparables
-  selon la locale de qui les produit. Cette exclusion justifiait de ne pas le
-  *traduire*, pas de le laisser incohérent.
-
-  L'anglais l'emporte pour trois raisons : un message de journal se cherche
-  **mot pour mot** dans un moteur de recherche, il se compare entre deux
-  machines aux locales différentes, et il est lu par quelqu'un qui diagnostique
-  — à côté des sorties de terraform, ansible et virsh, qui sont déjà anglaises.
-
-  La règle est écrite là où un contributeur la rencontre (le gabarit de PR) et
-  tenue par `test_journal_en_anglais.py`. Sans test, elle se redéferait ligne
-  par ligne, ce qui est exactement ce qui est arrivé à l'interface avant que son
-  propre garde-fou n'existe.
-
-
-## [0.1.82] - 2026-08-24
-
-### Corrigé
-
-- **Un test à conteneur réel ne peut plus démarrer sans sonde de disponibilité**
-  (issue #155). Deux tests de `test_services.py` échouaient par intermittence,
-  toujours sous charge, jamais au repos. Leur point commun : ils attendaient un
-  **vrai** conteneur. Sans sonde, `start` rend la main dès que `docker run` a
-  répondu, ce qui ne dit rien de l'état du service à l'intérieur — l'étape
-  suivante devient une course, gagnée au repos et perdue sous charge.
-
-  L'instabilité elle-même ne se reproduit plus : mesuré sous charge Docker
-  soutenue, 12 exécutions ciblées et 4 suites complètes, aucun échec. Ce qui est
-  ajouté est un garde-fou contre la **régression** de la correction, avec des
-  exemptions nommées une par une et motivées — un test dont le conteneur meurt
-  par conception ne peut pas porter de sonde, et l'exiger transformerait le
-  garde-fou en obstacle.
-
-- **`test_post_start_en_echec_reel_leve_service_error` passait pour la mauvaise
-  raison.** Sans sonde, le `ServiceError` qu'il attend pouvait venir du
-  conteneur pas encore prêt à recevoir un `docker exec`, plutôt que de la
-  commande en échec qu'il prétend prouver. Il déclare désormais une sonde et
-  vérifie que l'erreur nomme la commande fautive.
-
-
-## [0.1.81] - 2026-08-24
-
-### Corrigé
-
-- **Un cloud-init qui a mal fini le dit désormais** (issue #178).
-  `wait_for_hosts_ready` jouait `cloud-init status --wait >/dev/null 2>&1 ||
-  true` : l'état **et** le code de retour partaient tous les deux à la poubelle.
-  Hors ligne, derrière un proxy ou sur un miroir lent, les quinze paquets du
-  premier démarrage ne s'installent pas, cloud-init finit en `degraded`, et
-  l'hôte était **tout de même déclaré prêt** — les labs échouaient ensuite sur
-  des commandes absentes, sans que rien ne relie les deux. Ne pas bloquer reste
-  la bonne décision : ce qui compte pour rendre la main, c'est que cloud-init
-  ait *terminé*. Mais terminer mal doit se dire.
-
-### Ajouté
-
-- **`doctor` gagne un contrôle `egress`.** Le provisionnement télécharge une
-  image, puis cloud-init installe des paquets : sans accès sortant, les deux
-  échouent. Les miroirs sondés sont **lus dans les templates packagés**, jamais
-  écrits dans le moteur, et un seul miroir joignable suffit à conclure — ce qui
-  est en cause est l'accès sortant lui-même, pas la disponibilité d'un miroir.
-  Requis sur un dépôt qui provisionne des VM, informatif sinon.
-
-### Documentation
-
-- **La décision sur les paquets du premier démarrage est écrite**, dans
-  `templates/cloud-init/README.md`. Bloquer sur un `degraded` a été écarté :
-  cloud-init rend un état global, et traiterait donc un `tree` absent comme un
-  `lvm2` absent. Les images pré-cuites sont la vraie réponse, mais un projet à
-  part entière. Déclarer les paquets lab par lab changerait le contrat v1, gelé.
-  Ce qui est retenu, c'est de rendre l'échec visible aux trois moments qui
-  comptent : avant, pendant, et dans le message qui nomme l'hôte.
-
-
-## [0.1.80] - 2026-08-24
-
-### Ajouté
-
-- **La CI valide les trois templates Terraform packagés** (issue #175). Le
-  pipeline couvrait le lint, mypy, les tests unitaires, le fuzzing et une suite
-  e2e sur la roue installée — mais ne jouait **aucun `terraform validate` nulle
-  part**, aucun provisionnement, et sa suite e2e ne joue que le lab de
-  démonstration, qui est `shell`. Les templates sont épinglés en `~> 0.9` (kvm)
-  et `~> 0.3` (incus) : une version mineure du provider peut casser le schéma,
-  et le dépôt a déjà vécu ce cas. Les tests unitaires existants sur ces
-  templates vérifient qu'un fichier contient une chaîne, pas que Terraform sait
-  le lire : une régression de template ne se découvrait donc que chez un
-  apprenant, en langage Terraform.
-
-  Le job joue `terraform init -backend=false` puis `terraform validate` sur kvm,
-  incus et outscale, collecte **tous** les échecs plutôt que de s'arrêter au
-  premier, nomme le provider fautif via `::error::`, et fait échouer la
-  construction. Terraform vient de l'archive de l'éditeur avec la somme de
-  contrôle qu'il publie, sur le patron déjà utilisé pour poutine — aucune action
-  tierce n'est ajoutée à la chaîne d'approvisionnement.
-
-### Documentation
-
-- **La décision sur les images amont est désormais écrite**, dans
-  `templates/terraform/README.md`. Les sept URL d'images pointent des chemins
-  mutables (`latest` / `current`), et c'est un choix : une somme épinglée que
-  personne ne tient à jour servirait aux apprenants une image de plus en plus
-  périmée, avec ses vulnérabilités connues — le durcissement deviendrait le
-  vecteur du problème qu'il prétend traiter. Les raisons qui rendent le risque
-  acceptable ici, et les conditions qui inverseraient la décision, sont
-  explicitées.
-
-
-## [0.1.79] - 2026-08-24
-
-### Ajouté
-
-- **`doctor --strict` traduit le diagnostic en code de sortie** (issue #176).
-  `doctor` sortait en 0 quel que soit l'état de ses contrôles, ce qui est le bon
-  choix pour un humain — un diagnostic n'est pas un échec — mais rendait la
-  commande inutilisable comme portail automatisé : un script devait analyser le
-  JSON pour savoir si quelque chose manquait.
-
-  Deux codes plutôt qu'un, parce que les deux situations appellent des gestes
-  différents :
-
-  | Mode | Code | Quand |
-  | --- | --- | --- |
-  | `doctor` | `0` | toujours, inchangé |
-  | `doctor --strict` | `9` | un contrôle requis a échoué |
-  | `doctor --strict` | `10` | un contrôle requis n'a pas pu être mesuré |
-
-  `9` se répare, `10` se remesure. Un environnement dont une sonde n'a pas
-  abouti n'est pas validé pour autant — c'est précisément ce qu'une construction
-  d'image ne doit pas confondre avec un succès. `9` l'emporte quand les deux
-  coexistent : une certitude est plus forte qu'une ignorance.
-
-  Le comportement par défaut ne bouge pas, et `--strict` ne change rien d'autre :
-  le tableau et le document restent rendus, **avant** que le code ne tombe, pour
-  qu'un appelant recevant un code non nul puisse encore lire ce qui n'allait pas.
-
-
-## [0.1.78] - 2026-08-24
-
-### Corrigé
-
-- **Un lab dont le moteur de conteneurs est injoignable ne s'affiche plus
-  « prêt »** (issue #179). `_services_degrades` rendait une liste vide quand
-  `docker_available()` était faux : « Docker **était** là et son démon est
-  tombé » devenait donc indistinguable de « Docker n'a jamais été installé ».
-  Dans le premier cas le lab est bel et bien injouable — `run` y échoue déjà
-  explicitement, code 2 — et pourtant `status` annonçait `ready`, voire
-  `validated` lorsqu'une note existait d'une session précédente.
-- Les deux causes se distinguent désormais, parce qu'elles appellent des gestes
-  opposés : installer un paquet, ou démarrer un démon et vérifier que le compte
-  peut lui parler. Un lab qui ne déclare **aucun** service continue d'ignorer le
-  moteur, sans même payer une sonde — c'était la moitié juste de la décision
-  d'origine, elle est gardée et testée pour elle-même.
-
-
-## [0.1.77] - 2026-08-24
-
-### Corrigé
-
-- **`run_command(check=False)` tient enfin sa promesse** (issue #174). Un
-  binaire absent, un délai dépassé ou toute autre `OSError` levait une
-  `CommandError` *quelles que soient les options* : tout appelant qui croyait
-  recevoir un `CommandResult` en toutes circonstances se trompait — et le nom du
-  paramètre l'encourageait à le croire. Deux victimes, mesurées par exécution
-  avant d'être corrigées : `dsoxlab catalog add` sortait en trace Python sur un
-  poste sans git, ce qui est la deuxième commande du parcours d'accueil ; et une
-  sonde qui expirait faisait sauter la boucle de réessai **entière** au lieu
-  d'être comptée comme un échec à réessayer.
-- **Une clé i18n manquante ne parvient plus brute à l'utilisateur.** `_()` rend
-  la clé elle-même quand elle n'est pas définie : une clé posée dans le code
-  mais pas dans les dictionnaires s'affichait donc `catalog_git_absent`. Un
-  garde-fou existait, mais s'arrêtait à `validators/` et `models/` ; il couvre
-  désormais tout appel `_("…")` littéral du paquet, dans les deux langues.
-
-### Ajouté
-
-- **`git` et `docker` sont des contrôles de `doctor`.** Aucun des deux n'est une
-  dépendance Python — `uv tool install` n'apporte ni l'un ni l'autre — et aucun
-  n'était déclaré nulle part. `git` est requis partout, puisque `catalog add`
-  clone. `docker`, lui, suit ce que le catalogue déclare : requis dès qu'un lab
-  déclare `runtime.services`, informatif sinon, pour qu'un dépôt qui ne s'en
-  sert pas n'en voie jamais de rouge.
-- **`CommandResult.failure`** nomme *pourquoi* une commande n'a pas pu tourner
-  (`not_found`, `timeout`, `os_error`), séparément d'un code de retour non nul.
-  Les deux appellent des gestes opposés — lire stderr, ou installer un paquet et
-  réessayer — et un appelant qui ne regardait que `returncode` les confondait.
-
-### Modifié
-
-- **Le tirage d'une image est désormais distinct du démarrage d'un conteneur.**
-  Le premier `docker run` tirait l'image dans son propre budget de 180 secondes :
-  au-delà, la commande échouait sur un message de démarrage qui ne parlait pas du
-  réseau ; en deçà, `run` pendait plusieurs minutes sans dire pourquoi. Le tirage
-  a maintenant son propre délai et s'annonce, et il est sauté si l'image est déjà
-  locale.
-
-
-## [0.1.76] - 2026-08-24
-
-### Corrigé
-
-- **Une fixture qui ne peut pas être copiée ne laisse plus un répertoire de
-  travail vide en silence** (issue #177). `ShellRuntime` itère sur
-  `runtime.fixtures`, pas sur le contenu de `fixtures/` : les deux écarts
-  possibles produisaient donc le même dégât, sans un mot. Une fixture *déclarée
-  mais absente du disque* partait en `logger.warning`, une fixture *présente
-  mais non déclarée* n'était jamais lue. Dans les deux cas `dsoxlab run` créait
-  un `challenge/work` vide, sortait en **0**, et l'apprenant n'avait rien à
-  faire. C'est le défaut qui a rendu **7 labs de `terraform-training`
-  injouables le 2026-07-28**, tous marqués faits — et il se cachait d'autant
-  mieux que les outils de vérification des corrigés copient, eux, le répertoire
-  entier : la solution passait au vert pendant que le parcours apprenant était
-  cassé.
-
-### Ajouté
-
-- **`validate-structure` compare désormais `fixtures/` à la déclaration**, dans
-  les deux sens : déclarée mais absente, présente mais non déclarée, et chemin
-  qui sort du workdir. Le contrôle est dans le lot par défaut (hors ligne), si
-  bien que la CI d'un catalogue attrape la faute avant un apprenant. Les
-  fichiers cachés en sont exemptés : un `.gitkeep` sert à versionner un
-  répertoire vide, et le signaler serait un faux positif que chaque auteur
-  apprendrait à ignorer.
-
-### Modifié
-
-- **Une fixture qui ne peut pas être copiée fait maintenant échouer `run`, au
-  lieu d'être ignorée.** C'est le renversement d'une décision antérieure —
-  qu'une faute de frappe dans une entrée ne devait pas priver l'apprenant de
-  tout son workdir. C'est le fichier manquant qui l'en prive : une erreur
-  d'auteur n'est pas quelque chose qu'il peut réparer, et un exercice amputé
-  échoue au `check` pour des raisons qu'il cherchera dans son propre travail.
-  La validation précède toute copie, donc c'est tout ou rien : un workdir à
-  moitié rempli a l'air de marcher. Toutes les fixtures fautives sont nommées
-  d'un coup, pour que l'auteur corrige en une passe plutôt qu'en autant de
-  `run` qu'il a de fixtures.
-
-
-## [0.1.75] - 2026-08-24
-
-### Corrigé
-
-- **Le contrôle du pool libvirt concluait « vert » quand il n'avait pas pu
-  regarder** (issue #172). La sonde invoquait `virsh -c qemu:///system` en
-  direct, sans la détection du préfixe `sudo -n` que `infra/libvirt.py` a
-  construite pour ce cas : sur toute machine où l'URI système exige des
-  droits, la sonde échouait à chaque fois, et cet échec était rendu `ok`, un
-  contrôle vert en permanence précisément là où `provision` allait mourir sur
-  « Pool Not Found ». La sonde passe désormais par `run_virsh`, et une sonde
-  qui ne peut pas mesurer rend `state: unknown` (introduit en 0.1.73), qui ne
-  peint le verdict ni en vert ni en rouge. `_check_kvm` interroge aussi
-  explicitement l'**URI système** : un `virsh version` nu peut viser l'URI
-  session selon la distribution, et répondre parfaitement à un utilisateur que
-  l'URI système refuse.
-
-- **Trois `sudo virsh` bruts sans `-n` pouvaient pendre ou échouer en
-  silence** (issue #173). `_ensure_kvm_dhcp_leases` (deux occurrences) et
-  `_reset_kvm_domain` capturaient leur sortie : un prompt de mot de passe sudo
-  n'avait aucun terminal où s'afficher et l'appel restait pendu ; sur une
-  machine configurée par le groupe `libvirt` sans droits sudo, le bail DHCP
-  n'était jamais posé et l'échec partait dans un journal que personne ne lit,
-  l'hôte mourant plus tard en « injoignable » sans cause visible. Les trois
-  appels passent désormais par `run_virsh` (chemin détecté, URI système,
-  jamais de prompt), et un bail refusé s'affiche **à l'écran** pendant
-  `provision`, pas seulement au journal. Un test garde-fou refuse désormais
-  tout `subprocess.run(["sudo", …])` qui capture sa sortie sans `-n` dans
-  `src/dsoxlab/`, sur le modèle du garde-fou anti-`shell=True` de 0.1.70.
-
-- `run_command` convertit désormais tout `OSError` en `CommandError` au lieu
-  de laisser un binaire qui disparaît en cours de route faire planter
-  l'appelant : un diagnostic ne doit pas mourir en diagnostiquant.
-
-## [0.1.74] - 2026-08-24
-
-### Corrigé
-
-- **`provision` annonçait un succès après avoir renoncé à attendre des hôtes qui
-  ne répondaient pas** (issue #170). Un délai dépassé n'était qu'un
-  avertissement ; la commande affichait ensuite « ✔ N hôtes provisionnés » et
-  sortait en 0. L'infrastructure existait mais n'était pas utilisable, et le
-  `run` suivant échouait en « unreachable » sans lien visible avec la cause.
-  Tout script qui teste le code de retour était aveugle — y compris la
-  construction d'une image prête à l'emploi, qui devra s'y fier. Un code de
-  sortie dédié (`8`) le dit désormais, aux côtés de ceux des orphelins.
-
-- **`check --json` était pollué dès qu'un lab déclarait des services** (issue
-  #171). `_valider` ne propageait pas `quiet` à `_ensure_services`, dont les
-  messages de progression partaient sur la sortie standard : `dsoxlab check
-  --json | jq` échouait sur tout lab de ce type. C'était le défaut corrigé en
-  0.1.23, revenu par une porte latérale.
-
-  `quiet` ne fait taire que **le progrès**. Les erreurs continuent de partir sur
-  la sortie d'erreur dans les deux modes : un service qui refuse de démarrer
-  doit rester audible, sans quoi `--json` masquerait la seule information qui
-  compte.
-
-
-## [0.1.73] - 2026-08-24
+Cette version clôt l'audit des angles morts. Son contenu a été développé
+sous les numéros 0.1.73 à 0.1.83, mergés le même jour et publiés ici d'un
+seul tenant — ces numéros n'ont jamais été tagués, donc rien n'a jamais été
+installable sous eux.
 
 ### Ajouté
 
@@ -368,6 +49,269 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
   rassurant d'un « ok » non mérité, ni le rouge accusateur d'une panne non
   prouvée. Le jeton est exposé par `doctor --json` et rendu « ? non mesuré » ;
   il ne peint jamais le verdict global en rouge.
+
+- **`validate-structure` compare désormais `fixtures/` à la déclaration**, dans
+  les deux sens : déclarée mais absente, présente mais non déclarée, et chemin
+  qui sort du workdir. Le contrôle est dans le lot par défaut (hors ligne), si
+  bien que la CI d'un catalogue attrape la faute avant un apprenant. Les
+  fichiers cachés en sont exemptés : un `.gitkeep` sert à versionner un
+  répertoire vide, et le signaler serait un faux positif que chaque auteur
+  apprendrait à ignorer.
+
+- **`git` et `docker` sont des contrôles de `doctor`.** Aucun des deux n'est une
+  dépendance Python — `uv tool install` n'apporte ni l'un ni l'autre — et aucun
+  n'était déclaré nulle part. `git` est requis partout, puisque `catalog add`
+  clone. `docker`, lui, suit ce que le catalogue déclare : requis dès qu'un lab
+  déclare `runtime.services`, informatif sinon, pour qu'un dépôt qui ne s'en
+  sert pas n'en voie jamais de rouge.
+- **`CommandResult.failure`** nomme *pourquoi* une commande n'a pas pu tourner
+  (`not_found`, `timeout`, `os_error`), séparément d'un code de retour non nul.
+  Les deux appellent des gestes opposés — lire stderr, ou installer un paquet et
+  réessayer — et un appelant qui ne regardait que `returncode` les confondait.
+
+- **`doctor --strict` traduit le diagnostic en code de sortie** (issue #176).
+  `doctor` sortait en 0 quel que soit l'état de ses contrôles, ce qui est le bon
+  choix pour un humain — un diagnostic n'est pas un échec — mais rendait la
+  commande inutilisable comme portail automatisé : un script devait analyser le
+  JSON pour savoir si quelque chose manquait.
+
+  Deux codes plutôt qu'un, parce que les deux situations appellent des gestes
+  différents :
+
+  | Mode | Code | Quand |
+  | --- | --- | --- |
+  | `doctor` | `0` | toujours, inchangé |
+  | `doctor --strict` | `9` | un contrôle requis a échoué |
+  | `doctor --strict` | `10` | un contrôle requis n'a pas pu être mesuré |
+
+  `9` se répare, `10` se remesure. Un environnement dont une sonde n'a pas
+  abouti n'est pas validé pour autant — c'est précisément ce qu'une construction
+  d'image ne doit pas confondre avec un succès. `9` l'emporte quand les deux
+  coexistent : une certitude est plus forte qu'une ignorance.
+
+  Le comportement par défaut ne bouge pas, et `--strict` ne change rien d'autre :
+  le tableau et le document restent rendus, **avant** que le code ne tombe, pour
+  qu'un appelant recevant un code non nul puisse encore lire ce qui n'allait pas.
+
+- **La CI valide les trois templates Terraform packagés** (issue #175). Le
+  pipeline couvrait le lint, mypy, les tests unitaires, le fuzzing et une suite
+  e2e sur la roue installée — mais ne jouait **aucun `terraform validate` nulle
+  part**, aucun provisionnement, et sa suite e2e ne joue que le lab de
+  démonstration, qui est `shell`. Les templates sont épinglés en `~> 0.9` (kvm)
+  et `~> 0.3` (incus) : une version mineure du provider peut casser le schéma,
+  et le dépôt a déjà vécu ce cas. Les tests unitaires existants sur ces
+  templates vérifient qu'un fichier contient une chaîne, pas que Terraform sait
+  le lire : une régression de template ne se découvrait donc que chez un
+  apprenant, en langage Terraform.
+
+  Le job joue `terraform init -backend=false` puis `terraform validate` sur kvm,
+  incus et outscale, collecte **tous** les échecs plutôt que de s'arrêter au
+  premier, nomme le provider fautif via `::error::`, et fait échouer la
+  construction. Terraform vient de l'archive de l'éditeur avec la somme de
+  contrôle qu'il publie, sur le patron déjà utilisé pour poutine — aucune action
+  tierce n'est ajoutée à la chaîne d'approvisionnement.
+
+- **`doctor` gagne un contrôle `egress`.** Le provisionnement télécharge une
+  image, puis cloud-init installe des paquets : sans accès sortant, les deux
+  échouent. Les miroirs sondés sont **lus dans les templates packagés**, jamais
+  écrits dans le moteur, et un seul miroir joignable suffit à conclure — ce qui
+  est en cause est l'accès sortant lui-même, pas la disponibilité d'un miroir.
+  Requis sur un dépôt qui provisionne des VM, informatif sinon.
+
+- **`doctor` contrôle désormais le pool de stockage Incus**
+  (linux-dsoxlab-training#54). Un utilisateur a signalé que sur un
+  provisionnement Incus raté, « seules les résolutions liées à KVM sont
+  proposées ». Le symptôme avait raison et l'hypothèse la plus évidente avait
+  tort : `_check_incus` **propose bien** `incus admin init` — mais seulement
+  quand `incus list` échoue en le disant. Or `incus list` **réussit** sur une
+  installation jamais initialisée : elle rend simplement une liste vide. Le
+  contrôle passait au vert, et la branche Incus de `doctor` n'ajoutait que
+  l'outil ISO, là où la branche KVM contrôle son pool depuis longtemps. Le
+  template crée le réseau mais écrit `pool = "default"` en dur sans le créer.
+
+### Modifié
+
+- **Une fixture qui ne peut pas être copiée fait maintenant échouer `run`, au
+  lieu d'être ignorée.** C'est le renversement d'une décision antérieure —
+  qu'une faute de frappe dans une entrée ne devait pas priver l'apprenant de
+  tout son workdir. C'est le fichier manquant qui l'en prive : une erreur
+  d'auteur n'est pas quelque chose qu'il peut réparer, et un exercice amputé
+  échoue au `check` pour des raisons qu'il cherchera dans son propre travail.
+  La validation précède toute copie, donc c'est tout ou rien : un workdir à
+  moitié rempli a l'air de marcher. Toutes les fixtures fautives sont nommées
+  d'un coup, pour que l'auteur corrige en une passe plutôt qu'en autant de
+  `run` qu'il a de fixtures.
+
+- **Le tirage d'une image est désormais distinct du démarrage d'un conteneur.**
+  Le premier `docker run` tirait l'image dans son propre budget de 180 secondes :
+  au-delà, la commande échouait sur un message de démarrage qui ne parlait pas du
+  réseau ; en deçà, `run` pendait plusieurs minutes sans dire pourquoi. Le tirage
+  a maintenant son propre délai et s'annonce, et il est sauté si l'image est déjà
+  locale.
+
+- **Le journal parle désormais une seule langue, et c'est l'anglais**
+  (issue #140). Il mélangeait le français et l'anglais, ce qui n'est pas une
+  question de goût : c'est le fichier que `dsoxlab support` collecte et qu'un
+  utilisateur colle dans un rapport de bug. Mesuré avant d'être corrigé —
+  **41 messages français contre 4 anglais**.
+
+  Les appels `logger.*` restent **délibérément hors** du garde-fou i18n : un
+  message de journal n'est pas un texte d'interface, il ne passe par `_()` nulle
+  part, et le traduire à l'exécution rendrait deux rapports de bug incomparables
+  selon la locale de qui les produit. Cette exclusion justifiait de ne pas le
+  *traduire*, pas de le laisser incohérent.
+
+  L'anglais l'emporte pour trois raisons : un message de journal se cherche
+  **mot pour mot** dans un moteur de recherche, il se compare entre deux
+  machines aux locales différentes, et il est lu par quelqu'un qui diagnostique
+  — à côté des sorties de terraform, ansible et virsh, qui sont déjà anglaises.
+
+  La règle est écrite là où un contributeur la rencontre (le gabarit de PR) et
+  tenue par `test_journal_en_anglais.py`. Sans test, elle se redéferait ligne
+  par ligne, ce qui est exactement ce qui est arrivé à l'interface avant que son
+  propre garde-fou n'existe.
+
+### Corrigé
+
+- **`provision` annonçait un succès après avoir renoncé à attendre des hôtes qui
+  ne répondaient pas** (issue #170). Un délai dépassé n'était qu'un
+  avertissement ; la commande affichait ensuite « ✔ N hôtes provisionnés » et
+  sortait en 0. L'infrastructure existait mais n'était pas utilisable, et le
+  `run` suivant échouait en « unreachable » sans lien visible avec la cause.
+  Tout script qui teste le code de retour était aveugle — y compris la
+  construction d'une image prête à l'emploi, qui devra s'y fier. Un code de
+  sortie dédié (`8`) le dit désormais, aux côtés de ceux des orphelins.
+
+- **`check --json` était pollué dès qu'un lab déclarait des services** (issue
+  #171). `_valider` ne propageait pas `quiet` à `_ensure_services`, dont les
+  messages de progression partaient sur la sortie standard : `dsoxlab check
+  --json | jq` échouait sur tout lab de ce type. C'était le défaut corrigé en
+  0.1.23, revenu par une porte latérale.
+
+  `quiet` ne fait taire que **le progrès**. Les erreurs continuent de partir sur
+  la sortie d'erreur dans les deux modes : un service qui refuse de démarrer
+  doit rester audible, sans quoi `--json` masquerait la seule information qui
+  compte.
+
+- **Le contrôle du pool libvirt concluait « vert » quand il n'avait pas pu
+  regarder** (issue #172). La sonde invoquait `virsh -c qemu:///system` en
+  direct, sans la détection du préfixe `sudo -n` que `infra/libvirt.py` a
+  construite pour ce cas : sur toute machine où l'URI système exige des
+  droits, la sonde échouait à chaque fois, et cet échec était rendu `ok`, un
+  contrôle vert en permanence précisément là où `provision` allait mourir sur
+  « Pool Not Found ». La sonde passe désormais par `run_virsh`, et une sonde
+  qui ne peut pas mesurer rend `state: unknown` (introduit en 0.1.73), qui ne
+  peint le verdict ni en vert ni en rouge. `_check_kvm` interroge aussi
+  explicitement l'**URI système** : un `virsh version` nu peut viser l'URI
+  session selon la distribution, et répondre parfaitement à un utilisateur que
+  l'URI système refuse.
+
+- **Trois `sudo virsh` bruts sans `-n` pouvaient pendre ou échouer en
+  silence** (issue #173). `_ensure_kvm_dhcp_leases` (deux occurrences) et
+  `_reset_kvm_domain` capturaient leur sortie : un prompt de mot de passe sudo
+  n'avait aucun terminal où s'afficher et l'appel restait pendu ; sur une
+  machine configurée par le groupe `libvirt` sans droits sudo, le bail DHCP
+  n'était jamais posé et l'échec partait dans un journal que personne ne lit,
+  l'hôte mourant plus tard en « injoignable » sans cause visible. Les trois
+  appels passent désormais par `run_virsh` (chemin détecté, URI système,
+  jamais de prompt), et un bail refusé s'affiche **à l'écran** pendant
+  `provision`, pas seulement au journal. Un test garde-fou refuse désormais
+  tout `subprocess.run(["sudo", …])` qui capture sa sortie sans `-n` dans
+  `src/dsoxlab/`, sur le modèle du garde-fou anti-`shell=True` de 0.1.70.
+
+- `run_command` convertit désormais tout `OSError` en `CommandError` au lieu
+  de laisser un binaire qui disparaît en cours de route faire planter
+  l'appelant : un diagnostic ne doit pas mourir en diagnostiquant.
+
+- **Une fixture qui ne peut pas être copiée ne laisse plus un répertoire de
+  travail vide en silence** (issue #177). `ShellRuntime` itère sur
+  `runtime.fixtures`, pas sur le contenu de `fixtures/` : les deux écarts
+  possibles produisaient donc le même dégât, sans un mot. Une fixture *déclarée
+  mais absente du disque* partait en `logger.warning`, une fixture *présente
+  mais non déclarée* n'était jamais lue. Dans les deux cas `dsoxlab run` créait
+  un `challenge/work` vide, sortait en **0**, et l'apprenant n'avait rien à
+  faire. C'est le défaut qui a rendu **7 labs de `terraform-training`
+  injouables le 2026-07-28**, tous marqués faits — et il se cachait d'autant
+  mieux que les outils de vérification des corrigés copient, eux, le répertoire
+  entier : la solution passait au vert pendant que le parcours apprenant était
+  cassé.
+
+- **`run_command(check=False)` tient enfin sa promesse** (issue #174). Un
+  binaire absent, un délai dépassé ou toute autre `OSError` levait une
+  `CommandError` *quelles que soient les options* : tout appelant qui croyait
+  recevoir un `CommandResult` en toutes circonstances se trompait — et le nom du
+  paramètre l'encourageait à le croire. Deux victimes, mesurées par exécution
+  avant d'être corrigées : `dsoxlab catalog add` sortait en trace Python sur un
+  poste sans git, ce qui est la deuxième commande du parcours d'accueil ; et une
+  sonde qui expirait faisait sauter la boucle de réessai **entière** au lieu
+  d'être comptée comme un échec à réessayer.
+- **Une clé i18n manquante ne parvient plus brute à l'utilisateur.** `_()` rend
+  la clé elle-même quand elle n'est pas définie : une clé posée dans le code
+  mais pas dans les dictionnaires s'affichait donc `catalog_git_absent`. Un
+  garde-fou existait, mais s'arrêtait à `validators/` et `models/` ; il couvre
+  désormais tout appel `_("…")` littéral du paquet, dans les deux langues.
+
+- **Un lab dont le moteur de conteneurs est injoignable ne s'affiche plus
+  « prêt »** (issue #179). `_services_degrades` rendait une liste vide quand
+  `docker_available()` était faux : « Docker **était** là et son démon est
+  tombé » devenait donc indistinguable de « Docker n'a jamais été installé ».
+  Dans le premier cas le lab est bel et bien injouable — `run` y échoue déjà
+  explicitement, code 2 — et pourtant `status` annonçait `ready`, voire
+  `validated` lorsqu'une note existait d'une session précédente.
+- Les deux causes se distinguent désormais, parce qu'elles appellent des gestes
+  opposés : installer un paquet, ou démarrer un démon et vérifier que le compte
+  peut lui parler. Un lab qui ne déclare **aucun** service continue d'ignorer le
+  moteur, sans même payer une sonde — c'était la moitié juste de la décision
+  d'origine, elle est gardée et testée pour elle-même.
+
+- **Un cloud-init qui a mal fini le dit désormais** (issue #178).
+  `wait_for_hosts_ready` jouait `cloud-init status --wait >/dev/null 2>&1 ||
+  true` : l'état **et** le code de retour partaient tous les deux à la poubelle.
+  Hors ligne, derrière un proxy ou sur un miroir lent, les quinze paquets du
+  premier démarrage ne s'installent pas, cloud-init finit en `degraded`, et
+  l'hôte était **tout de même déclaré prêt** — les labs échouaient ensuite sur
+  des commandes absentes, sans que rien ne relie les deux. Ne pas bloquer reste
+  la bonne décision : ce qui compte pour rendre la main, c'est que cloud-init
+  ait *terminé*. Mais terminer mal doit se dire.
+
+- **Un test à conteneur réel ne peut plus démarrer sans sonde de disponibilité**
+  (issue #155). Deux tests de `test_services.py` échouaient par intermittence,
+  toujours sous charge, jamais au repos. Leur point commun : ils attendaient un
+  **vrai** conteneur. Sans sonde, `start` rend la main dès que `docker run` a
+  répondu, ce qui ne dit rien de l'état du service à l'intérieur — l'étape
+  suivante devient une course, gagnée au repos et perdue sous charge.
+
+  L'instabilité elle-même ne se reproduit plus : mesuré sous charge Docker
+  soutenue, 12 exécutions ciblées et 4 suites complètes, aucun échec. Ce qui est
+  ajouté est un garde-fou contre la **régression** de la correction, avec des
+  exemptions nommées une par une et motivées — un test dont le conteneur meurt
+  par conception ne peut pas porter de sonde, et l'exiger transformerait le
+  garde-fou en obstacle.
+
+- **`test_post_start_en_echec_reel_leve_service_error` passait pour la mauvaise
+  raison.** Sans sonde, le `ServiceError` qu'il attend pouvait venir du
+  conteneur pas encore prêt à recevoir un `docker exec`, plutôt que de la
+  commande en échec qu'il prétend prouver. Il déclare désormais une sonde et
+  vérifie que l'erreur nomme la commande fautive.
+
+### Documentation
+
+- **La décision sur les images amont est désormais écrite**, dans
+  `templates/terraform/README.md`. Les sept URL d'images pointent des chemins
+  mutables (`latest` / `current`), et c'est un choix : une somme épinglée que
+  personne ne tient à jour servirait aux apprenants une image de plus en plus
+  périmée, avec ses vulnérabilités connues — le durcissement deviendrait le
+  vecteur du problème qu'il prétend traiter. Les raisons qui rendent le risque
+  acceptable ici, et les conditions qui inverseraient la décision, sont
+  explicitées.
+
+- **La décision sur les paquets du premier démarrage est écrite**, dans
+  `templates/cloud-init/README.md`. Bloquer sur un `degraded` a été écarté :
+  cloud-init rend un état global, et traiterait donc un `tree` absent comme un
+  `lvm2` absent. Les images pré-cuites sont la vraie réponse, mais un projet à
+  part entière. Déclarer les paquets lab par lab changerait le contrat v1, gelé.
+  Ce qui est retenu, c'est de rendre l'échec visible aux trois moments qui
+  comptent : avant, pendant, et dans le message qui nomme l'hôte.
 
 ## [0.1.72] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,311 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.84] - 2026-08-24
 
-### Added
-
-- **`doctor` now checks the Incus storage pool**
-  (linux-dsoxlab-training#54). A user reported that on a failed Incus
-  provisioning, "only the KVM-related fixes are offered". The symptom was right
-  and the obvious hypothesis wrong: `_check_incus` *does* offer `incus admin
-  init` — but only when `incus list` fails saying so. `incus list` **succeeds**
-  on a never-initialised install: it simply returns an empty list. The check
-  passed green, and the Incus branch of `doctor` only added the ISO tool, where
-  the KVM branch has checked its storage pool for a long time. The template
-  creates the network but hard-codes `pool = "default"` without creating it.
-
-## [0.1.83] - 2026-08-24
-
-### Changed
-
-- **The log now speaks one language, and it is English** (issue #140). It mixed
-  French and English, which is not a matter of taste: this is the file
-  `dsoxlab support` collects and that a user pastes into a bug report. Measured
-  before being fixed — **41 French messages against 4 English ones**.
-
-  `logger.*` calls stay **deliberately outside** the i18n guard: a log line is
-  not interface text, it never goes through `_()`, and translating it at
-  runtime would make two bug reports incomparable depending on the locale of
-  whoever produced them. That exclusion justified not *translating* the log,
-  not leaving it incoherent.
-
-  English wins for three reasons: a log line gets searched **word for word**,
-  it gets compared between machines with different locales, and it is read by
-  someone diagnosing — next to the output of terraform, ansible and virsh,
-  which is already English.
-
-  The rule is written where a contributor meets it (the PR template) and held
-  by `test_journal_en_anglais.py`. Without a test it would come undone line by
-  line, which is exactly what happened to the interface before its own guard
-  existed.
-
-
-## [0.1.82] - 2026-08-24
-
-### Fixed
-
-- **A real-container test can no longer start without a readiness probe**
-  (issue #155). Two tests of `test_services.py` failed intermittently, always
-  under load, never at rest. Their common trait: they waited for a **real**
-  container. Without a probe, `start` hands back control as soon as `docker
-  run` answers, which says nothing about the service inside — the next step
-  becomes a race, won at rest and lost under load.
-
-  The instability itself no longer reproduces: measured under sustained Docker
-  load, 12 targeted runs and 4 full suites, not one failure. What this adds is
-  a guard against the **regression** of the fix, with exemptions named one by
-  one and motivated — a test whose container dies on purpose cannot carry a
-  probe, and requiring one would turn the guard into an obstacle.
-
-- **`test_post_start_en_echec_reel_leve_service_error` was passing for the
-  wrong reason.** Without a probe, the `ServiceError` it expects could come
-  from the container not yet accepting a `docker exec`, rather than from the
-  failing command it means to prove. It now declares a probe and asserts that
-  the error names the offending command.
-
-
-## [0.1.81] - 2026-08-24
-
-### Fixed
-
-- **A cloud-init that finished badly now says so** (issue #178).
-  `wait_for_hosts_ready` ran `cloud-init status --wait >/dev/null 2>&1 || true`:
-  both the state *and* the return code went to the bin. Offline, behind a proxy
-  or on a slow mirror, the fifteen first-boot packages do not install,
-  cloud-init ends up `degraded`, and the host was **still declared ready** —
-  labs then failed on missing commands with nothing linking the two. Not
-  blocking remains the right call: what matters to hand back control is that
-  cloud-init has *finished*. But finishing badly must be said.
-
-### Added
-
-- **`doctor` gains an `egress` check.** Provisioning downloads an image, then
-  cloud-init installs packages: without outbound access both fail. The mirrors
-  it probes are **read from the packaged templates**, never written into the
-  engine, and a single reachable mirror is enough to conclude — what is at
-  stake is outbound access itself, not one mirror's availability. Required on a
-  repository that provisions VMs, informational otherwise.
-
-### Documentation
-
-- **The first-boot package decision is written down**, in
-  `templates/cloud-init/README.md`. Blocking on a `degraded` was rejected —
-  cloud-init reports a global state, so it would treat a missing `tree` like a
-  missing `lvm2`. Pre-baked images are the real answer but a project of their
-  own. Per-lab package declarations would change the frozen v1 contract. What
-  was retained is making the failure visible at the three moments that matter:
-  before, during, and in the message that names the host.
-
-
-## [0.1.80] - 2026-08-24
-
-### Added
-
-- **CI validates the three packaged Terraform templates** (issue #175). The
-  pipeline covered lint, mypy, unit tests, fuzzing and an e2e suite on the
-  installed wheel — but ran **no `terraform validate` anywhere**, no
-  provisioning, and its e2e suite only plays the demo lab, which is `shell`.
-  The templates are pinned to `~> 0.9` (kvm) and `~> 0.3` (incus): a minor
-  provider release can break the schema, and this repository has already lived
-  through it. The existing unit tests on those templates assert that a file
-  contains a string, not that Terraform can read it, so a template regression
-  was only ever discovered on a learner's machine, in Terraform's own language.
-
-  The job runs `terraform init -backend=false` then `terraform validate` on
-  kvm, incus and outscale, collects every failure rather than stopping at the
-  first, names the offending provider through `::error::`, and fails the build.
-  Terraform comes from the vendor's release archive with its published
-  checksum, following the pattern already used for poutine — no third-party
-  action is added to the supply chain.
-
-### Documentation
-
-- **The upstream-image decision is now written down**, in
-  `templates/terraform/README.md`. The seven image URLs point at mutable
-  `latest` / `current` paths, and that is a choice: pinning a checksum that
-  nobody keeps current would serve learners an increasingly stale image, with
-  its known vulnerabilities — the hardening would become the vector of the
-  problem it claims to address. The reasons it is acceptable here, and the
-  conditions that would reverse it, are spelled out.
-
-
-## [0.1.79] - 2026-08-24
-
-### Added
-
-- **`doctor --strict` turns the diagnosis into an exit code** (issue #176).
-  `doctor` exited 0 whatever the state of its checks, which is the right call
-  for a human — a diagnosis is not a failure — but made the command unusable as
-  an automated gate: a script had to parse the JSON to learn whether anything
-  was missing.
-
-  Two codes rather than one, because the two situations call for different
-  gestures:
-
-  | Mode | Code | When |
-  | --- | --- | --- |
-  | `doctor` | `0` | always, unchanged |
-  | `doctor --strict` | `9` | a required check failed |
-  | `doctor --strict` | `10` | a required check could not be measured |
-
-  `9` gets repaired, `10` gets measured again. An environment whose probe did
-  not complete is not validated for all that — which is exactly what an image
-  build must not mistake for a success. `9` wins when both coexist: a certainty
-  outweighs an ignorance.
-
-  The default does not move, and `--strict` changes nothing else: the table and
-  the document are still rendered, **before** the code lands, so a caller
-  receiving a non-zero code can still read what went wrong.
-
-
-## [0.1.78] - 2026-08-24
-
-### Fixed
-
-- **A lab whose container engine is unreachable no longer shows as ready**
-  (issue #179). `_services_degrades` returned an empty list when
-  `docker_available()` was false, so "Docker **was** there and its daemon went
-  down" was indistinguishable from "Docker was never installed". In the first
-  case the lab really is unplayable — `run` already fails on it explicitly with
-  exit code 2 — yet `status` announced `ready`, or even `validated` when a score
-  existed from an earlier session.
-- The two causes are now told apart, because they call for opposite gestures:
-  install a package, versus start a daemon and check the account may talk to it.
-  A lab that declares **no** service still ignores the engine entirely, without
-  even paying for a probe — that was the sound half of the original decision,
-  and it is kept and tested on its own.
-
-
-## [0.1.77] - 2026-08-24
-
-### Fixed
-
-- **`run_command(check=False)` now keeps its promise** (issue #174). A missing
-  binary, an expired timeout or any other `OSError` raised a `CommandError`
-  *whatever the options*, so any caller expecting a `CommandResult` in all
-  circumstances was wrong — and the parameter name encouraged them to expect
-  it. Two victims, measured by running them before being fixed: `dsoxlab
-  catalog add` exited with a Python traceback on a machine without git, which
-  is the second command of the onboarding path; and a probe that timed out
-  aborted the **whole** retry loop instead of counting as one failure to retry.
-- **A missing i18n key no longer reaches the user as a raw key.** `_()` returns
-  the key itself when it is undefined, so a key added to the code but not to
-  the dictionaries printed as `catalog_git_absent`. A guard existed but stopped
-  at `validators/` and `models/`; it now covers every literal `_("…")` in the
-  package, in both languages.
-
-### Added
-
-- **`git` and `docker` are `doctor` checks.** Neither is a Python dependency —
-  `uv tool install` brings neither — and neither was declared anywhere. `git`
-  is required everywhere, since `catalog add` clones. `docker` follows what the
-  catalogue declares: required as soon as one lab declares `runtime.services`,
-  informational otherwise, so a repository that does not use it never sees red
-  for it.
-- **`CommandResult.failure`** names *why* a command could not run
-  (`not_found`, `timeout`, `os_error`), separately from a non-zero return code.
-  The two call for opposite gestures — read stderr, versus install a package or
-  retry — and a caller reading only `returncode` conflated them.
-
-### Changed
-
-- **Pulling an image is now separate from starting a container.** The first
-  `docker run` pulled the image within its own 180-second budget: beyond that
-  the command failed on a startup message that never mentioned the network, and
-  below it `run` hung for minutes without saying why. The pull now has its own
-  budget and announces itself, and is skipped when the image is already local.
-
-
-## [0.1.76] - 2026-08-24
-
-### Fixed
-
-- **A fixture that cannot be copied no longer leaves an empty work directory in
-  silence** (issue #177). `ShellRuntime` iterates over `runtime.fixtures`, not
-  over the contents of `fixtures/`, so both possible gaps caused the same
-  damage without a word: a fixture *declared but missing from disk* went to a
-  `logger.warning`, and a fixture *present but undeclared* was never read. In
-  both cases `dsoxlab run` created an empty `challenge/work`, exited **0**, and
-  the learner had nothing to do. This is the defect that made **7 labs of
-  `terraform-training` unplayable on 2026-07-28**, all marked done — and it hid
-  all the better because the tooling that checks the solutions copies the whole
-  directory, so the answer key went green while the learner's path was broken.
-
-### Added
-
-- **`validate-structure` now compares `fixtures/` against the declaration**,
-  both ways: declared-but-missing, present-but-undeclared, and a path escaping
-  the workdir. The check runs in the default (offline) set, so a catalogue's CI
-  catches the mistake before a learner does. Hidden files are exempt: a
-  `.gitkeep` versions an empty directory, and flagging it would be a false
-  positive every author would learn to ignore.
-
-### Changed
-
-- **A fixture that cannot be copied now fails `run` instead of being skipped.**
-  This reverses an earlier decision — that a typo in one entry should not
-  deprive the learner of the whole workdir. It is the missing file that
-  deprives them: an authoring mistake is not something they can fix, and an
-  amputated exercise fails `check` for reasons they will look for in their own
-  work. Validation happens before any copy, so it is all or nothing: a
-  half-filled workdir looks like it works. Every offending fixture is named at
-  once, so an author fixes them in one pass rather than one `run` per fixture.
-
-
-## [0.1.75] - 2026-08-24
-
-### Fixed
-
-- **The libvirt pool check concluded "green" when it could not look** (issue
-  #172). The probe invoked `virsh -c qemu:///system` directly, without the
-  `sudo -n` prefix detection that `infra/libvirt.py` was built for: on any
-  machine where the system URI requires privileges, the probe failed every
-  time, and that failure was reported as `ok` — a permanently green check
-  right where `provision` was about to die on "Pool Not Found". The probe now
-  goes through `run_virsh`, and a probe that cannot measure yields
-  `state: unknown` (introduced in 0.1.73), which never paints the verdict
-  green nor red. `_check_kvm` also queries the **system URI** explicitly: a
-  bare `virsh version` may target the session URI depending on the
-  distribution, and answer perfectly for a user the system URI refuses.
-
-- **Three raw `sudo virsh` calls without `-n` could hang or fail silently**
-  (issue #173). `_ensure_kvm_dhcp_leases` (twice) and `_reset_kvm_domain`
-  captured their output, so a sudo password prompt had no terminal to show on
-  and the call hung; on a machine configured through the `libvirt` group
-  without sudo rights, the DHCP lease was never planted and the failure went
-  to a log nobody reads, the host later dying as "unreachable" with no visible
-  cause. All three calls now go through `run_virsh` (detected path, system
-  URI, never a prompt), and a refused lease is printed **on screen** by
-  `provision`, not just logged. A guard test now rejects any
-  `subprocess.run(["sudo", …])` that captures its output without `-n` in
-  `src/dsoxlab/`, on the model of the anti-`shell=True` guard from 0.1.70.
-
-- `run_command` now converts every `OSError` into a `CommandError` instead of
-  letting a binary that vanishes mid-run crash the caller — a diagnosis must
-  not die while diagnosing.
-
-## [0.1.74] - 2026-08-24
-
-### Fixed
-
-- **`provision` announced success after giving up on hosts that never answered**
-  (issue #170). A timeout was a mere warning; the command then printed
-  "✔ N hosts provisioned" and exited 0. The infrastructure existed but was not
-  usable, and the next `run` failed with "unreachable" without any visible link
-  to the cause. Every script testing the return code was blind — including the
-  build of a ready-made image, which will rely on it. A dedicated exit code
-  (`8`) now says it, alongside the ones for orphans.
-
-- **`check --json` was polluted as soon as a lab declared services** (issue
-  #171). `_valider` did not propagate `quiet` to `_ensure_services`, whose
-  progress messages went to stdout: `dsoxlab check --json | jq` failed on any
-  such lab. This was the defect fixed in 0.1.23, back through a side door.
-
-  `quiet` silences **progress only**. Errors keep going to stderr in both modes:
-  a service refusing to start must still be heard, or `--json` would hide the
-  one thing that matters.
-
-
-## [0.1.73] - 2026-08-24
+This release closes the blind-spot audit. Its entries were developed as
+0.1.73 through 0.1.83, merged the same day and published here in one go —
+those numbers were never tagged, so nothing was ever installable under
+them.
 
 ### Added
 
@@ -348,6 +47,251 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reassuring green of an unearned "ok" nor the accusing red of an unproven
   failure. The token is exposed by `doctor --json` and rendered as "? not
   measured"; it never paints the top-level verdict red.
+
+- **`validate-structure` now compares `fixtures/` against the declaration**,
+  both ways: declared-but-missing, present-but-undeclared, and a path escaping
+  the workdir. The check runs in the default (offline) set, so a catalogue's CI
+  catches the mistake before a learner does. Hidden files are exempt: a
+  `.gitkeep` versions an empty directory, and flagging it would be a false
+  positive every author would learn to ignore.
+
+- **`git` and `docker` are `doctor` checks.** Neither is a Python dependency —
+  `uv tool install` brings neither — and neither was declared anywhere. `git`
+  is required everywhere, since `catalog add` clones. `docker` follows what the
+  catalogue declares: required as soon as one lab declares `runtime.services`,
+  informational otherwise, so a repository that does not use it never sees red
+  for it.
+- **`CommandResult.failure`** names *why* a command could not run
+  (`not_found`, `timeout`, `os_error`), separately from a non-zero return code.
+  The two call for opposite gestures — read stderr, versus install a package or
+  retry — and a caller reading only `returncode` conflated them.
+
+- **`doctor --strict` turns the diagnosis into an exit code** (issue #176).
+  `doctor` exited 0 whatever the state of its checks, which is the right call
+  for a human — a diagnosis is not a failure — but made the command unusable as
+  an automated gate: a script had to parse the JSON to learn whether anything
+  was missing.
+
+  Two codes rather than one, because the two situations call for different
+  gestures:
+
+  | Mode | Code | When |
+  | --- | --- | --- |
+  | `doctor` | `0` | always, unchanged |
+  | `doctor --strict` | `9` | a required check failed |
+  | `doctor --strict` | `10` | a required check could not be measured |
+
+  `9` gets repaired, `10` gets measured again. An environment whose probe did
+  not complete is not validated for all that — which is exactly what an image
+  build must not mistake for a success. `9` wins when both coexist: a certainty
+  outweighs an ignorance.
+
+  The default does not move, and `--strict` changes nothing else: the table and
+  the document are still rendered, **before** the code lands, so a caller
+  receiving a non-zero code can still read what went wrong.
+
+- **CI validates the three packaged Terraform templates** (issue #175). The
+  pipeline covered lint, mypy, unit tests, fuzzing and an e2e suite on the
+  installed wheel — but ran **no `terraform validate` anywhere**, no
+  provisioning, and its e2e suite only plays the demo lab, which is `shell`.
+  The templates are pinned to `~> 0.9` (kvm) and `~> 0.3` (incus): a minor
+  provider release can break the schema, and this repository has already lived
+  through it. The existing unit tests on those templates assert that a file
+  contains a string, not that Terraform can read it, so a template regression
+  was only ever discovered on a learner's machine, in Terraform's own language.
+
+  The job runs `terraform init -backend=false` then `terraform validate` on
+  kvm, incus and outscale, collects every failure rather than stopping at the
+  first, names the offending provider through `::error::`, and fails the build.
+  Terraform comes from the vendor's release archive with its published
+  checksum, following the pattern already used for poutine — no third-party
+  action is added to the supply chain.
+
+- **`doctor` gains an `egress` check.** Provisioning downloads an image, then
+  cloud-init installs packages: without outbound access both fail. The mirrors
+  it probes are **read from the packaged templates**, never written into the
+  engine, and a single reachable mirror is enough to conclude — what is at
+  stake is outbound access itself, not one mirror's availability. Required on a
+  repository that provisions VMs, informational otherwise.
+
+- **`doctor` now checks the Incus storage pool**
+  (linux-dsoxlab-training#54). A user reported that on a failed Incus
+  provisioning, "only the KVM-related fixes are offered". The symptom was right
+  and the obvious hypothesis wrong: `_check_incus` *does* offer `incus admin
+  init` — but only when `incus list` fails saying so. `incus list` **succeeds**
+  on a never-initialised install: it simply returns an empty list. The check
+  passed green, and the Incus branch of `doctor` only added the ISO tool, where
+  the KVM branch has checked its storage pool for a long time. The template
+  creates the network but hard-codes `pool = "default"` without creating it.
+
+### Changed
+
+- **A fixture that cannot be copied now fails `run` instead of being skipped.**
+  This reverses an earlier decision — that a typo in one entry should not
+  deprive the learner of the whole workdir. It is the missing file that
+  deprives them: an authoring mistake is not something they can fix, and an
+  amputated exercise fails `check` for reasons they will look for in their own
+  work. Validation happens before any copy, so it is all or nothing: a
+  half-filled workdir looks like it works. Every offending fixture is named at
+  once, so an author fixes them in one pass rather than one `run` per fixture.
+
+- **Pulling an image is now separate from starting a container.** The first
+  `docker run` pulled the image within its own 180-second budget: beyond that
+  the command failed on a startup message that never mentioned the network, and
+  below it `run` hung for minutes without saying why. The pull now has its own
+  budget and announces itself, and is skipped when the image is already local.
+
+- **The log now speaks one language, and it is English** (issue #140). It mixed
+  French and English, which is not a matter of taste: this is the file
+  `dsoxlab support` collects and that a user pastes into a bug report. Measured
+  before being fixed — **41 French messages against 4 English ones**.
+
+  `logger.*` calls stay **deliberately outside** the i18n guard: a log line is
+  not interface text, it never goes through `_()`, and translating it at
+  runtime would make two bug reports incomparable depending on the locale of
+  whoever produced them. That exclusion justified not *translating* the log,
+  not leaving it incoherent.
+
+  English wins for three reasons: a log line gets searched **word for word**,
+  it gets compared between machines with different locales, and it is read by
+  someone diagnosing — next to the output of terraform, ansible and virsh,
+  which is already English.
+
+  The rule is written where a contributor meets it (the PR template) and held
+  by `test_journal_en_anglais.py`. Without a test it would come undone line by
+  line, which is exactly what happened to the interface before its own guard
+  existed.
+
+### Fixed
+
+- **`provision` announced success after giving up on hosts that never answered**
+  (issue #170). A timeout was a mere warning; the command then printed
+  "✔ N hosts provisioned" and exited 0. The infrastructure existed but was not
+  usable, and the next `run` failed with "unreachable" without any visible link
+  to the cause. Every script testing the return code was blind — including the
+  build of a ready-made image, which will rely on it. A dedicated exit code
+  (`8`) now says it, alongside the ones for orphans.
+
+- **`check --json` was polluted as soon as a lab declared services** (issue
+  #171). `_valider` did not propagate `quiet` to `_ensure_services`, whose
+  progress messages went to stdout: `dsoxlab check --json | jq` failed on any
+  such lab. This was the defect fixed in 0.1.23, back through a side door.
+
+  `quiet` silences **progress only**. Errors keep going to stderr in both modes:
+  a service refusing to start must still be heard, or `--json` would hide the
+  one thing that matters.
+
+- **The libvirt pool check concluded "green" when it could not look** (issue
+  #172). The probe invoked `virsh -c qemu:///system` directly, without the
+  `sudo -n` prefix detection that `infra/libvirt.py` was built for: on any
+  machine where the system URI requires privileges, the probe failed every
+  time, and that failure was reported as `ok` — a permanently green check
+  right where `provision` was about to die on "Pool Not Found". The probe now
+  goes through `run_virsh`, and a probe that cannot measure yields
+  `state: unknown` (introduced in 0.1.73), which never paints the verdict
+  green nor red. `_check_kvm` also queries the **system URI** explicitly: a
+  bare `virsh version` may target the session URI depending on the
+  distribution, and answer perfectly for a user the system URI refuses.
+
+- **Three raw `sudo virsh` calls without `-n` could hang or fail silently**
+  (issue #173). `_ensure_kvm_dhcp_leases` (twice) and `_reset_kvm_domain`
+  captured their output, so a sudo password prompt had no terminal to show on
+  and the call hung; on a machine configured through the `libvirt` group
+  without sudo rights, the DHCP lease was never planted and the failure went
+  to a log nobody reads, the host later dying as "unreachable" with no visible
+  cause. All three calls now go through `run_virsh` (detected path, system
+  URI, never a prompt), and a refused lease is printed **on screen** by
+  `provision`, not just logged. A guard test now rejects any
+  `subprocess.run(["sudo", …])` that captures its output without `-n` in
+  `src/dsoxlab/`, on the model of the anti-`shell=True` guard from 0.1.70.
+
+- `run_command` now converts every `OSError` into a `CommandError` instead of
+  letting a binary that vanishes mid-run crash the caller — a diagnosis must
+  not die while diagnosing.
+
+- **A fixture that cannot be copied no longer leaves an empty work directory in
+  silence** (issue #177). `ShellRuntime` iterates over `runtime.fixtures`, not
+  over the contents of `fixtures/`, so both possible gaps caused the same
+  damage without a word: a fixture *declared but missing from disk* went to a
+  `logger.warning`, and a fixture *present but undeclared* was never read. In
+  both cases `dsoxlab run` created an empty `challenge/work`, exited **0**, and
+  the learner had nothing to do. This is the defect that made **7 labs of
+  `terraform-training` unplayable on 2026-07-28**, all marked done — and it hid
+  all the better because the tooling that checks the solutions copies the whole
+  directory, so the answer key went green while the learner's path was broken.
+
+- **`run_command(check=False)` now keeps its promise** (issue #174). A missing
+  binary, an expired timeout or any other `OSError` raised a `CommandError`
+  *whatever the options*, so any caller expecting a `CommandResult` in all
+  circumstances was wrong — and the parameter name encouraged them to expect
+  it. Two victims, measured by running them before being fixed: `dsoxlab
+  catalog add` exited with a Python traceback on a machine without git, which
+  is the second command of the onboarding path; and a probe that timed out
+  aborted the **whole** retry loop instead of counting as one failure to retry.
+- **A missing i18n key no longer reaches the user as a raw key.** `_()` returns
+  the key itself when it is undefined, so a key added to the code but not to
+  the dictionaries printed as `catalog_git_absent`. A guard existed but stopped
+  at `validators/` and `models/`; it now covers every literal `_("…")` in the
+  package, in both languages.
+
+- **A lab whose container engine is unreachable no longer shows as ready**
+  (issue #179). `_services_degrades` returned an empty list when
+  `docker_available()` was false, so "Docker **was** there and its daemon went
+  down" was indistinguishable from "Docker was never installed". In the first
+  case the lab really is unplayable — `run` already fails on it explicitly with
+  exit code 2 — yet `status` announced `ready`, or even `validated` when a score
+  existed from an earlier session.
+- The two causes are now told apart, because they call for opposite gestures:
+  install a package, versus start a daemon and check the account may talk to it.
+  A lab that declares **no** service still ignores the engine entirely, without
+  even paying for a probe — that was the sound half of the original decision,
+  and it is kept and tested on its own.
+
+- **A cloud-init that finished badly now says so** (issue #178).
+  `wait_for_hosts_ready` ran `cloud-init status --wait >/dev/null 2>&1 || true`:
+  both the state *and* the return code went to the bin. Offline, behind a proxy
+  or on a slow mirror, the fifteen first-boot packages do not install,
+  cloud-init ends up `degraded`, and the host was **still declared ready** —
+  labs then failed on missing commands with nothing linking the two. Not
+  blocking remains the right call: what matters to hand back control is that
+  cloud-init has *finished*. But finishing badly must be said.
+
+- **A real-container test can no longer start without a readiness probe**
+  (issue #155). Two tests of `test_services.py` failed intermittently, always
+  under load, never at rest. Their common trait: they waited for a **real**
+  container. Without a probe, `start` hands back control as soon as `docker
+  run` answers, which says nothing about the service inside — the next step
+  becomes a race, won at rest and lost under load.
+
+  The instability itself no longer reproduces: measured under sustained Docker
+  load, 12 targeted runs and 4 full suites, not one failure. What this adds is
+  a guard against the **regression** of the fix, with exemptions named one by
+  one and motivated — a test whose container dies on purpose cannot carry a
+  probe, and requiring one would turn the guard into an obstacle.
+
+- **`test_post_start_en_echec_reel_leve_service_error` was passing for the
+  wrong reason.** Without a probe, the `ServiceError` it expects could come
+  from the container not yet accepting a `docker exec`, rather than from the
+  failing command it means to prove. It now declares a probe and asserts that
+  the error names the offending command.
+
+### Documentation
+
+- **The upstream-image decision is now written down**, in
+  `templates/terraform/README.md`. The seven image URLs point at mutable
+  `latest` / `current` paths, and that is a choice: pinning a checksum that
+  nobody keeps current would serve learners an increasingly stale image, with
+  its known vulnerabilities — the hardening would become the vector of the
+  problem it claims to address. The reasons it is acceptable here, and the
+  conditions that would reverse it, are spelled out.
+
+- **The first-boot package decision is written down**, in
+  `templates/cloud-init/README.md`. Blocking on a `degraded` was rejected —
+  cloud-init reports a global state, so it would treat a missing `tree` like a
+  missing `lvm2`. Pre-baked images are the real answer but a project of their
+  own. Per-lab package declarations would change the frozen v1 contract. What
+  was retained is making the failure visible at the three moments that matter:
+  before, during, and in the message that names the host.
 
 ## [0.1.72] - 2026-08-24
 


### PR DESCRIPTION
# Summary

`scripts/check-release.py` refusait le tag : **douze versions décrites au
CHANGELOG et absentes de PyPI**. Le dernier tag comme la dernière version
publiée sont **0.1.72**.

## La cause est un défaut de méthode, pas un accident

J'ai bumpé la version à chaque PR de la journée, en suivant la règle du dépôt
« un changement fonctionnel → CHANGELOG + bump + release », **sans jamais faire
la release qui va avec**. Douze numéros sont ainsi apparus, sous lesquels rien
n'a jamais été installable.

## Ce que j'ai écarté

Exempter ces versions nommément dans `check-release.py`. Le mécanisme le permet,
et c'est ce que le message d'erreur propose en second recours — j'avais commencé
par là. Mais exempter, c'est **apprendre au garde-fou à se taire sur un défaut
réel** : le CHANGELOG aurait continué de décrire douze versions qu'aucun
utilisateur ne peut installer.

## Ce que fait ce commit

Les entrées **0.1.73 à 0.1.84** sont fusionnées sous la seule **0.1.84**, celle
qui part réellement.

| Contrôle | Avant | Après |
|---|---|---|
| puces de contenu, `CHANGELOG.md` | 30 | **30** |
| puces de contenu, `CHANGELOG.fr.md` | 30 | **30** |
| numéros fantômes restants | 12 | **0** |

Aucun contenu n'est perdu : les puces sont regroupées par section et dans
l'ordre chronologique d'origine, ce qu'un contrôle vérifie avant et après la
fusion. Les exemptions que j'avais ajoutées entre-temps sont retirées — elles
n'ont plus d'objet, et `VERSIONS_JAMAIS_PUBLIEES` retrouve sa seule entrée
historique.

Le garde-fou rend désormais **« les 71 versions annoncées sont publiées »**.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `uv run ruff check src/dsoxlab tests tests_e2e fuzz scripts` passes
- [x] `uv run mypy src/dsoxlab` passes (strict)
- [x] `uv run pytest` passes — **861 passed**
- [x] `uv run pytest tests_e2e` passes — 18 passed (inchangés)
- [x] The engine stays domain-agnostic — aucun code moteur n'est touché
- [x] No hardcoded personal path or host
- [x] Manually tested — `scripts/check-release.py` rejoué : le contrôle des versions annoncées passe au vert

### When behavior changes

- [x] **Both** `CHANGELOG.md` and `CHANGELOG.fr.md` updated
- [x] La version reste **0.1.84** ; `uv.lock` est déjà aligné, rien à rafraîchir

### When a command or option is added, removed or changed

N/A — aucune commande ni option n'est touchée.

### When `.github/workflows/` is touched

N/A — aucun workflow n'est touché.

### When the declarative contract (`meta.yml` / `lab.yaml`) changes

N/A — le contrat est inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)